### PR TITLE
feat: Add FlowResult type for proper error handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,9 +113,24 @@ Step Flow is an execution engine for AI workflows, built in Rust. The project is
 
 ### Error Handling
 
-- Each crate has its own `error.rs` module with custom error types
-- Uses `error-stack` for rich error context and propagation
-- Uses `thiserror` for defining error enums
+Step Flow distinguishes between two types of errors:
+
+1. **Flow Errors** (`FlowError`): Business logic failures that are part of normal workflow execution
+   - Represented by the `FlowError` type with error codes and messages
+   - Used for validation failures, missing data, or expected failure conditions
+   - Allow workflows to continue and handle errors gracefully
+
+2. **System Errors** (`Result::Err`): Implementation or infrastructure failures
+   - Used for plugin communication failures, serialization errors, etc.
+   - Represent unexpected conditions that should halt execution
+   - Each crate has its own `error.rs` module with custom error types
+   - Uses `error-stack` for rich error context and propagation
+   - Uses `thiserror` for defining error enums
+
+The `FlowResult` enum enables proper error propagation through workflow execution:
+- `Success(ValueRef)`: Step completed successfully with output
+- `Skipped`: Step was conditionally skipped
+- `Failed(FlowError)`: Step failed with a business logic error
 
 ## Code Style
 

--- a/crates/stepflow-builtins/src/lib.rs
+++ b/crates/stepflow-builtins/src/lib.rs
@@ -1,4 +1,4 @@
-use stepflow_core::{component::ComponentInfo, workflow::ValueRef};
+use stepflow_core::{FlowResult, component::ComponentInfo, workflow::ValueRef};
 
 mod error;
 mod messages;
@@ -14,5 +14,5 @@ pub use plugin::Builtins;
 pub(crate) trait BuiltinComponent: Send + Sync {
     fn component_info(&self) -> Result<ComponentInfo>;
 
-    async fn execute(&self, input: ValueRef) -> Result<ValueRef>;
+    async fn execute(&self, input: ValueRef) -> Result<FlowResult>;
 }

--- a/crates/stepflow-builtins/src/plugin.rs
+++ b/crates/stepflow-builtins/src/plugin.rs
@@ -1,6 +1,7 @@
 use crate::{BuiltinComponent, registry};
 use error_stack::ResultExt as _;
 use stepflow_core::{
+    FlowResult,
     component::ComponentInfo,
     workflow::{Component, ValueRef},
 };
@@ -29,7 +30,7 @@ impl Plugin for Builtins {
             .change_context(PluginError::ComponentInfo)
     }
 
