### PR TITLE
feat: Change reference syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,6 +2064,7 @@ name = "stepflow-core"
 version = "0.1.0"
 dependencies = [
  "indexmap",
+ "insta",
  "safer_owning_ref",
  "schemars",
  "serde",

--- a/crates/stepflow-core/Cargo.toml
+++ b/crates/stepflow-core/Cargo.toml
@@ -17,6 +17,7 @@ serde_yml.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+insta.workspace = true
 similar-asserts.workspace = true
 
 [lints]

--- a/crates/stepflow-core/src/workflow/flow.rs
+++ b/crates/stepflow-core/src/workflow/flow.rs
@@ -136,8 +136,8 @@ mod tests {
             args:
               a: "hello world 2"
         outputs:
-            s1a: { $from: "s1", path: "a" }
-            s2b: { $from: s2, path: a }
+            s1a: { $ref: { step: s1 }, path: "a" }
+            s2b: { $ref: { step: s2 }, path: a }
         output_schema:
             type: object
             properties:

--- a/crates/stepflow-execution/src/spawn_workflow.rs
+++ b/crates/stepflow-execution/src/spawn_workflow.rs
@@ -24,7 +24,7 @@ pub(crate) async fn spawn_workflow(
     let mut state = State::new();
 
     tracing::debug!("Recording input {input:?}");
-    state.record_literal(BaseRef::Input, input)?;
+    state.record_literal(BaseRef::WORKFLOW_INPUT, input)?;
 
     let mut step_tasks = FuturesUnordered::new();
 
@@ -37,7 +37,7 @@ pub(crate) async fn spawn_workflow(
     for step in steps {
         tracing::debug!("Creating future for step {step:?}");
         // Record the future step result.
-        let result_tx = state.record_future(BaseRef::Step(step.id.clone()))?;
+        let result_tx = state.record_future(BaseRef::step_output(step.id.clone()))?;
 
         let plugin = executor
             .plugins

--- a/crates/stepflow-main/tests/flows/basic.yaml
+++ b/crates/stepflow-main/tests/flows/basic.yaml
@@ -59,15 +59,15 @@ steps:
   - id: step1
     component: mock://one_output
     args:
-      input: { $from: $input, path: name }
+      input: { $ref: { workflow: input }, path: name }
   - id: step2
     component: mock://two_outputs
     args:
-      input: { $from: step1, path: output }
+      input: { $ref: { step: step1 }, path: output }
 outputs:
-    name: { $from: step1, path: output }
-    x: { $from: step2, path: x }
-    y: { $from: step2, path: y }
+    name: { $ref: { step: step1 }, path: output }
+    x: { $ref: { step: step2 }, path: x }
+    y: { $ref: { step: step2 }, path: y }
 test_cases:
   - input:
       name: a

--- a/crates/stepflow-main/tests/flows/conditional_skip.yaml
+++ b/crates/stepflow-main/tests/flows/conditional_skip.yaml
@@ -62,19 +62,19 @@ output_schema:
 steps:
   - id: conditional_step
     component: mock://one_output
-    skip_if: { $from: $input, path: should_skip }
+    skip_if: { $ref: { workflow: input }, path: should_skip }
     args:
-      input: { $from: $input, path: value }
+      input: { $ref: { workflow: input }, path: value }
   - id: dependent_step
     component: mock://handle_skip
     args:
       input: 
-        $from: conditional_step
+        $ref: { step: conditional_step }
         path: output
         on_skip:
           action: use_default
 outputs:
-  dependent_result: { $from: dependent_step, path: output }
+  dependent_result: { $ref: { step: dependent_step }, path: output }
 test_cases:
   - input:
       should_skip: false

--- a/crates/stepflow-main/tests/flows/conditional_skip_use_default.yaml
+++ b/crates/stepflow-main/tests/flows/conditional_skip_use_default.yaml
@@ -62,20 +62,20 @@ output_schema:
 steps:
   - id: conditional_step
     component: mock://one_output
-    skip_if: { $from: $input, path: should_skip }
+    skip_if: { $ref: { workflow: input }, path: should_skip }
     args:
-      input: { $from: $input, path: value }
+      input: { $ref: { workflow: input }, path: value }
   - id: dependent_step
     component: mock://handle_skip
     args:
       input:
-        $from: conditional_step
+        $ref: { step: conditional_step }
         path: output
         on_skip:
           action: use_default
           default_value: "it was skipped"
 outputs:
-  dependent_result: { $from: dependent_step, path: output }
+  dependent_result: { $ref: { step: dependent_step }, path: output }
 test_cases:
   - input:
       should_skip: false

--- a/crates/stepflow-main/tests/flows/error_fail.yaml
+++ b/crates/stepflow-main/tests/flows/error_fail.yaml
@@ -35,9 +35,9 @@ steps:
     on_error:
       action: fail
     args:
-      mode: { $from: $input, path: mode }
+      mode: { $ref: { workflow: input }, path: mode }
 outputs:
-  error_result: { $from: error, path: output }
+  error_result: { $ref: { step: error }, path: output }
 test_cases:
   - input: { mode: "error" }
     expect_failure: true

--- a/crates/stepflow-main/tests/flows/error_skip.yaml
+++ b/crates/stepflow-main/tests/flows/error_skip.yaml
@@ -35,9 +35,9 @@ steps:
     on_error:
       action: skip
     args:
-      mode: { $from: $input, path: mode }
+      mode: { $ref: { workflow: input }, path: mode }
 outputs:
-  error_result: { $from: error, path: output }
+  error_result: { $ref: { step: error }, path: output }
 test_cases:
   - input: { mode: "error" }
   - input: { mode: "succeed" }

--- a/crates/stepflow-main/tests/flows/error_use_default.yaml
+++ b/crates/stepflow-main/tests/flows/error_use_default.yaml
@@ -32,9 +32,9 @@ steps:
     on_error:
       action: use_default
     args:
-      mode: { $from: $input, path: mode }
+      mode: { $ref: { workflow: input }, path: mode }
 outputs:
-  error_result: { $from: error }
+  error_result: { $ref: { step: error } }
 test_cases:
   - input: { mode: "error" }
   - input: { mode: "succeed" }

--- a/crates/stepflow-main/tests/flows/error_use_default_value.yaml
+++ b/crates/stepflow-main/tests/flows/error_use_default_value.yaml
@@ -37,9 +37,9 @@ steps:
       default_value:
         output: "using default value"
     args:
-      mode: { $from: $input, path: mode }
+      mode: { $ref: { workflow: input }, path: mode }
 outputs:
-  error_result: { $from: error, path: output }
+  error_result: { $ref: { step: error }, path: output }
 test_cases:
   - input: { mode: "error" }
   - input: { mode: "succeed" }

--- a/crates/stepflow-main/tests/flows/nested_eval.yaml
+++ b/crates/stepflow-main/tests/flows/nested_eval.yaml
@@ -17,11 +17,11 @@ steps:
             args:
               user_prompt: "Hello from nested flow"
         outputs:
-          result: { $from: inner_step }
+          result: { $ref: { step: inner_step } }
       input: {}
 
 outputs:
-  nested_result: { $from: nested_flow }
+  nested_result: { $ref: { step: nested_flow } }
 
 test_cases:
   - input: {}

--- a/crates/stepflow-main/tests/flows/python_math.yaml
+++ b/crates/stepflow-main/tests/flows/python_math.yaml
@@ -22,22 +22,22 @@ steps:
   - id: m_plus_n
     component: python://add
     args:
-      a: { $from: $input, path: m }
-      b: { $from: $input, path: n }
+      a: { $ref: { workflow: input }, path: m }
+      b: { $ref: { workflow: input }, path: n }
   - id: m_times_n
     component: python://multiply
     args:
-      a: { $from: $input, path: m }
-      b: { $from: $input, path: n }
+      a: { $ref: { workflow: input }, path: m }
+      b: { $ref: { workflow: input }, path: n }
   - id: m_plus_n_times_n
     component: python://multiply
     args:
-      a: { $from: m_plus_n, path: result }
-      b: { $from: $input, path: n }
+      a: { $ref: { step: m_plus_n }, path: result }
+      b: { $ref: { workflow: input }, path: n }
 outputs:
-  m_plus_n_times_n: { $from: m_plus_n_times_n, path: result }
-  m_times_n: { $from: m_times_n, path: result }
-  m_plus_n: { $from: m_plus_n, path: result }
+  m_plus_n_times_n: { $ref: { step: m_plus_n_times_n }, path: result }
+  m_times_n: { $ref: { step: m_times_n }, path: result }
+  m_plus_n: { $ref: { step: m_plus_n }, path: result }
 test_cases:
   - input:
       m: 8

--- a/docs/docs/workflows/control_flow.md
+++ b/docs/docs/workflows/control_flow.md
@@ -32,9 +32,9 @@ Steps can be conditionally skipped using the `skip` field:
 steps:
   - id: expensive_analysis
     component: ai/analyze
-    skip: { $from: workflow_input, path: is_premium_user }
+    skip: { $ref: { workflow: input }, path: is_premium_user }
     args:
-      data: { $from: previous_step }
+      data: { $ref: { step: previous_step } }
 ```
 
 ### Skip Conditions
@@ -53,9 +53,9 @@ steps:
   - id: consumer_step
     component: data/process
     args:
-      required_data: { $from: step1 }
+      required_data: { $ref: { step: step1 } }
       optional_enhancement:
-        $from: step2
+        $ref: { step: step2 }
         $on_skip: "use_default"
         $default: "no_enhancement"
 ```
@@ -110,11 +110,11 @@ steps:
           - id: process
             component: data/transform
             args:
-              input: $from: workflow_input, path: data
+              input: { $ref: { workflow: input }, path: data }
         outputs:
-          result: $from: process
+          result: { $ref: { step: process } }
       input:
-        data: $from: previous_step, path: processed_data
+        data: { $ref: { step: previous_step }, path: processed_data }
 ```
 
 ### Sub-workflow Execution

--- a/examples/data-pipeline/debug-pipeline.yaml
+++ b/examples/data-pipeline/debug-pipeline.yaml
@@ -16,39 +16,39 @@ steps:
   - id: calculate_total_revenue
     component: python://sum_field
     args:
-      data: { $from: "$input", path: "sales_data" }
+      data: { $ref: { workflow: input }, path: "sales_data" }
       field: "revenue"
 
   - id: count_sales
     component: python://count_items
     args:
-      data: { $from: "$input", path: "sales_data" }
+      data: { $ref: { workflow: input }, path: "sales_data" }
 
   - id: calculate_average_sale
     component: python://average_field
     args:
-      data: { $from: "$input", path: "sales_data" }
+      data: { $ref: { workflow: input }, path: "sales_data" }
       field: "revenue"
 
   - id: calculate_performance_ratio
     component: python://divide
     args:
-      a: { $from: "calculate_total_revenue", path: "result" }
-      b: { $from: "$input", path: "target_revenue" }
+      a: { $ref: { step: "calculate_total_revenue" }, path: "result" }
+      b: { $ref: { workflow: input }, path: "target_revenue" }
 
   # Format metrics summary for display
   - id: format_metrics_summary
     component: python://format_metrics
     args:
-      total_revenue: { $from: "calculate_total_revenue", path: "result" }
-      sales_count: { $from: "count_sales", path: "result" }
-      average_sale: { $from: "calculate_average_sale", path: "result" }
-      performance_ratio: { $from: "calculate_performance_ratio", path: "result" }
-      target_revenue: { $from: "$input", path: "target_revenue" }
+      total_revenue: { $ref: { step: "calculate_total_revenue" }, path: "result" }
+      sales_count: { $ref: { step: "count_sales" }, path: "result" }
+      average_sale: { $ref: { step: "calculate_average_sale" }, path: "result" }
+      performance_ratio: { $ref: { step: "calculate_performance_ratio" }, path: "result" }
+      target_revenue: { $ref: { workflow: input }, path: "target_revenue" }
 
 outputs:
-  total_revenue: { $from: "calculate_total_revenue", path: "result" }
-  sales_count: { $from: "count_sales", path: "result" }
-  average_sale: { $from: "calculate_average_sale", path: "result" }
-  performance_ratio: { $from: "calculate_performance_ratio", path: "result" }
-  business_summary: { $from: "format_metrics_summary", path: "summary" }
+  total_revenue: { $ref: { step: "calculate_total_revenue" }, path: "result" }
+  sales_count: { $ref: { step: "count_sales" }, path: "result" }
+  average_sale: { $ref: { step: "calculate_average_sale" }, path: "result" }
+  performance_ratio: { $ref: { step: "calculate_performance_ratio" }, path: "result" }
+  business_summary: { $ref: { step: "format_metrics_summary" }, path: "summary" }

--- a/examples/data-pipeline/pipeline.yaml
+++ b/examples/data-pipeline/pipeline.yaml
@@ -16,53 +16,53 @@ steps:
   - id: calculate_total_revenue
     component: python://sum_field
     args:
-      data: { $from: "$input", path: "sales_data" }
+      data: { $ref: { workflow: input }, path: "sales_data" }
       field: "revenue"
 
   - id: count_sales
     component: python://count_items
     args:
-      data: { $from: "$input", path: "sales_data" }
+      data: { $ref: { workflow: input }, path: "sales_data" }
 
   - id: calculate_average_sale
     component: python://average_field
     args:
-      data: { $from: "$input", path: "sales_data" }
+      data: { $ref: { workflow: input }, path: "sales_data" }
       field: "revenue"
 
   # This step waits for total_revenue to complete
   - id: calculate_performance_ratio
     component: python://divide
     args:
-      a: { $from: "calculate_total_revenue", path: "result" }
-      b: { $from: "$input", path: "target_revenue" }
+      a: { $ref: { step: "calculate_total_revenue" }, path: "result" }
+      b: { $ref: { workflow: input }, path: "target_revenue" }
 
   # Format metrics for AI analysis (waits for all calculations)
   - id: format_metrics_summary
     component: python://format_metrics
     args:
-      total_revenue: { $from: "calculate_total_revenue", path: "result" }
-      sales_count: { $from: "count_sales", path: "result" }
-      average_sale: { $from: "calculate_average_sale", path: "result" }
-      performance_ratio: { $from: "calculate_performance_ratio", path: "result" }
-      target_revenue: { $from: "$input", path: "target_revenue" }
+      total_revenue: { $ref: { step: "calculate_total_revenue" }, path: "result" }
+      sales_count: { $ref: { step: "count_sales" }, path: "result" }
+      average_sale: { $ref: { step: "calculate_average_sale" }, path: "result" }
+      performance_ratio: { $ref: { step: "calculate_performance_ratio" }, path: "result" }
+      target_revenue: { $ref: { workflow: input }, path: "target_revenue" }
 
   # Format messages for OpenAI (depends on metrics summary)  
   - id: create_openai_messages
     component: "builtins://create_messages"
     args:
       system_instructions: "You are a sales analyst providing insights based on business metrics. Be specific and actionable."
-      user_prompt: { $from: "format_metrics_summary", path: "summary" }
+      user_prompt: { $ref: { step: "format_metrics_summary" }, path: "summary" }
 
   # Generate AI insights from the metrics
   - id: generate_ai_insights
     component: "builtins://openai"
     args:
-      messages: { $from: "create_openai_messages", path: "messages" }
+      messages: { $ref: { step: "create_openai_messages" }, path: "messages" }
 
 outputs:
-  total_revenue: { $from: "calculate_total_revenue", path: "result" }
-  sales_count: { $from: "count_sales", path: "result" }
-  average_sale: { $from: "calculate_average_sale", path: "result" }
-  performance_ratio: { $from: "calculate_performance_ratio", path: "result" }
-  ai_insights: { $from: "generate_ai_insights", path: "response" }
+  total_revenue: { $ref: { step: "calculate_total_revenue" }, path: "result" }
+  sales_count: { $ref: { step: "count_sales" }, path: "result" }
+  average_sale: { $ref: { step: "calculate_average_sale" }, path: "result" }
+  performance_ratio: { $ref: { step: "calculate_performance_ratio" }, path: "result" }
+  ai_insights: { $ref: { step: "generate_ai_insights" }, path: "response" }

--- a/examples/openai/openai_chat.yaml
+++ b/examples/openai/openai_chat.yaml
@@ -14,13 +14,13 @@ steps:
   - id: create_messages
     component: "builtins://create_messages"
     args:
-      system_instructions: { $from: $input, path: system_message }
-      user_prompt: { $from: $input, path: prompt }
+      system_instructions: { $ref: { workflow: input }, path: system_message }
+      user_prompt: { $ref: { workflow: input }, path: prompt }
 
   - id: send_message
     component: "builtins://openai"
     args:
-      messages: { $from: create_messages, path: messages }
+      messages: { $ref: { step: create_messages }, path: messages }
   
 outputs:
-  response: { step: send_message, field: response }
+  response: { $ref: { step: send_message }, path: response }

--- a/examples/python/basic.yaml
+++ b/examples/python/basic.yaml
@@ -16,19 +16,19 @@ steps:
   - id: m_plus_n
     component: python://add
     args:
-      a: { $from: $input, path: m }
-      b: { $from: $input, path: n }
+      a: { $ref: { workflow: input }, path: m }
+      b: { $ref: { workflow: input }, path: n }
   - id: m_times_n
     component: python://multiply
     args:
-      a: { $from: $input, path: m }
-      b: { $from: $input, path: n }
+      a: { $ref: { workflow: input }, path: m }
+      b: { $ref: { workflow: input }, path: n }
   - id: m_plus_n_times_n
     component: python://multiply
     args:
-      a: { $from: m_plus_n, path: result }
-      b: { $from: $input, path: n }
+      a: { $ref: { step: m_plus_n }, path: result }
+      b: { $ref: { workflow: input }, path: n }
 outputs:
-  m_plus_n_times_n: { $from: m_plus_n_times_n, path: result }
-  m_times_n: { $from: m_times_n, path: result }
-  m_plus_n: { $from: m_plus_n, path: result }
+  m_plus_n_times_n: { $ref: { step: m_plus_n_times_n }, path: result }
+  m_times_n: { $ref: { step: m_times_n }, path: result }
+  m_plus_n: { $ref: { step: m_plus_n }, path: result }


### PR DESCRIPTION
This came up when looking at syntax for referencing different parts of steps, etc. The new syntax is more uniform -- it is always a `$ref` and then a struct with fields indicating what is being referenced.

In the future, we can allow `$ref` to be a string that is parsed into one of these structs. This allows us to treat the struct as the "reference format", while still providing an expression-like shorthand for people writing flows directly.