### PR TITLE
feat: Support stdin and inline input values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,17 @@ cargo test -p stepflow-execution -- execute_flows
 
 ### Running the App
 ```bash
-# Run a workflow with input
+# Run a workflow with input file
 cargo run -- run --flow=examples/python/basic.yaml --input=examples/python/input1.json
+
+# Run a workflow with inline JSON input
+cargo run -- run --flow=examples/python/basic.yaml --input-json='{"m": 3, "n": 4}'
+
+# Run a workflow with inline YAML input
+cargo run -- run --flow=examples/python/basic.yaml --input-yaml='m: 2\nn: 7'
+
+# Run a workflow reading from stdin (JSON format)
+echo '{"m": 1, "n": 2}' | cargo run -- run --flow=examples/python/basic.yaml --format=json
 
 # Run with a custom config file
 cargo run -- run --flow=<flow.yaml> --input=<input.json> --config=<stepflow-config.yml>


### PR DESCRIPTION
1. `--input=<file>` - Input from file (format inferred from extension)
2. `--input-json=<value>` - Input value as JSON string
3. `--input-yaml=<value>` - Input value as YAML string
4. `--format=<json|yaml>` - Format for stdin input (when no other input specified)