-    async fn execute(&self, component: &Component, input: ValueRef) -> Result<ValueRef> {
+    async fn execute(&self, component: &Component, input: ValueRef) -> Result<FlowResult> {
         let component = registry::get_component(component)?;
         component
             .execute(input)

--- a/crates/stepflow-core/src/lib.rs
+++ b/crates/stepflow-core/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod component;
 pub mod schema;
 pub mod workflow;
+
+mod step_result;
+pub use step_result::*;

--- a/crates/stepflow-core/src/step_result.rs
+++ b/crates/stepflow-core/src/step_result.rs
@@ -1,0 +1,69 @@
+use std::borrow::Cow;
+
+use crate::workflow::ValueRef;
+
+/// An error reported from within a flow or step.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct FlowError {
+    pub code: i64,
+    pub message: Cow<'static, str>,
+    pub data: Option<ValueRef>,
+}
+
+pub const FLOW_ERROR_UNDEFINED_FIELD: i64 = 1;
+
+impl FlowError {
+    pub fn new(code: i64, message: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    pub fn with_data<D: serde::Serialize>(self, data: D) -> Result<Self, serde_json::Error> {
+        let data = serde_json::to_value(data)?.into();
+        Ok(Self {
+            data: Some(data),
+            ..self
+        })
+    }
+}
+
+/// The results of a step execution.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case", tag = "status")]
+pub enum FlowResult {
+    /// The step execution was successful.
+    Success(ValueRef),
+    /// The step was skipped.
+    Skipped,
+    /// The step failed with the given error.
+    Failed(FlowError),
+}
+
+impl From<serde_json::Value> for FlowResult {
+    fn from(value: serde_json::Value) -> Self {
+        Self::Success(ValueRef::new(value))
+    }
+}
+
+impl FlowResult {
+    pub fn success(&self) -> Option<&serde_json::Value> {
+        match self {
+            Self::Success(value) => Some(value.as_ref()),
+            _ => None,
+        }
+    }
+
+    pub fn skipped(&self) -> bool {
+        matches!(self, Self::Skipped)
+    }
+
+    pub fn failed(&self) -> Option<&FlowError> {
+        match self {
+            Self::Failed(error) => Some(error),
+            _ => None,
+        }
+    }
+}

--- a/crates/stepflow-core/src/workflow/expr.rs
+++ b/crates/stepflow-core/src/workflow/expr.rs
@@ -58,10 +58,10 @@ impl Expr {
         }
     }
 
-    pub fn field(&self) -> Option<&str> {
+    pub fn path(&self) -> Option<&str> {
         match self {
             Self::Literal { .. } => None,
-            Self::Ref { path: field, .. } => field.as_deref(),
+            Self::Ref { path, .. } => path.as_deref(),
         }
     }
 }

--- a/crates/stepflow-core/src/workflow/value.rs
+++ b/crates/stepflow-core/src/workflow/value.rs
@@ -64,8 +64,8 @@ impl ValueRef {
     /// NOTE: This increments the references to the root value. If the resulting
     /// field reference is significantly smaller than the root value and likely
     /// to outlive it, consider instead creating a new (rooted) value.
-    pub fn field(&self, field: &str) -> Option<ValueRef> {
-        self.maybe_map(|o| o.as_object().and_then(|o| o.get(field)))
+    pub fn path(&self, path: &str) -> Option<ValueRef> {
+        self.maybe_map(|o| o.as_object().and_then(|o| o.get(path)))
     }
 }
 

--- a/crates/stepflow-execution/tests/test_execution.rs
+++ b/crates/stepflow-execution/tests/test_execution.rs
@@ -49,21 +49,21 @@ fn create_mock_plugin() -> MockPlugin {
         .mock_component("mock://one_output")
         .behavior(
             serde_json::json!({ "input": "a" }),
-            MockComponentBehavior::valid(serde_json::json!({ "output": "b" })),
+            MockComponentBehavior::result(serde_json::json!({ "output": "b" })),
         )
         .behavior(
             serde_json::json!({ "input": "hello" }),
-            MockComponentBehavior::valid(serde_json::json!({ "output": "world" })),
+            MockComponentBehavior::result(serde_json::json!({ "output": "world" })),
         );
     mock_plugin
         .mock_component("mock://two_outputs")
         .behavior(
             serde_json::json!({ "input": "b" }),
-            MockComponentBehavior::valid(serde_json::json!({ "x": 1, "y": 2 })),
+            MockComponentBehavior::result(serde_json::json!({ "x": 1, "y": 2 })),
         )
         .behavior(
             serde_json::json!({ "input": "world" }),
-            MockComponentBehavior::valid(serde_json::json!({ "x": 2, "y": 8 })),
+            MockComponentBehavior::result(serde_json::json!({ "x": 2, "y": 8 })),
         );
     mock_plugin
 }
@@ -134,9 +134,14 @@ fn run_tests(plugins: Plugins, rt: tokio::runtime::Handle) {
     });
 }
 
-fn normalize_value(value: stepflow_core::workflow::ValueRef) -> stepflow_core::workflow::ValueRef {
-    let value = normalize_json(value.as_ref().to_owned());
-    value.into()
+fn normalize_value(value: stepflow_core::FlowResult) -> stepflow_core::FlowResult {
+    match value {
+        stepflow_core::FlowResult::Success(value) => {
+            let value = normalize_json(value.as_ref().to_owned());
+            stepflow_core::FlowResult::Success(value.into())
+        }
+        other => other,
+    }
 }
 
 /// Recursively sorts all objects in a `serde_json::Value`.

--- a/crates/stepflow-main/src/cli.rs
+++ b/crates/stepflow-main/src/cli.rs
@@ -166,7 +166,7 @@ fn load_input(path: Option<PathBuf>) -> Result<stepflow_core::workflow::ValueRef
     }
 }
 
