### PR TITLE
feat: Implement write queue for state updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,6 +2913,7 @@ version = "0.1.0"
 dependencies = [
  "error-stack",
  "hex",
+ "indexmap",
  "insta",
  "safer_owning_ref",
  "schemars",
@@ -3061,6 +3062,7 @@ dependencies = [
 name = "stepflow-state"
 version = "0.1.0"
 dependencies = [
+ "bit-set",
  "chrono",
  "error-stack",
  "futures",
@@ -3076,6 +3078,7 @@ dependencies = [
 name = "stepflow-state-sql"
 version = "0.1.0"
 dependencies = [
+ "bit-set",
  "chrono",
  "error-stack",
  "futures",

--- a/crates/stepflow-analysis/src/error.rs
+++ b/crates/stepflow-analysis/src/error.rs
@@ -7,6 +7,8 @@ pub enum AnalysisError {
     MalformedReference { message: String },
     #[error("Step not found: {step_id}")]
     StepNotFound { step_id: String },
+    #[error("Error getting dependencies")]
+    DependencyAnalysis,
 }
 
 impl AnalysisError {

--- a/crates/stepflow-core/Cargo.toml
+++ b/crates/stepflow-core/Cargo.toml
@@ -18,6 +18,7 @@ doctest = false
 [dependencies]
 error-stack.workspace = true
 hex.workspace = true
+indexmap.workspace = true
 safer_owning_ref.workspace = true
 schemars.workspace = true
 serde_json.workspace = true

--- a/crates/stepflow-core/src/dependencies.rs
+++ b/crates/stepflow-core/src/dependencies.rs
@@ -1,0 +1,285 @@
+use indexmap::IndexMap;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use utoipa::ToSchema;
+
+use crate::workflow::{BaseRef, Expr, ValueRef, WorkflowRef};
+
+/// How a value receives its input data
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum ValueDependencies {
+    /// Value is an object with named fields
+    Object(IndexMap<String, HashSet<Dependency>>),
+    /// Value is not an object (single value, array, etc.)
+    Other(HashSet<Dependency>),
+}
+
+impl ValueDependencies {
+    /// Iterator over all dependencies of this value.
+    pub fn dependencies(&self) -> Box<dyn Iterator<Item = &Dependency> + '_> {
+        match self {
+            ValueDependencies::Object(map) => Box::new(map.values().flatten()),
+            ValueDependencies::Other(set) => Box::new(set.iter()),
+        }
+    }
+
+    /// Iterator over all steps this value depends on.
+    pub fn step_dependencies(&self) -> impl Iterator<Item = &str> {
+        self.dependencies().filter_map(Dependency::step_id)
+    }
+
+    /// Get the set of step IDs this value depends on.
+    pub fn step_dependency_set(&self) -> HashSet<String> {
+        self.step_dependencies().map(|s| s.to_string()).collect()
+    }
+}
+
+/// Source of input data
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum Dependency {
+    /// Comes from workflow input
+    #[serde(rename_all = "camelCase")]
+    FlowInput {
+        /// Optional field path within workflow input
+        field: Option<String>,
+    },
+    /// Comes from another step's output
+    #[serde(rename_all = "camelCase")]
+    StepOutput {
+        /// Which step produces this data
+        step_id: String,
+        /// Optional field path within step output
+        field: Option<String>,
+        /// If true, the step_id may be skipped and this step still executed.
+        optional: bool,
+    },
+}
+
+impl Dependency {
+    /// Return the step this dependency is on, if any.
+    pub fn step_id(&self) -> Option<&str> {
+        match self {
+            Dependency::FlowInput { .. } => None,
+            Dependency::StepOutput { step_id, .. } => Some(step_id),
+        }
+    }
+}
+
+/// Result of parsing a value for dependency analysis
+enum ParseResult<'a> {
+    /// A literal. Dependencies inside the value should be ignored.
+    Literal,
+    /// An expression.
+    Expr(Expr),
+    /// A value. Dependencies inside the value should be extracted.
+    Value(&'a serde_json::Value),
+}
+
+impl<'a> TryFrom<&'a ValueRef> for ParseResult<'a> {
+    type Error = error_stack::Report<DependencyError>;
+
+    fn try_from(value: &'a ValueRef) -> Result<Self, Self::Error> {
+        if let Some(fields) = value.as_object() {
+            if fields.contains_key("$literal") {
+                Ok(ParseResult::Literal)
+            } else if fields.contains_key("$from") {
+                let expr: Expr = serde_json::from_value(value.as_ref().clone()).map_err(|e| {
+                    error_stack::report!(DependencyError::ParseError)
+                        .attach_printable(format!("Failed to parse expression: {}", e))
+                })?;
+                Ok(ParseResult::Expr(expr))
+            } else {
+                Ok(ParseResult::Value(value.as_ref()))
+            }
+        } else {
+            Ok(ParseResult::Value(value.as_ref()))
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a serde_json::Value> for ParseResult<'a> {
+    type Error = error_stack::Report<DependencyError>;
+
+    fn try_from(value: &'a serde_json::Value) -> Result<Self, Self::Error> {
+        if let Some(fields) = value.as_object() {
+            if fields.contains_key("$literal") {
+                Ok(ParseResult::Literal)
+            } else if fields.contains_key("$from") {
+                let expr: Expr = serde_json::from_value(value.clone()).map_err(|e| {
+                    error_stack::report!(DependencyError::ParseError)
+                        .attach_printable(format!("Failed to parse expression: {}", e))
+                })?;
+                Ok(ParseResult::Expr(expr))
+            } else {
+                Ok(ParseResult::Value(value))
+            }
+        } else {
+            Ok(ParseResult::Value(value))
+        }
+    }
+}
+
+/// Extract detailed dependency information from a ValueRef
+pub fn extract_value_dependencies(
+    value_ref: &ValueRef,
+) -> Result<ValueDependencies, error_stack::Report<DependencyError>> {
+    match ParseResult::try_from(value_ref)? {
+        ParseResult::Literal => Ok(ValueDependencies::Other(HashSet::new())),
+        ParseResult::Expr(expr) => {
+            let mut deps = HashSet::new();
+            if let Some(dep) = extract_dependency_from_expr(&expr)? {
+                deps.insert(dep);
+            } else {
+                return Err(error_stack::report!(DependencyError::MalformedReference)
+                    .attach_printable(format!(
+                        "Found object with '$from' key that parsed as a literal expression: {:?}",
+                        value_ref
+                    )));
+            }
+            Ok(ValueDependencies::Other(deps))
+        }
+        ParseResult::Value(serde_json::Value::Object(fields)) => {
+            let fields = fields
+                .iter()
+                .map(|(f, v)| {
+                    let mut deps = HashSet::new();
+                    extract_dependencies_from_value(v, &mut deps)?;
+                    Ok((f.to_owned(), deps))
+                })
+                .collect::<Result<IndexMap<_, _>, error_stack::Report<DependencyError>>>()?;
+            Ok(ValueDependencies::Object(fields))
+        }
+        ParseResult::Value(v) => {
+            let mut deps = HashSet::new();
+            extract_dependencies_from_value(v, &mut deps)?;
+            Ok(ValueDependencies::Other(deps))
+        }
+    }
+}
+
+/// Extract dependencies from a JSON value
+fn extract_dependencies_from_value(
+    value: &serde_json::Value,
+    deps: &mut HashSet<Dependency>,
+) -> Result<(), error_stack::Report<DependencyError>> {
+    match ParseResult::try_from(value)? {
+        ParseResult::Literal => {}
+        ParseResult::Expr(expr) => {
+            if let Some(dep) = extract_dependency_from_expr(&expr)? {
+                deps.insert(dep);
+            }
+        }
+        ParseResult::Value(serde_json::Value::Object(fields)) => {
+            for val in fields.values() {
+                extract_dependencies_from_value(val, deps)?;
+            }
+        }
+        ParseResult::Value(serde_json::Value::Array(elements)) => {
+            for val in elements {
+                extract_dependencies_from_value(val, deps)?;
+            }
+        }
+        ParseResult::Value(_) => {}
+    }
+    Ok(())
+}
+
+/// Extract a dependency from an expression
+fn extract_dependency_from_expr(
+    expr: &Expr,
+) -> Result<Option<Dependency>, error_stack::Report<DependencyError>> {
+    match expr {
+        Expr::Ref {
+            from,
+            path,
+            on_skip,
+        } => {
+            let optional = on_skip.is_optional();
+            match from {
+                BaseRef::Step { step } => Ok(Some(Dependency::StepOutput {
+                    step_id: step.clone(),
+                    field: path.clone(),
+                    optional,
+                })),
+                BaseRef::Workflow(WorkflowRef::Input) => Ok(Some(Dependency::FlowInput {
+                    field: path.clone(),
+                })),
+            }
+        }
+        Expr::Literal(_) => Ok(None),
+    }
+}
+
+/// Error types for dependency analysis
+#[derive(Debug, thiserror::Error)]
+pub enum DependencyError {
+    #[error("Failed to parse expression")]
+    ParseError,
+    #[error("Malformed reference")]
+    MalformedReference,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_extract_simple_step_dependency() {
+        let value = ValueRef::new(json!({
+            "$from": {"step": "step1"}
+        }));
+
+        let deps = extract_value_dependencies(&value).unwrap();
+        let step_deps = deps.step_dependency_set();
+        let expected: HashSet<String> = ["step1"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(step_deps, expected);
+    }
+
+    #[test]
+    fn test_extract_object_dependencies() {
+        let value = ValueRef::new(json!({
+            "field1": {"$from": {"step": "step1"}},
+            "field2": {"$from": {"step": "step2"}},
+            "literal": "value"
+        }));
+
+        let deps = extract_value_dependencies(&value).unwrap();
+        let step_deps = deps.step_dependency_set();
+
+        match &deps {
+            ValueDependencies::Object(fields) => {
+                assert_eq!(fields.len(), 3);
+                // field1 should have step1 dependency
+                assert_eq!(fields["field1"].len(), 1);
+                // field2 should have step2 dependency
+                assert_eq!(fields["field2"].len(), 1);
+                // literal field should have no dependencies
+                assert_eq!(fields["literal"].len(), 0);
+            }
+            _ => panic!("Expected Object dependencies"),
+        }
+        let expected: HashSet<String> = ["step1", "step2"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(step_deps, expected);
+    }
+
+    #[test]
+    fn test_extract_flow_input_dependency() {
+        let value = ValueRef::new(json!({
+            "$from": {"workflow": "input"}
+        }));
+
+        let deps = extract_value_dependencies(&value).unwrap();
+        // Should have no step dependencies (flow input dependency)
+        let step_deps = deps.step_dependency_set();
+        assert!(step_deps.is_empty());
+
+        // But should have a flow input dependency
+        let all_deps: Vec<_> = deps.dependencies().collect();
+        assert_eq!(all_deps.len(), 1);
+        assert!(matches!(all_deps[0], Dependency::FlowInput { .. }));
+    }
+}

--- a/crates/stepflow-core/src/lib.rs
+++ b/crates/stepflow-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod blob;
 pub mod component;
+pub mod dependencies;
 pub mod schema;
 pub mod status;
 pub mod workflow;

--- a/crates/stepflow-core/src/workflow.rs
+++ b/crates/stepflow-core/src/workflow.rs
@@ -2,10 +2,12 @@ mod component;
 mod expr;
 mod flow;
 mod step;
+mod step_id;
 mod value;
 
 pub use component::*;
 pub use expr::*;
 pub use flow::*;
 pub use step::*;
+pub use step_id::*;
 pub use value::*;

--- a/crates/stepflow-core/src/workflow/step_id.rs
+++ b/crates/stepflow-core/src/workflow/step_id.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use crate::workflow::Flow;
+
+/// A step identifier that combines the step index with a reference to the flow.
+/// This allows efficient lookup using the index while maintaining access to
+/// the step ID string and other step metadata through the flow reference.
+#[derive(Debug, Clone)]
+pub struct StepId {
+    /// The step index in the workflow
+    pub index: usize,
+    /// Reference to the flow containing this step
+    pub flow: Arc<Flow>,
+}
+
+impl PartialEq for StepId {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index && Arc::ptr_eq(&self.flow, &other.flow)
+    }
+}
+
+impl Eq for StepId {}
+
+impl std::hash::Hash for StepId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.index.hash(state);
+        Arc::as_ptr(&self.flow).hash(state);
+    }
+}
+
+impl StepId {
+    /// Get the step name/ID string from the flow
+    pub fn step_name(&self) -> &str {
+        &self.flow.steps[self.index].id
+    }
+}
+
+impl std::fmt::Display for StepId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.step_name())
+    }
+}

--- a/crates/stepflow-execution/src/lib.rs
+++ b/crates/stepflow-execution/src/lib.rs
@@ -2,6 +2,7 @@ mod error;
 mod executor;
 mod value_resolver;
 mod workflow_executor;
+mod write_cache;
 
 pub use error::{ExecutionError, Result};
 pub use executor::StepFlowExecutor;

--- a/crates/stepflow-execution/src/write_cache.rs
+++ b/crates/stepflow-execution/src/write_cache.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use bit_set::BitSet;
+use stepflow_core::{FlowResult, status::StepStatus as CoreStepStatus};
+use stepflow_state::{StateError, StateStore};
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+use stepflow_core::workflow::StepId;
+
+/// Write-through cache for step results and status updates
+#[derive(Debug, Clone)]
+pub struct WriteCache {
+    /// Internal data protected by Arc for cheap cloning
+    inner: Arc<WriteCacheInner>,
+}
+
+#[derive(Debug)]
+struct WriteCacheInner {
+    /// Cached step results by step index (Vec index = step index)
+    step_results: RwLock<Vec<Option<FlowResult>>>,
+    /// Cached step statuses by step index (Vec index = step index)
+    step_statuses: RwLock<Vec<Option<CoreStepStatus>>>,
+}
+
+impl WriteCache {
+    pub fn new(step_count: usize) -> Self {
+        Self {
+            inner: Arc::new(WriteCacheInner {
+                step_results: RwLock::new(vec![None; step_count]),
+                step_statuses: RwLock::new(vec![None; step_count]),
+            }),
+        }
+    }
+
+    /// Cache a step result
+    pub async fn cache_step_result(&self, step_index: usize, result: FlowResult) {
+        let mut step_results = self.inner.step_results.write().await;
+        debug_assert!(step_index < step_results.len(), "Step index out of bounds");
+        step_results[step_index] = Some(result);
+    }
+
+    /// Cache step status updates
+    pub async fn cache_step_statuses(&self, status: CoreStepStatus, step_indices: &BitSet) {
+        let mut step_statuses = self.inner.step_statuses.write().await;
+        for step_index in step_indices.iter() {
+            debug_assert!(step_index < step_statuses.len(), "Step index out of bounds");
+            step_statuses[step_index] = Some(status);
+        }
+    }
+
+    /// Get cached step result if available
+    pub async fn get_step_result(&self, step_id: &StepId) -> Option<FlowResult> {
+        let step_results = self.inner.step_results.read().await;
+        step_results.get(step_id.index).and_then(|opt| opt.clone())
+    }
+
+    /// Get step result with read-through to state store
+    ///
+    /// This method first checks the cache, and if not found, falls back to the state store.
+    /// This encapsulates the read-through pattern within the cache itself.
+    pub async fn get_step_result_with_fallback(
+        &self,
+        step_id: StepId,
+        execution_id: Uuid,
+        state_store: &Arc<dyn StateStore>,
+    ) -> Result<FlowResult, error_stack::Report<StateError>> {
+        // First check cache
+        if let Some(cached_result) = self.get_step_result(&step_id).await {
+            return Ok(cached_result);
+        }
+
+        // Not in cache, fetch from state store
+        state_store
+            .get_step_result_by_id(execution_id, step_id)
+            .await
+    }
+}

--- a/crates/stepflow-server/src/api.rs
+++ b/crates/stepflow-server/src/api.rs
@@ -69,13 +69,13 @@ pub use runs::{CreateRunRequest, CreateRunResponse};
         flows::StoreFlowResponse,
         flows::FlowResponse,
         stepflow_analysis::AnalysisResult,
-        stepflow_analysis::Dependency,
         stepflow_analysis::Diagnostic,
         stepflow_analysis::DiagnosticLevel,
         stepflow_analysis::DiagnosticMessage,
         stepflow_analysis::Diagnostics,
         stepflow_analysis::FlowAnalysis,
         stepflow_analysis::StepAnalysis,
+        stepflow_core::dependencies::Dependency,
     )),
 )]
 struct StepflowApi;

