### PR TITLE
feat: Capture stderr and log to trace

### DIFF
--- a/crates/stepflow-protocol/src/stdio/launcher.rs
+++ b/crates/stepflow-protocol/src/stdio/launcher.rs
@@ -44,6 +44,7 @@ impl Launcher {
             .args(&self.args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
             .kill_on_drop(true);
 
         command.current_dir(


### PR DESCRIPTION
This makes debugging easier since everything shows up in the tracing.

In the future, we should include a trace ID on requests, allowing distributed tracing to connect things.