-fn write_output(path: Option<PathBuf>, output: stepflow_core::workflow::ValueRef) -> Result<()> {
+fn write_output(path: Option<PathBuf>, output: stepflow_core::FlowResult) -> Result<()> {
     match path {
         Some(path) => {
             let format = Format::from_path(&path)?;

--- a/crates/stepflow-main/src/run.rs
+++ b/crates/stepflow-main/src/run.rs
@@ -1,13 +1,13 @@
 use crate::{MainError, Result};
 use error_stack::ResultExt as _;
-use stepflow_core::workflow::Flow;
+use stepflow_core::{FlowResult, workflow::Flow};
 use stepflow_plugin::Plugins;
 
 pub async fn run(
     plugins: &Plugins,
     flow: Flow,
     input: stepflow_core::workflow::ValueRef,
-) -> Result<stepflow_core::workflow::ValueRef> {
+) -> Result<FlowResult> {
     let result = stepflow_execution::execute(plugins, &flow, input)
         .await
         .change_context(MainError::FlowExecution)?;

--- a/crates/stepflow-main/src/submit.rs
+++ b/crates/stepflow-main/src/submit.rs
@@ -6,6 +6,6 @@ pub async fn submit(
     _service: Url,
     _flow: Flow,
     _input: stepflow_core::workflow::ValueRef,
-) -> Result<stepflow_core::workflow::ValueRef> {
+) -> Result<stepflow_core::FlowResult> {
     todo!()
 }

--- a/crates/stepflow-plugin/src/plugin.rs
+++ b/crates/stepflow-plugin/src/plugin.rs
@@ -1,5 +1,6 @@
 use crate::Result;
 use stepflow_core::{
+    FlowResult,
     component::ComponentInfo,
     workflow::{Component, ValueRef},
 };
@@ -15,5 +16,5 @@ pub trait Plugin: Send + Sync {
     /// Execute the step and return the resulting arguments.
     ///
     /// The arguments should be fully resolved.
-    async fn execute(&self, component: &Component, input: ValueRef) -> Result<ValueRef>;
+    async fn execute(&self, component: &Component, input: ValueRef) -> Result<FlowResult>;
 }

--- a/crates/stepflow-plugin/src/plugins.rs
+++ b/crates/stepflow-plugin/src/plugins.rs
@@ -59,8 +59,8 @@ impl Plugins {
 
 #[cfg(test)]
 mod tests {
-    use stepflow_core::component::ComponentInfo;
     use stepflow_core::workflow::ValueRef;
+    use stepflow_core::{FlowResult, component::ComponentInfo};
 
     use crate::{Plugin, Result};
 
@@ -78,7 +78,7 @@ mod tests {
             todo!()
         }
 
-        async fn execute(&self, _component: &Component, _input: ValueRef) -> Result<ValueRef> {
+        async fn execute(&self, _component: &Component, _input: ValueRef) -> Result<FlowResult> {
             todo!()
         }
     }

--- a/crates/stepflow-protocol/src/stdio/plugin.rs
+++ b/crates/stepflow-protocol/src/stdio/plugin.rs
@@ -1,5 +1,6 @@
 use error_stack::ResultExt;
 use stepflow_core::{
+    FlowResult,
     component::ComponentInfo,
     workflow::{Component, ValueRef},
 };
@@ -47,7 +48,7 @@ impl Plugin for StdioPlugin {
         Ok(response.info)
     }
 
-    async fn execute(&self, component: &Component, input: ValueRef) -> Result<ValueRef> {
+    async fn execute(&self, component: &Component, input: ValueRef) -> Result<FlowResult> {
         let response = self
             .client
             .request(&crate::schema::component_execute::Request {
@@ -57,6 +58,6 @@ impl Plugin for StdioPlugin {
             .await
             .change_context(PluginError::Execution)?;
 
-        Ok(response.output)
+        Ok(FlowResult::Success(response.output))
     }
 }


### PR DESCRIPTION
Introduces FlowResult enum to distinguish between business logic failures (Failed/Skipped) and implementation errors. This enables proper error propagation through workflow execution while preserving system reliability.

This doesn't fix existing errors that should be business-logic errors but those will be revisited as part of the work on conditional execution and exception handling.