--- a/crates/stepflow-server/src/api/runs.rs
+++ b/crates/stepflow-server/src/api/runs.rs
@@ -374,7 +374,7 @@ pub async fn get_run_steps(
     // Get step results for completed steps
     let step_results = state_store.list_step_results(run_id).await?;
 
-    let mut completed_steps: HashMap<usize, stepflow_state::StepResult<'_>> = HashMap::new();
+    let mut completed_steps: HashMap<usize, stepflow_state::StepResult> = HashMap::new();
     for step_result in step_results {
         completed_steps.insert(step_result.step_idx(), step_result);
     }

--- a/crates/stepflow-state-sql/Cargo.toml
+++ b/crates/stepflow-state-sql/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 doctest = false
 
 [dependencies]
+bit-set.workspace = true
 chrono.workspace = true
 error-stack.workspace = true
 futures.workspace = true

--- a/crates/stepflow-state/Cargo.toml
+++ b/crates/stepflow-state/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 doctest = false
 
 [dependencies]
+bit-set.workspace = true
 chrono.workspace = true
 error-stack.workspace = true
 futures.workspace = true

--- a/crates/stepflow-state/src/lib.rs
+++ b/crates/stepflow-state/src/lib.rs
@@ -6,6 +6,6 @@ pub use error::{Result, StateError};
 pub use in_memory::InMemoryStateStore;
 pub use state_store::{
     DebugSessionData, ExecutionDetails, ExecutionFilters, ExecutionStepDetails, ExecutionSummary,
-    ExecutionWithBlobs, StateStore, StepInfo, StepResult, WorkflowLabelMetadata,
-    WorkflowWithMetadata,
+    ExecutionWithBlobs, StateStore, StateWriteOperation, StepInfo, StepResult,
+    WorkflowLabelMetadata, WorkflowWithMetadata,
 };

--- a/tests/sql-state/simple_workflow.yaml
+++ b/tests/sql-state/simple_workflow.yaml
@@ -16,7 +16,7 @@ steps:
 
 output: 
   input_message: {$from: { workflow: input }, path: message }
-  processed_result: { $from: { step: process_message }, path: result }
+  processed_result: { $from: { step: "process_message" }, path: result }
 
 test:
   cases:

--- a/tests/sql-state/stepflow-config.yml
+++ b/tests/sql-state/stepflow-config.yml
@@ -17,6 +17,9 @@ plugins:
           { value: "Testing execution state persistence" }:
             outcome: success
             result: { result: "Testing execution state persistence" }
+          { value: "Testing" }:
+            outcome: success
+            result: { result: "Testing" }
 
 # Use SQLite with in-memory database for testing
 state_store:


### PR DESCRIPTION
- Enable non-blocking writes during execution by sending them to a queue
- Allow StateStore implementations to manage the queue and processing appropriately (eg., batching, etc.).
- Add write-through cache for value resolution so we "read our writes" without flushing the queue.
- Add workflow recovery logic to handle missed status transitions that can occur due to async write queue delays or system restarts.
- Remove lifetime from StepResult for queueing.
- Centralize dependency analysis and validation logic.

Recovery process:
1. Query completed step results from state store
2. Mark completed steps in dependency tracker
3. Identify steps that should be runnable based on dependencies
4. Fix status mismatches by updating blocked steps to runnable
5. Cache recovered step results for performance