### PR TITLE
feat: Use blobs for flows

### DIFF
--- a/examples/basic/workflow.yaml
+++ b/examples/basic/workflow.yaml
@@ -38,6 +38,7 @@ steps:
             b: { type: integer }
           required: [a, b]
         code: "input['a'] + input['b']"
+      blob_type: "data"
 
   # Create UDF for multiplication
   - id: create_multiplication_udf
@@ -51,6 +52,7 @@ steps:
             b: { type: integer }
           required: [a, b]
         code: "input['a'] * input['b']"
+      blob_type: "data"
 
   # Calculate m + n using UDF
   - id: m_plus_n

--- a/examples/data-pipeline/debug-pipeline.yaml
+++ b/examples/data-pipeline/debug-pipeline.yaml
@@ -20,6 +20,7 @@ steps:
       data:
         $literal:
           code: "sum(item['revenue'] for item in input['sales_data'])"
+      blob_type: "data"
 
   - id: calculate_total_revenue
     component: "/python/udf"
@@ -34,6 +35,7 @@ steps:
       data:
         $literal:
           code: "len(input['sales_data'])"
+      blob_type: "data"
 
   - id: count_sales
     component: "/python/udf"

--- a/examples/data-pipeline/pipeline.yaml
+++ b/examples/data-pipeline/pipeline.yaml
@@ -20,6 +20,7 @@ steps:
       data:
         $literal:
           code: "sum(item['revenue'] for item in input['sales_data'])"
+      blob_type: "data"
 
   - id: calculate_total_revenue
     component: "/python/udf"
@@ -34,6 +35,7 @@ steps:
       data:
         $literal:
           code: "len(input['sales_data'])"
+      blob_type: "data"
 
   - id: count_sales
     component: "/python/udf"
@@ -48,6 +50,7 @@ steps:
       data:
         $literal:
           code: "sum(item['revenue'] for item in input['sales_data']) / len(input['sales_data']) if input['sales_data'] else 0"
+      blob_type: "data"
 
   - id: calculate_average_sale
     component: "/python/udf"
@@ -63,6 +66,7 @@ steps:
       data:
         $literal:
           code: "input['a'] / input['b'] if input['b'] != 0 else 0"
+      blob_type: "data"
 
   - id: calculate_performance_ratio
     component: "/python/udf"

--- a/examples/eval/math-eval.yaml
+++ b/examples/eval/math-eval.yaml
@@ -9,10 +9,10 @@ input_schema:
       type: array
 
 steps:
-  - id: nested_math
-    component: /builtin/eval
+  - id: create_nested_flow
+    component: /builtin/put_blob
     input:
-      workflow:
+      data:
         $literal:
           schema: https://stepflow.org/schemas/v1/flow.json
           name: "Nested Math Workflow"
@@ -29,6 +29,7 @@ steps:
                         b: { type: integer }
                       required: [a, b]
                     code: "input['a'] + input['b']"
+                blob_type: "data"
 
             - id: compute_sum
               component: "/python/udf"
@@ -39,6 +40,12 @@ steps:
                   b: { $from: { workflow: input }, path: "y" }
           output:
             sum_result: { $from: { step: compute_sum } }
+      blob_type: "flow"
+
+  - id: nested_math
+    component: /builtin/eval
+    input:
+      flow_id: { $from: { step: create_nested_flow }, path: "blob_id" }
       input:
         x: 5
         y: 3

--- a/examples/eval/simple-eval.yaml
+++ b/examples/eval/simple-eval.yaml
@@ -3,16 +3,22 @@ name: "Simple Eval Component Test"
 description: "Basic test of the eval builtin component"
 
 steps:
-  - id: test_eval
-    component: /builtin/eval
+  - id: create_nested_flow
+    component: /builtin/put_blob
     input:
-      workflow:
+      data:
         $literal:
           schema: https://stepflow.org/schemas/v1/flow.json
           name: "Simple Nested Workflow"
           steps: []
           output:
             test_result: "Hello from nested workflow!"
+      blob_type: "flow"
+
+  - id: test_eval
+    component: /builtin/eval
+    input:
+      flow_id: { $from: { step: create_nested_flow }, path: "blob_id" }
       input: {}
 
 output:

--- a/examples/file-loading/load-pipeline.yaml
+++ b/examples/file-loading/load-pipeline.yaml
@@ -26,6 +26,7 @@ steps:
       data:
         $literal:
           code: "input['file_data']['sales_data']"
+      blob_type: "data"
 
   - id: extract_sales_array
     component: "/python/udf"
@@ -41,6 +42,7 @@ steps:
       data:
         $literal:
           code: "sum(item['revenue'] for item in input['sales_data'])"
+      blob_type: "data"
 
   - id: calculate_total_revenue
     component: "/python/udf"

--- a/examples/loop-components/builtin_iterate.yaml
+++ b/examples/loop-components/builtin_iterate.yaml
@@ -3,11 +3,12 @@ name: "Test Builtin Iterate"
 description: "Test the builtin iterate component"
 
 steps:
-  - id: count_to_target
-    component: "/python/iterate"
+  - id: create_counter_flow
+    component: "/builtin/put_blob"
     input:
-      flow:
+      data:
         $literal:
+          schema: "https://stepflow.org/schemas/v1/flow.json"
           steps:
             - id: counter
               component: "/python/counter_step"
@@ -15,6 +16,12 @@ steps:
                 current: { $from: { workflow: input }, path: "current" }
                 target: { $from: { workflow: input }, path: "target" }
           output: { $from: { step: "counter" } }
+      blob_type: "flow"
+  
+  - id: count_to_target
+    component: "/python/iterate"
+    input:
+      flow_id: { $from: { step: "create_counter_flow" }, path: "blob_id" }
       initial_input:
         current: { $from: { workflow: input }, path: "current" }
         target: { $from: { workflow: input }, path: "target" }

--- a/examples/loop-components/iterate.yaml
+++ b/examples/loop-components/iterate.yaml
@@ -30,11 +30,12 @@ output_schema:
           description: "Whether iteration was terminated by max_iterations"
 
 steps:
-  - id: count_to_target
-    component: "/python/iterate"
+  - id: create_counter_flow
+    component: "/builtin/put_blob"
     input:
-      flow:
+      data:
         $literal:
+          schema: "https://stepflow.org/schemas/v1/flow.json"
           steps:
             - id: counter
               component: "/python/counter_step"
@@ -42,6 +43,12 @@ steps:
                 current: { $from: { workflow: input }, path: "current" }
                 target: { $from: { workflow: input }, path: "target" }
           output: { $from: { step: "counter" } }
+      blob_type: "flow"
+  
+  - id: count_to_target
+    component: "/python/iterate"
+    input:
+      flow_id: { $from: { step: "create_counter_flow" }, path: "blob_id" }
       initial_input:
         current: { $from: { workflow: input }, path: "current" }
         target: { $from: { workflow: input }, path: "target" }

--- a/examples/loop-components/map_example.yaml
+++ b/examples/loop-components/map_example.yaml
@@ -19,17 +19,24 @@ output_schema:
   description: "Array of doubled numbers"
 
 steps:
-  - id: double_all
-    component: "/python/map"
+  - id: create_doubler_flow
+    component: "/builtin/put_blob"
     input:
-      flow:
+      data:
         $literal:
+          schema: "https://stepflow.org/schemas/v1/flow.json"
           steps:
             - id: doubler
               component: "/python/double_value"
               input:
                 value: { $from: { workflow: input } }
           output: { $from: { step: "doubler" }, path: "result" }
+      blob_type: "flow"
+  
+  - id: double_all
+    component: "/python/map"
+    input:
+      flow_id: { $from: { step: "create_doubler_flow" }, path: "blob_id" }
       items: { $from: { workflow: input }, path: "items" }
 
 output: { $from: { step: "double_all" }, path: "results" }

--- a/schemas/flow.json
+++ b/schemas/flow.json
@@ -1,0 +1,715 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Flow",
+  "description": "A workflow consisting of a sequence of steps and their outputs.\n\nA flow represents a complete workflow that can be executed. It contains:\n- A sequence of steps to execute\n- Named outputs that can reference step outputs\n\nFlows should not be cloned. They should generally be stored and passed as a\nreference or inside an `Arc`.",
+  "oneOf": [
+    {
+      "title": "FlowV1",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the flow.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "description": "The description of the flow.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "description": "The version of the flow.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "inputSchema": {
+          "description": "The input schema of the flow.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "outputSchema": {
+          "description": "The output schema of the flow.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "steps": {
+          "description": "The steps to execute for the flow.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Step"
+          },
+          "default": []
+        },
+        "output": {
+          "description": "The outputs of the flow, mapping output names to their values.",
+          "$ref": "#/$defs/ValueTemplate"
+        },
+        "test": {
+          "description": "Test configuration for the flow.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TestConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "examples": {
+          "description": "Example inputs for the workflow that can be used for testing and UI dropdowns.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/ExampleInput"
+          }
+        },
+        "schema": {
+          "type": "string",
+          "const": "https://stepflow.org/schemas/v1/flow.json"
+        }
+      },
+      "required": [
+        "schema",
+        "steps"
+      ]
+    }
+  ],
+  "$defs": {
+    "Schema": {
+      "description": "A JSON schema describing allowed JSON values.",
+      "type": "object",
+      "additionalProperties": true,
+      "example": "\n                {\n                \"type\": \"object\",\n                \"properties\": {\n                    \"item\": {\n                    \"type\": \"object\",\n                    \"properties\": {\n                        \"label\": {\"type\": \"string\"},\n                    },\n                    \"required\": [\"label\"]\n                    }\n                },\n                \"required\": [\"item\"]\n                }\n            "
+    },
+    "Step": {
+      "description": "A step in a workflow that executes a component with specific arguments.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Identifier for the step",
+          "type": "string"
+        },
+        "component": {
+          "description": "The component to execute in this step",
+          "$ref": "#/$defs/Component"
+        },
+        "inputSchema": {
+          "description": "The input schema for this step.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "outputSchema": {
+          "description": "The output schema for this step.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "skipIf": {
+          "description": "If set and the referenced value is truthy, this step will be skipped.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Expr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "onError": {
+          "$ref": "#/$defs/ErrorAction"
+        },
+        "input": {
+          "description": "Arguments to pass to the component for this step",
+          "$ref": "#/$defs/ValueTemplate"
+        }
+      },
+      "required": [
+        "id",
+        "component"
+      ]
+    },
+    "Component": {
+      "description": "Identifies a specific plugin and atomic functionality to execute. Use component name for builtins (e.g., 'eval') or path format for plugins (e.g., '/python/udf').",
+      "type": "string",
+      "examples": [
+        "/builtin/eval",
+        "/mcpfs/list_files",
+        "/python/udf"
+      ]
+    },
+    "Expr": {
+      "description": "An expression that can be either a literal value or a template expression.",
+      "anyOf": [
+        {
+          "title": "Reference",
+          "description": "Reference a value from a step, workflow, or other source.",
+          "type": "object",
+          "properties": {
+            "$from": {
+              "description": "The source of the reference.",
+              "$ref": "#/$defs/BaseRef"
+            },
+            "path": {
+              "description": "JSON path expression to apply to the referenced value.\n\nDefaults to `$` (the whole referenced value).\nMay also be a bare field name (without the leading $) if\nthe referenced value is an object.",
+              "$ref": "#/$defs/JsonPath"
+            },
+            "onSkip": {
+              "$ref": "#/$defs/SkipAction"
+            }
+          },
+          "required": [
+            "$from"
+          ]
+        },
+        {
+          "title": "EscapedLiteral",
+          "description": "A literal value that was escaped.\n\nNo template expansion is performed within the value, allowing\nfor raw JSON values that include `$from` or other special characters.",
+          "type": "object",
+          "properties": {
+            "$literal": {
+              "description": "A literal value that should not be expanded for expressions.\nThis allows creating JSON values that contain `$from` without expansion.",
+              "$ref": "#/$defs/Value"
+            }
+          },
+          "required": [
+            "$literal"
+          ]
+        },
+        {
+          "title": "Literal",
+          "description": "A direct literal value that serializes naturally without special syntax",
+          "$ref": "#/$defs/Value"
+        }
+      ]
+    },
+    "BaseRef": {
+      "description": "An expression that can be either a literal value or a template expression.",
+      "anyOf": [
+        {
+          "title": "WorkflowReference",
+          "description": "Reference properties of the workflow.",
+          "type": "object",
+          "properties": {
+            "workflow": {
+              "$ref": "#/$defs/WorkflowRef"
+            }
+          },
+          "required": [
+            "workflow"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "title": "StepReference",
+          "description": "Reference the output of a step.",
+          "type": "object",
+          "properties": {
+            "step": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "step"
+          ]
+        }
+      ]
+    },
+    "WorkflowRef": {
+      "type": "string",
+      "enum": [
+        "input"
+      ]
+    },
+    "JsonPath": {
+      "description": "JSON path expression to apply to the referenced value. May use `$` to reference the whole value. May also be a bare field name (without the leading $) if the referenced value is an object.",
+      "type": "string",
+      "examples": [
+        "field",
+        "$.field",
+        "$[\"field\"]",
+        "$[0]",
+        "$.field[0].nested"
+      ]
+    },
+    "SkipAction": {
+      "oneOf": [
+        {
+          "title": "OnSkipSkip",
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "const": "skip"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "title": "OnSkipDefault",
+          "type": "object",
+          "properties": {
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Value"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "action": {
+              "type": "string",
+              "const": "useDefault"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        }
+      ]
+    },
+    "Value": {
+      "description": "Any JSON value (object, array, string, number, boolean, or null)"
+    },
+    "ErrorAction": {
+      "oneOf": [
+        {
+          "title": "OnErrorFail",
+          "description": "If the step fails, the flow will fail.",
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "const": "fail"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "title": "OnErrorSkip",
+          "description": "If the step fails, mark it as skipped. This allows down-stream steps to handle the skipped step.",
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "const": "skip"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "title": "OnErrorDefault",
+          "description": "If the step fails, use the `defaultValue` instead.",
+          "type": "object",
+          "properties": {
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ValueTemplate"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "action": {
+              "type": "string",
+              "const": "useDefault"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "title": "OnErrorRetry",
+          "description": "If the step fails, retry it.",
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "const": "retry"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        }
+      ]
+    },
+    "ValueTemplate": {
+      "description": "A value that can be either a literal JSON value or an expression that references other values using the $from syntax",
+      "anyOf": [
+        {
+          "description": "An expression with `$from` syntax for referencing other values",
+          "$ref": "#/$defs/Expr"
+        },
+        {
+          "description": "JSON null value",
+          "type": "null"
+        },
+        {
+          "description": "JSON boolean value",
+          "type": "boolean"
+        },
+        {
+          "description": "JSON numeric value",
+          "type": "number"
+        },
+        {
+          "description": "JSON string value",
+          "type": "string"
+        },
+        {
+          "description": "JSON array where each element can be a template",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ValueTemplate"
+          }
+        },
+        {
+          "description": "JSON object where each value can be a template",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ValueTemplate"
+          }
+        }
+      ]
+    },
+    "TestConfig": {
+      "description": "Configuration for testing a workflow.",
+      "type": "object",
+      "properties": {
+        "servers": {
+          "description": "Test servers to start before running tests.\nKey is the server name, value is the server configuration.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/TestServerConfig"
+          }
+        },
+        "config": {
+          "description": "Stepflow configuration specific to tests.\nCan reference server URLs using placeholders like {server_name.url}."
+        },
+        "cases": {
+          "description": "Test cases for the workflow.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TestCase"
+          }
+        }
+      }
+    },
+    "TestServerConfig": {
+      "description": "Configuration for a test server.",
+      "type": "object",
+      "properties": {
+        "command": {
+          "description": "Command to start the server.",
+          "type": "string"
+        },
+        "args": {
+          "description": "Arguments for the server command.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "description": "Environment variables for the server process.\nValues can contain placeholders like {port} which will be substituted.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "workingDirectory": {
+          "description": "Working directory for the server process.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "portRange": {
+          "description": "Port range for automatic port allocation.\nIf not specified, a random available port will be used.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "prefixItems": [
+            {
+              "type": "integer",
+              "format": "uint16",
+              "minimum": 0,
+              "maximum": 65535
+            },
+            {
+              "type": "integer",
+              "format": "uint16",
+              "minimum": 0,
+              "maximum": 65535
+            }
+          ],
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "healthCheck": {
+          "description": "Health check configuration.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TestServerHealthCheck"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "startupTimeoutMs": {
+          "description": "Maximum time to wait for server startup (in milliseconds).",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0,
+          "default": 10000
+        },
+        "shutdownTimeoutMs": {
+          "description": "Maximum time to wait for server shutdown (in milliseconds).",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0,
+          "default": 5000
+        }
+      },
+      "required": [
+        "command"
+      ]
+    },
+    "TestServerHealthCheck": {
+      "description": "Health check configuration for test servers.",
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Path for health check endpoint (e.g., \"/health\").",
+          "type": "string"
+        },
+        "timeoutMs": {
+          "description": "Timeout for health check requests (in milliseconds).",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0,
+          "default": 5000
+        },
+        "retryAttempts": {
+          "description": "Number of retry attempts for health checks.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 3
+        },
+        "retryDelayMs": {
+          "description": "Delay between retry attempts (in milliseconds).",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0,
+          "default": 1000
+        }
+      },
+      "required": [
+        "path"
+      ]
+    },
+    "TestCase": {
+      "description": "A single test case for a workflow.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Unique identifier for the test case.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description of what this test case verifies.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "input": {
+          "description": "Input data for the workflow in this test case.",
+          "$ref": "#/$defs/Value"
+        },
+        "output": {
+          "description": "Expected output from the workflow for this test case.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FlowResult"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "input"
+      ]
+    },
+    "FlowResult": {
+      "title": "FlowResult",
+      "description": "The results of a step execution.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/FlowResultSuccess"
+        },
+        {
+          "$ref": "#/$defs/FlowResultSkipped"
+        },
+        {
+          "$ref": "#/$defs/FlowResultFailed"
+        }
+      ],
+      "discriminator": {
+        "propertyName": "outcome",
+        "mapping": {
+          "success": "#/$defs/FlowResultSuccess",
+          "skipped": "#/$defs/FlowResultSkipped",
+          "failed": "#/$defs/FlowResultFailed"
+        }
+      }
+    },
+    "FlowError": {
+      "description": "An error reported from within a flow or step.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "message": {
+          "type": "string"
+        },
+        "data": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Value"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "FlowResultSuccess": {
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "title": "FlowOutcome",
+          "const": "success",
+          "default": "success"
+        },
+        "result": {
+          "$ref": "#/$defs/Value"
+        }
+      },
+      "required": [
+        "outcome",
+        "result"
+      ]
+    },
+    "FlowResultSkipped": {
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "title": "FlowOutcome",
+          "const": "skipped",
+          "default": "skipped"
+        }
+      },
+      "required": [
+        "outcome"
+      ]
+    },
+    "FlowResultFailed": {
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "title": "FlowOutcome",
+          "const": "failed",
+          "default": "failed"
+        },
+        "error": {
+          "$ref": "#/$defs/FlowError"
+        }
+      },
+      "required": [
+        "outcome",
+        "error"
+      ]
+    },
+    "ExampleInput": {
+      "description": "An example input for a workflow that can be used in UI dropdowns.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the example input for display purposes.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description of what this example demonstrates.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "input": {
+          "description": "The input data for this example.",
+          "$ref": "#/$defs/Value"
+        }
+      },
+      "required": [
+        "name",
+        "input"
+      ]
+    }
+  }
+}

--- a/schemas/protocol.json
+++ b/schemas/protocol.json
@@ -182,9 +182,21 @@
       "properties": {
         "data": {
           "$ref": "#/$defs/Value"
+        },
+        "blob_type": {
+          "$ref": "#/$defs/BlobType"
         }
       },
       "required": [
+        "data",
+        "blob_type"
+      ]
+    },
+    "BlobType": {
+      "description": "Type of blob stored in the blob store",
+      "type": "string",
+      "enum": [
+        "flow",
         "data"
       ]
     },
@@ -192,9 +204,9 @@
       "description": "Sent from the component server to the StepFlow to evaluate a flow with the provided input.",
       "type": "object",
       "properties": {
-        "flow": {
-          "description": "The flow to evaluate.",
-          "$ref": "#/$defs/Flow"
+        "flow_id": {
+          "description": "The ID of the flow to evaluate (blob ID of the flow).",
+          "$ref": "#/$defs/BlobId"
         },
         "input": {
           "description": "The input to provide to the flow.",
@@ -202,705 +214,7 @@
         }
       },
       "required": [
-        "flow",
-        "input"
-      ]
-    },
-    "Flow": {
-      "description": "A workflow consisting of a sequence of steps and their outputs.\n\nA flow represents a complete workflow that can be executed. It contains:\n- A sequence of steps to execute\n- Named outputs that can reference step outputs\n\nFlows should not be cloned. They should generally be stored and passed as a\nreference or inside an `Arc`.",
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "name": {
-              "description": "The name of the flow.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "description": {
-              "description": "The description of the flow.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "version": {
-              "description": "The version of the flow.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "inputSchema": {
-              "description": "The input schema of the flow.",
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Schema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "outputSchema": {
-              "description": "The output schema of the flow.",
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Schema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "steps": {
-              "description": "The steps to execute for the flow.",
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/Step"
-              },
-              "default": []
-            },
-            "output": {
-              "description": "The outputs of the flow, mapping output names to their values.",
-              "$ref": "#/$defs/ValueTemplate"
-            },
-            "test": {
-              "description": "Test configuration for the flow.",
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/TestConfig"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "examples": {
-              "description": "Example inputs for the workflow that can be used for testing and UI dropdowns.",
-              "type": [
-                "array",
-                "null"
-              ],
-              "items": {
-                "$ref": "#/$defs/ExampleInput"
-              }
-            },
-            "schema": {
-              "type": "string",
-              "const": "https://stepflow.org/schemas/v1/flow.json"
-            }
-          },
-          "required": [
-            "schema",
-            "steps"
-          ]
-        }
-      ]
-    },
-    "Schema": {
-      "description": "A JSON schema describing allowed JSON values.",
-      "type": "object",
-      "additionalProperties": true,
-      "example": "\n                {\n                \"type\": \"object\",\n                \"properties\": {\n                    \"item\": {\n                    \"type\": \"object\",\n                    \"properties\": {\n                        \"label\": {\"type\": \"string\"},\n                    },\n                    \"required\": [\"label\"]\n                    }\n                },\n                \"required\": [\"item\"]\n                }\n            "
-    },
-    "Step": {
-      "description": "A step in a workflow that executes a component with specific arguments.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Identifier for the step",
-          "type": "string"
-        },
-        "component": {
-          "description": "The component to execute in this step",
-          "$ref": "#/$defs/Component"
-        },
-        "inputSchema": {
-          "description": "The input schema for this step.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Schema"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "outputSchema": {
-          "description": "The output schema for this step.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Schema"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "skipIf": {
-          "description": "If set and the referenced value is truthy, this step will be skipped.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Expr"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "onError": {
-          "$ref": "#/$defs/ErrorAction"
-        },
-        "input": {
-          "description": "Arguments to pass to the component for this step",
-          "$ref": "#/$defs/ValueTemplate"
-        }
-      },
-      "required": [
-        "id",
-        "component"
-      ]
-    },
-    "Expr": {
-      "description": "An expression that can be either a literal value or a template expression.",
-      "anyOf": [
-        {
-          "title": "Reference",
-          "description": "Reference a value from a step, workflow, or other source.",
-          "type": "object",
-          "properties": {
-            "$from": {
-              "description": "The source of the reference.",
-              "$ref": "#/$defs/BaseRef"
-            },
-            "path": {
-              "description": "JSON path expression to apply to the referenced value.\n\nDefaults to `$` (the whole referenced value).\nMay also be a bare field name (without the leading $) if\nthe referenced value is an object.",
-              "$ref": "#/$defs/JsonPath"
-            },
-            "onSkip": {
-              "$ref": "#/$defs/SkipAction"
-            }
-          },
-          "required": [
-            "$from"
-          ]
-        },
-        {
-          "title": "EscapedLiteral",
-          "description": "A literal value that was escaped.\n\nNo template expansion is performed within the value, allowing\nfor raw JSON values that include `$from` or other special characters.",
-          "type": "object",
-          "properties": {
-            "$literal": {
-              "description": "A literal value that should not be expanded for expressions.\nThis allows creating JSON values that contain `$from` without expansion.",
-              "$ref": "#/$defs/Value"
-            }
-          },
-          "required": [
-            "$literal"
-          ]
-        },
-        {
-          "title": "Literal",
-          "description": "A direct literal value that serializes naturally without special syntax",
-          "$ref": "#/$defs/Value"
-        }
-      ]
-    },
-    "BaseRef": {
-      "description": "An expression that can be either a literal value or a template expression.",
-      "anyOf": [
-        {
-          "title": "WorkflowReference",
-          "description": "Reference properties of the workflow.",
-          "type": "object",
-          "properties": {
-            "workflow": {
-              "$ref": "#/$defs/WorkflowRef"
-            }
-          },
-          "required": [
-            "workflow"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "title": "StepReference",
-          "description": "Reference the output of a step.",
-          "type": "object",
-          "properties": {
-            "step": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "step"
-          ]
-        }
-      ]
-    },
-    "WorkflowRef": {
-      "type": "string",
-      "enum": [
-        "input"
-      ]
-    },
-    "JsonPath": {
-      "description": "JSON path expression to apply to the referenced value. May use `$` to reference the whole value. May also be a bare field name (without the leading $) if the referenced value is an object.",
-      "type": "string",
-      "examples": [
-        "field",
-        "$.field",
-        "$[\"field\"]",
-        "$[0]",
-        "$.field[0].nested"
-      ]
-    },
-    "SkipAction": {
-      "oneOf": [
-        {
-          "title": "OnSkipSkip",
-          "type": "object",
-          "properties": {
-            "action": {
-              "type": "string",
-              "const": "skip"
-            }
-          },
-          "required": [
-            "action"
-          ]
-        },
-        {
-          "title": "OnSkipDefault",
-          "type": "object",
-          "properties": {
-            "defaultValue": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Value"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "action": {
-              "type": "string",
-              "const": "useDefault"
-            }
-          },
-          "required": [
-            "action"
-          ]
-        }
-      ]
-    },
-    "ErrorAction": {
-      "oneOf": [
-        {
-          "title": "OnErrorFail",
-          "description": "If the step fails, the flow will fail.",
-          "type": "object",
-          "properties": {
-            "action": {
-              "type": "string",
-              "const": "fail"
-            }
-          },
-          "required": [
-            "action"
-          ]
-        },
-        {
-          "title": "OnErrorSkip",
-          "description": "If the step fails, mark it as skipped. This allows down-stream steps to handle the skipped step.",
-          "type": "object",
-          "properties": {
-            "action": {
-              "type": "string",
-              "const": "skip"
-            }
-          },
-          "required": [
-            "action"
-          ]
-        },
-        {
-          "title": "OnErrorDefault",
-          "description": "If the step fails, use the `defaultValue` instead.",
-          "type": "object",
-          "properties": {
-            "defaultValue": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ValueTemplate"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "action": {
-              "type": "string",
-              "const": "useDefault"
-            }
-          },
-          "required": [
-            "action"
-          ]
-        },
-        {
-          "title": "OnErrorRetry",
-          "description": "If the step fails, retry it.",
-          "type": "object",
-          "properties": {
-            "action": {
-              "type": "string",
-              "const": "retry"
-            }
-          },
-          "required": [
-            "action"
-          ]
-        }
-      ]
-    },
-    "ValueTemplate": {
-      "description": "A value that can be either a literal JSON value or an expression that references other values using the $from syntax",
-      "anyOf": [
-        {
-          "description": "An expression with `$from` syntax for referencing other values",
-          "$ref": "#/$defs/Expr"
-        },
-        {
-          "description": "JSON null value",
-          "type": "null"
-        },
-        {
-          "description": "JSON boolean value",
-          "type": "boolean"
-        },
-        {
-          "description": "JSON numeric value",
-          "type": "number"
-        },
-        {
-          "description": "JSON string value",
-          "type": "string"
-        },
-        {
-          "description": "JSON array where each element can be a template",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ValueTemplate"
-          }
-        },
-        {
-          "description": "JSON object where each value can be a template",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/ValueTemplate"
-          }
-        }
-      ]
-    },
-    "TestConfig": {
-      "description": "Configuration for testing a workflow.",
-      "type": "object",
-      "properties": {
-        "servers": {
-          "description": "Test servers to start before running tests.\nKey is the server name, value is the server configuration.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/TestServerConfig"
-          }
-        },
-        "config": {
-          "description": "Stepflow configuration specific to tests.\nCan reference server URLs using placeholders like {server_name.url}."
-        },
-        "cases": {
-          "description": "Test cases for the workflow.",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/TestCase"
-          }
-        }
-      }
-    },
-    "TestServerConfig": {
-      "description": "Configuration for a test server.",
-      "type": "object",
-      "properties": {
-        "command": {
-          "description": "Command to start the server.",
-          "type": "string"
-        },
-        "args": {
-          "description": "Arguments for the server command.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "env": {
-          "description": "Environment variables for the server process.\nValues can contain placeholders like {port} which will be substituted.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "workingDirectory": {
-          "description": "Working directory for the server process.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "portRange": {
-          "description": "Port range for automatic port allocation.\nIf not specified, a random available port will be used.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "prefixItems": [
-            {
-              "type": "integer",
-              "format": "uint16",
-              "minimum": 0,
-              "maximum": 65535
-            },
-            {
-              "type": "integer",
-              "format": "uint16",
-              "minimum": 0,
-              "maximum": 65535
-            }
-          ],
-          "minItems": 2,
-          "maxItems": 2
-        },
-        "healthCheck": {
-          "description": "Health check configuration.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TestServerHealthCheck"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "startupTimeoutMs": {
-          "description": "Maximum time to wait for server startup (in milliseconds).",
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0,
-          "default": 10000
-        },
-        "shutdownTimeoutMs": {
-          "description": "Maximum time to wait for server shutdown (in milliseconds).",
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0,
-          "default": 5000
-        }
-      },
-      "required": [
-        "command"
-      ]
-    },
-    "TestServerHealthCheck": {
-      "description": "Health check configuration for test servers.",
-      "type": "object",
-      "properties": {
-        "path": {
-          "description": "Path for health check endpoint (e.g., \"/health\").",
-          "type": "string"
-        },
-        "timeoutMs": {
-          "description": "Timeout for health check requests (in milliseconds).",
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0,
-          "default": 5000
-        },
-        "retryAttempts": {
-          "description": "Number of retry attempts for health checks.",
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0,
-          "default": 3
-        },
-        "retryDelayMs": {
-          "description": "Delay between retry attempts (in milliseconds).",
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0,
-          "default": 1000
-        }
-      },
-      "required": [
-        "path"
-      ]
-    },
-    "TestCase": {
-      "description": "A single test case for a workflow.",
-      "type": "object",
-      "properties": {
-        "name": {
-          "description": "Unique identifier for the test case.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Optional description of what this test case verifies.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "input": {
-          "description": "Input data for the workflow in this test case.",
-          "$ref": "#/$defs/Value"
-        },
-        "output": {
-          "description": "Expected output from the workflow for this test case.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/FlowResult"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "required": [
-        "name",
-        "input"
-      ]
-    },
-    "FlowResult": {
-      "title": "FlowResult",
-      "description": "The results of a step execution.",
-      "oneOf": [
-        {
-          "$ref": "#/$defs/FlowResultSuccess"
-        },
-        {
-          "$ref": "#/$defs/FlowResultSkipped"
-        },
-        {
-          "$ref": "#/$defs/FlowResultFailed"
-        }
-      ],
-      "discriminator": {
-        "propertyName": "outcome",
-        "mapping": {
-          "success": "#/$defs/FlowResultSuccess",
-          "skipped": "#/$defs/FlowResultSkipped",
-          "failed": "#/$defs/FlowResultFailed"
-        }
-      }
-    },
-    "FlowError": {
-      "description": "An error reported from within a flow or step.",
-      "type": "object",
-      "properties": {
-        "code": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "message": {
-          "type": "string"
-        },
-        "data": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Value"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "required": [
-        "code",
-        "message"
-      ]
-    },
-    "FlowResultSuccess": {
-      "type": "object",
-      "properties": {
-        "outcome": {
-          "title": "FlowOutcome",
-          "const": "success",
-          "default": "success"
-        },
-        "result": {
-          "$ref": "#/$defs/Value"
-        }
-      },
-      "required": [
-        "outcome",
-        "result"
-      ]
-    },
-    "FlowResultSkipped": {
-      "type": "object",
-      "properties": {
-        "outcome": {
-          "title": "FlowOutcome",
-          "const": "skipped",
-          "default": "skipped"
-        }
-      },
-      "required": [
-        "outcome"
-      ]
-    },
-    "FlowResultFailed": {
-      "type": "object",
-      "properties": {
-        "outcome": {
-          "title": "FlowOutcome",
-          "const": "failed",
-          "default": "failed"
-        },
-        "error": {
-          "$ref": "#/$defs/FlowError"
-        }
-      },
-      "required": [
-        "outcome",
-        "error"
-      ]
-    },
-    "ExampleInput": {
-      "description": "An example input for a workflow that can be used in UI dropdowns.",
-      "type": "object",
-      "properties": {
-        "name": {
-          "description": "Name of the example input for display purposes.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Optional description of what this example demonstrates.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "input": {
-          "description": "The input data for this example.",
-          "$ref": "#/$defs/Value"
-        }
-      },
-      "required": [
-        "name",
+        "flow_id",
         "input"
       ]
     },
@@ -1041,6 +355,12 @@
         "component"
       ]
     },
+    "Schema": {
+      "description": "A JSON schema describing allowed JSON values.",
+      "type": "object",
+      "additionalProperties": true,
+      "example": "\n                {\n                \"type\": \"object\",\n                \"properties\": {\n                    \"item\": {\n                    \"type\": \"object\",\n                    \"properties\": {\n                        \"label\": {\"type\": \"string\"},\n                    },\n                    \"required\": [\"label\"]\n                    }\n                },\n                \"required\": [\"item\"]\n                }\n            "
+    },
     "ListComponentsResult": {
       "description": "Sent from the component server back to StepFlow with a list of all available components.",
       "type": "object",
@@ -1058,15 +378,19 @@
       ]
     },
     "GetBlobResult": {
-      "description": "Sent from the StepFlow back to the component server with the content of the requested blob.",
+      "description": "Sent from the StepFlow back to the component server with the blob data and metadata.",
       "type": "object",
       "properties": {
         "data": {
           "$ref": "#/$defs/Value"
+        },
+        "blob_type": {
+          "$ref": "#/$defs/BlobType"
         }
       },
       "required": [
-        "data"
+        "data",
+        "blob_type"
       ]
     },
     "PutBlobResult": {
@@ -1092,6 +416,103 @@
       },
       "required": [
         "result"
+      ]
+    },
+    "FlowResult": {
+      "title": "FlowResult",
+      "description": "The results of a step execution.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/FlowResultSuccess"
+        },
+        {
+          "$ref": "#/$defs/FlowResultSkipped"
+        },
+        {
+          "$ref": "#/$defs/FlowResultFailed"
+        }
+      ],
+      "discriminator": {
+        "propertyName": "outcome",
+        "mapping": {
+          "success": "#/$defs/FlowResultSuccess",
+          "skipped": "#/$defs/FlowResultSkipped",
+          "failed": "#/$defs/FlowResultFailed"
+        }
+      }
+    },
+    "FlowError": {
+      "description": "An error reported from within a flow or step.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "message": {
+          "type": "string"
+        },
+        "data": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Value"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "FlowResultSuccess": {
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "title": "FlowOutcome",
+          "const": "success",
+          "default": "success"
+        },
+        "result": {
+          "$ref": "#/$defs/Value"
+        }
+      },
+      "required": [
+        "outcome",
+        "result"
+      ]
+    },
+    "FlowResultSkipped": {
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "title": "FlowOutcome",
+          "const": "skipped",
+          "default": "skipped"
+        }
+      },
+      "required": [
+        "outcome"
+      ]
+    },
+    "FlowResultFailed": {
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "title": "FlowOutcome",
+          "const": "failed",
+          "default": "failed"
+        },
+        "error": {
+          "$ref": "#/$defs/FlowError"
+        }
+      },
+      "required": [
+        "outcome",
+        "error"
       ]
     },
     "MethodError": {

--- a/sdks/python/generate.py
+++ b/sdks/python/generate.py
@@ -188,7 +188,7 @@ def generate_types_from_schema(
 
 
 def main():
-    """Generate protocol types from JSON schema (flow types are now included in protocol)."""
+    """Generate protocol and flow types from JSON schemas."""
     parser = argparse.ArgumentParser(
         description="Generate StepFlow Python SDK types from JSON schemas"
     )
@@ -198,9 +198,16 @@ def main():
 
     args = parser.parse_args()
 
-    # Generate protocol types (includes Flow and all other types)
+    # Generate protocol types
     result = generate_types_from_schema(
         "protocol", "generated_protocol.py", check_only=args.check
+    )
+    if result != 0:
+        return result
+
+    # Generate flow types
+    result = generate_types_from_schema(
+        "flow", "generated_flow.py", check_only=args.check
     )
     if result != 0:
         return result

--- a/sdks/python/src/stepflow_py/__init__.py
+++ b/sdks/python/src/stepflow_py/__init__.py
@@ -15,7 +15,7 @@
 
 from .context import StepflowContext
 from .flow_builder import FlowBuilder, StepHandle
-from .generated_protocol import (
+from .generated_flow import (
     ErrorAction,
     OnErrorDefault,
     OnErrorFail,

--- a/sdks/python/src/stepflow_py/flow_builder.py
+++ b/sdks/python/src/stepflow_py/flow_builder.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from .generated_protocol import (
+from .generated_flow import (
     Component,
     ErrorAction,
     EscapedLiteral,
@@ -31,10 +31,10 @@ from .generated_protocol import (
     ValueTemplate,
     WorkflowReference,
 )
-from .generated_protocol import (
+from .generated_flow import (
     StepReference as GeneratedStepReference,
 )
-from .generated_protocol import (
+from .generated_flow import (
     Value as GeneratedValue,
 )
 from .value import (

--- a/sdks/python/src/stepflow_py/generated_flow.py
+++ b/sdks/python/src/stepflow_py/generated_flow.py
@@ -1,0 +1,406 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Auto-generated flow types from schemas/flow.json
+# To regenerate this file, run:
+#   uv run python generate.py
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Annotated, Any, ClassVar, Dict, List, Literal
+
+from msgspec import Meta, Struct, field
+
+
+class Schema(Struct, kw_only=True):
+    pass
+
+
+Component = Annotated[
+    str,
+    Meta(
+        description="Identifies a specific plugin and atomic functionality to execute. Use component name for builtins (e.g., 'eval') or path format for plugins (e.g., '/python/udf').",
+        examples=['/builtin/eval', '/mcpfs/list_files', '/python/udf'],
+    ),
+]
+
+
+class StepReference(Struct, kw_only=True):
+    step: str
+
+
+class WorkflowRef(Enum):
+    input = 'input'
+
+
+JsonPath = Annotated[
+    str,
+    Meta(
+        description='JSON path expression to apply to the referenced value. May use `$` to reference the whole value. May also be a bare field name (without the leading $) if the referenced value is an object.',
+        examples=['field', '$.field', '$["field"]', '$[0]', '$.field[0].nested'],
+    ),
+]
+
+
+class OnSkipSkip(Struct, kw_only=True):
+    action: Literal['skip']
+
+
+Value = Annotated[
+    Any,
+    Meta(
+        description='Any JSON value (object, array, string, number, boolean, or null)'
+    ),
+]
+
+
+class OnErrorFail(Struct, kw_only=True):
+    action: Literal['fail']
+
+
+class OnErrorSkip(Struct, kw_only=True):
+    action: Literal['skip']
+
+
+class OnErrorRetry(Struct, kw_only=True):
+    action: Literal['retry']
+
+
+class TestServerHealthCheck(Struct, kw_only=True):
+    path: Annotated[
+        str, Meta(description='Path for health check endpoint (e.g., "/health").')
+    ]
+    timeoutMs: (
+        Annotated[
+            int,
+            Meta(
+                description='Timeout for health check requests (in milliseconds).', ge=0
+            ),
+        ]
+        | None
+    ) = 5000
+    retryAttempts: (
+        Annotated[
+            int, Meta(description='Number of retry attempts for health checks.', ge=0)
+        ]
+        | None
+    ) = 3
+    retryDelayMs: (
+        Annotated[
+            int,
+            Meta(description='Delay between retry attempts (in milliseconds).', ge=0),
+        ]
+        | None
+    ) = 1000
+
+
+class FlowError(Struct, kw_only=True):
+    code: int
+    message: str
+    data: Value | None = None
+
+
+class FlowResultSuccess(Struct, kw_only=True, tag_field='outcome', tag='success'):
+    outcome: ClassVar[Annotated[Literal['success'], Meta(title='FlowOutcome')]]
+    result: Value
+
+
+class FlowResultSkipped(Struct, kw_only=True, tag_field='outcome', tag='skipped'):
+    outcome: ClassVar[Annotated[Literal['skipped'], Meta(title='FlowOutcome')]]
+
+
+class FlowResultFailed(Struct, kw_only=True, tag_field='outcome', tag='failed'):
+    outcome: ClassVar[Annotated[Literal['failed'], Meta(title='FlowOutcome')]]
+    error: FlowError
+
+
+class ExampleInput(Struct, kw_only=True):
+    name: Annotated[
+        str, Meta(description='Name of the example input for display purposes.')
+    ]
+    input: Annotated[Value, Meta(description='The input data for this example.')]
+    description: (
+        Annotated[
+            str | None,
+            Meta(description='Optional description of what this example demonstrates.'),
+        ]
+        | None
+    ) = None
+
+
+class EscapedLiteral(Struct, kw_only=True):
+    field_literal: Annotated[
+        Value,
+        Meta(
+            description='A literal value that should not be expanded for expressions.\nThis allows creating JSON values that contain `$from` without expansion.'
+        ),
+    ] = field(name='$literal')
+
+
+class WorkflowReference(Struct, kw_only=True):
+    workflow: WorkflowRef
+
+
+BaseRef = Annotated[
+    WorkflowReference | StepReference,
+    Meta(
+        description='An expression that can be either a literal value or a template expression.'
+    ),
+]
+
+
+class OnSkipDefault(Struct, kw_only=True):
+    action: Literal['useDefault']
+    defaultValue: Value | None = None
+
+
+SkipAction = OnSkipSkip | OnSkipDefault
+
+
+class TestServerConfig(Struct, kw_only=True):
+    command: Annotated[str, Meta(description='Command to start the server.')]
+    args: (
+        Annotated[List[str], Meta(description='Arguments for the server command.')]
+        | None
+    ) = None
+    env: (
+        Annotated[
+            Dict[str, str],
+            Meta(
+                description='Environment variables for the server process.\nValues can contain placeholders like {port} which will be substituted.'
+            ),
+        ]
+        | None
+    ) = None
+    workingDirectory: (
+        Annotated[
+            str | None, Meta(description='Working directory for the server process.')
+        ]
+        | None
+    ) = None
+    portRange: (
+        Annotated[
+            List[Any] | None,
+            Meta(
+                description='Port range for automatic port allocation.\nIf not specified, a random available port will be used.'
+            ),
+        ]
+        | None
+    ) = None
+    healthCheck: (
+        Annotated[
+            TestServerHealthCheck | None,
+            Meta(description='Health check configuration.'),
+        ]
+        | None
+    ) = None
+    startupTimeoutMs: (
+        Annotated[
+            int,
+            Meta(
+                description='Maximum time to wait for server startup (in milliseconds).',
+                ge=0,
+            ),
+        ]
+        | None
+    ) = 10000
+    shutdownTimeoutMs: (
+        Annotated[
+            int,
+            Meta(
+                description='Maximum time to wait for server shutdown (in milliseconds).',
+                ge=0,
+            ),
+        ]
+        | None
+    ) = 5000
+
+
+FlowResult = Annotated[
+    FlowResultSuccess | FlowResultSkipped | FlowResultFailed,
+    Meta(description='The results of a step execution.', title='FlowResult'),
+]
+
+
+class Reference(Struct, kw_only=True):
+    field_from: Annotated[BaseRef, Meta(description='The source of the reference.')] = (
+        field(name='$from')
+    )
+    path: (
+        Annotated[
+            JsonPath,
+            Meta(
+                description='JSON path expression to apply to the referenced value.\n\nDefaults to `$` (the whole referenced value).\nMay also be a bare field name (without the leading $) if\nthe referenced value is an object.'
+            ),
+        ]
+        | None
+    ) = None
+    onSkip: SkipAction | None = None
+
+
+Expr = Annotated[
+    Reference | EscapedLiteral | Value,
+    Meta(
+        description='An expression that can be either a literal value or a template expression.'
+    ),
+]
+
+
+ValueTemplate = Annotated[
+    Expr | bool | float | str | List['ValueTemplate'] | Dict[str, 'ValueTemplate'] | None,
+    Meta(
+        description='A value that can be either a literal JSON value or an expression that references other values using the $from syntax'
+    ),
+]
+
+
+class TestCase(Struct, kw_only=True):
+    name: Annotated[str, Meta(description='Unique identifier for the test case.')]
+    input: Annotated[
+        Value, Meta(description='Input data for the workflow in this test case.')
+    ]
+    description: (
+        Annotated[
+            str | None,
+            Meta(description='Optional description of what this test case verifies.'),
+        ]
+        | None
+    ) = None
+    output: (
+        Annotated[
+            FlowResult | None,
+            Meta(description='Expected output from the workflow for this test case.'),
+        ]
+        | None
+    ) = None
+
+
+class OnErrorDefault(Struct, kw_only=True):
+    action: Literal['useDefault']
+    defaultValue: ValueTemplate | None = None
+
+
+ErrorAction = OnErrorFail | OnErrorSkip | OnErrorDefault | OnErrorRetry
+
+
+class TestConfig(Struct, kw_only=True):
+    servers: (
+        Annotated[
+            Dict[str, TestServerConfig],
+            Meta(
+                description='Test servers to start before running tests.\nKey is the server name, value is the server configuration.'
+            ),
+        ]
+        | None
+    ) = None
+    config: (
+        Annotated[
+            Any,
+            Meta(
+                description='Stepflow configuration specific to tests.\nCan reference server URLs using placeholders like {server_name.url}.'
+            ),
+        ]
+        | None
+    ) = None
+    cases: (
+        Annotated[List[TestCase], Meta(description='Test cases for the workflow.')]
+        | None
+    ) = None
+
+
+class Step(Struct, kw_only=True):
+    id: Annotated[str, Meta(description='Identifier for the step')]
+    component: Annotated[
+        Component, Meta(description='The component to execute in this step')
+    ]
+    inputSchema: (
+        Annotated[Schema | None, Meta(description='The input schema for this step.')]
+        | None
+    ) = None
+    outputSchema: (
+        Annotated[Schema | None, Meta(description='The output schema for this step.')]
+        | None
+    ) = None
+    skipIf: (
+        Annotated[
+            Expr | None,
+            Meta(
+                description='If set and the referenced value is truthy, this step will be skipped.'
+            ),
+        ]
+        | None
+    ) = None
+    onError: ErrorAction | None = None
+    input: (
+        Annotated[
+            ValueTemplate,
+            Meta(description='Arguments to pass to the component for this step'),
+        ]
+        | None
+    ) = None
+
+
+class FlowV1(Struct, kw_only=True):
+    steps: Annotated[List[Step], Meta(description='The steps to execute for the flow.')]
+    schema_: Literal['https://stepflow.org/schemas/v1/flow.json'] = field(name='schema')
+    name: Annotated[str | None, Meta(description='The name of the flow.')] | None = None
+    description: (
+        Annotated[str | None, Meta(description='The description of the flow.')] | None
+    ) = None
+    version: (
+        Annotated[str | None, Meta(description='The version of the flow.')] | None
+    ) = None
+    inputSchema: (
+        Annotated[Schema | None, Meta(description='The input schema of the flow.')]
+        | None
+    ) = None
+    outputSchema: (
+        Annotated[Schema | None, Meta(description='The output schema of the flow.')]
+        | None
+    ) = None
+    output: (
+        Annotated[
+            ValueTemplate,
+            Meta(
+                description='The outputs of the flow, mapping output names to their values.'
+            ),
+        ]
+        | None
+    ) = None
+    test: (
+        Annotated[
+            TestConfig | None, Meta(description='Test configuration for the flow.')
+        ]
+        | None
+    ) = None
+    examples: (
+        Annotated[
+            List[ExampleInput],
+            Meta(
+                description='Example inputs for the workflow that can be used for testing and UI dropdowns.'
+            ),
+        ]
+        | None
+    ) = None
+
+
+Flow = Annotated[
+    FlowV1,
+    Meta(
+        description='A workflow consisting of a sequence of steps and their outputs.\n\nA flow represents a complete workflow that can be executed. It contains:\n- A sequence of steps to execute\n- Named outputs that can reference step outputs\n\nFlows should not be cloned. They should generally be stored and passed as a\nreference or inside an `Arc`.',
+        title='Flow',
+    ),
+]

--- a/sdks/python/src/stepflow_py/generated_protocol.py
+++ b/sdks/python/src/stepflow_py/generated_protocol.py
@@ -20,9 +20,9 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Annotated, Any, ClassVar, Dict, List, Literal
+from typing import Annotated, Any, ClassVar, List, Literal
 
-from msgspec import Meta, Struct, field
+from msgspec import Meta, Struct
 
 JsonRpc = Annotated[
     Literal['2.0'], Meta(description='The version of the JSON-RPC protocol.')
@@ -93,90 +93,44 @@ BlobId = Annotated[
 ]
 
 
-class PutBlobParams(Struct, kw_only=True):
-    data: Value
+class BlobType(Enum):
+    flow = 'flow'
+    data = 'data'
+
+
+class EvaluateFlowParams(Struct, kw_only=True):
+    flow_id: Annotated[
+        BlobId,
+        Meta(description='The ID of the flow to evaluate (blob ID of the flow).'),
+    ]
+    input: Annotated[Value, Meta(description='The input to provide to the flow.')]
+
+
+class InitializeResult(Struct, kw_only=True):
+    server_protocol_version: Annotated[
+        int,
+        Meta(
+            description='Version of the protocol being used by the component server.',
+            ge=0,
+        ),
+    ]
+
+
+class ComponentExecuteResult(Struct, kw_only=True):
+    output: Annotated[Value, Meta(description='The result of the component execution.')]
 
 
 class Schema(Struct, kw_only=True):
     pass
 
 
-class EscapedLiteral(Struct, kw_only=True):
-    field_literal: Annotated[
-        Value,
-        Meta(
-            description='A literal value that should not be expanded for expressions.\nThis allows creating JSON values that contain `$from` without expansion.'
-        ),
-    ] = field(name='$literal')
+class GetBlobResult(Struct, kw_only=True):
+    data: Value
+    blob_type: BlobType
 
 
-class StepReference(Struct, kw_only=True):
-    step: str
-
-
-class WorkflowRef(Enum):
-    input = 'input'
-
-
-JsonPath = Annotated[
-    str,
-    Meta(
-        description='JSON path expression to apply to the referenced value. May use `$` to reference the whole value. May also be a bare field name (without the leading $) if the referenced value is an object.',
-        examples=['field', '$.field', '$["field"]', '$[0]', '$.field[0].nested'],
-    ),
-]
-
-
-class OnSkipSkip(Struct, kw_only=True):
-    action: Literal['skip']
-
-
-class OnSkipDefault(Struct, kw_only=True):
-    action: Literal['useDefault']
-    defaultValue: Value | None = None
-
-
-SkipAction = OnSkipSkip | OnSkipDefault
-
-
-class OnErrorFail(Struct, kw_only=True):
-    action: Literal['fail']
-
-
-class OnErrorSkip(Struct, kw_only=True):
-    action: Literal['skip']
-
-
-class OnErrorRetry(Struct, kw_only=True):
-    action: Literal['retry']
-
-
-class TestServerHealthCheck(Struct, kw_only=True):
-    path: Annotated[
-        str, Meta(description='Path for health check endpoint (e.g., "/health").')
-    ]
-    timeoutMs: (
-        Annotated[
-            int,
-            Meta(
-                description='Timeout for health check requests (in milliseconds).', ge=0
-            ),
-        ]
-        | None
-    ) = 5000
-    retryAttempts: (
-        Annotated[
-            int, Meta(description='Number of retry attempts for health checks.', ge=0)
-        ]
-        | None
-    ) = 3
-    retryDelayMs: (
-        Annotated[
-            int,
-            Meta(description='Delay between retry attempts (in milliseconds).', ge=0),
-        ]
-        | None
-    ) = 1000
+class PutBlobResult(Struct, kw_only=True):
+    blob_id: BlobId
 
 
 class FlowError(Struct, kw_only=True):
@@ -199,32 +153,38 @@ class FlowResultFailed(Struct, kw_only=True, tag_field='outcome', tag='failed'):
     error: FlowError
 
 
-class ExampleInput(Struct, kw_only=True):
-    name: Annotated[
-        str, Meta(description='Name of the example input for display purposes.')
+class Error(Struct, kw_only=True):
+    code: Annotated[int, Meta(description='A numeric code indicating the error type.')]
+    message: Annotated[
+        str, Meta(description='Concise, single-sentence description of the error.')
     ]
-    input: Annotated[Value, Meta(description='The input data for this example.')]
-    description: (
+    data: (
         Annotated[
-            str | None,
-            Meta(description='Optional description of what this example demonstrates.'),
+            Value | None,
+            Meta(
+                description='Primitive or structured value that contains additional information about the error.'
+            ),
         ]
         | None
     ) = None
 
 
-class InitializeResult(Struct, kw_only=True):
-    server_protocol_version: Annotated[
-        int,
-        Meta(
-            description='Version of the protocol being used by the component server.',
-            ge=0,
-        ),
-    ]
+class Initialized(Struct, kw_only=True):
+    pass
 
 
-class ComponentExecuteResult(Struct, kw_only=True):
-    output: Annotated[Value, Meta(description='The result of the component execution.')]
+class ComponentExecuteParams(Struct, kw_only=True):
+    component: Annotated[Component, Meta(description='The component to execute.')]
+    input: Annotated[Value, Meta(description='The input to the component.')]
+
+
+class GetBlobParams(Struct, kw_only=True):
+    blob_id: Annotated[BlobId, Meta(description='The ID of the blob to retrieve.')]
+
+
+class PutBlobParams(Struct, kw_only=True):
+    data: Value
+    blob_type: BlobType
 
 
 class ComponentInfo(Struct, kw_only=True):
@@ -261,128 +221,10 @@ class ListComponentsResult(Struct, kw_only=True):
     ]
 
 
-class GetBlobResult(Struct, kw_only=True):
-    data: Value
-
-
-class PutBlobResult(Struct, kw_only=True):
-    blob_id: BlobId
-
-
-class Error(Struct, kw_only=True):
-    code: Annotated[int, Meta(description='A numeric code indicating the error type.')]
-    message: Annotated[
-        str, Meta(description='Concise, single-sentence description of the error.')
-    ]
-    data: (
-        Annotated[
-            Value | None,
-            Meta(
-                description='Primitive or structured value that contains additional information about the error.'
-            ),
-        ]
-        | None
-    ) = None
-
-
-class Initialized(Struct, kw_only=True):
-    pass
-
-
-class ComponentExecuteParams(Struct, kw_only=True):
-    component: Annotated[Component, Meta(description='The component to execute.')]
-    input: Annotated[Value, Meta(description='The input to the component.')]
-
-
-class GetBlobParams(Struct, kw_only=True):
-    blob_id: Annotated[BlobId, Meta(description='The ID of the blob to retrieve.')]
-
-
-class WorkflowReference(Struct, kw_only=True):
-    workflow: WorkflowRef
-
-
-BaseRef = Annotated[
-    WorkflowReference | StepReference,
-    Meta(
-        description='An expression that can be either a literal value or a template expression.'
-    ),
-]
-
-
-class TestServerConfig(Struct, kw_only=True):
-    command: Annotated[str, Meta(description='Command to start the server.')]
-    args: (
-        Annotated[List[str], Meta(description='Arguments for the server command.')]
-        | None
-    ) = None
-    env: (
-        Annotated[
-            Dict[str, str],
-            Meta(
-                description='Environment variables for the server process.\nValues can contain placeholders like {port} which will be substituted.'
-            ),
-        ]
-        | None
-    ) = None
-    workingDirectory: (
-        Annotated[
-            str | None, Meta(description='Working directory for the server process.')
-        ]
-        | None
-    ) = None
-    portRange: (
-        Annotated[
-            List[Any] | None,
-            Meta(
-                description='Port range for automatic port allocation.\nIf not specified, a random available port will be used.'
-            ),
-        ]
-        | None
-    ) = None
-    healthCheck: (
-        Annotated[
-            TestServerHealthCheck | None,
-            Meta(description='Health check configuration.'),
-        ]
-        | None
-    ) = None
-    startupTimeoutMs: (
-        Annotated[
-            int,
-            Meta(
-                description='Maximum time to wait for server startup (in milliseconds).',
-                ge=0,
-            ),
-        ]
-        | None
-    ) = 10000
-    shutdownTimeoutMs: (
-        Annotated[
-            int,
-            Meta(
-                description='Maximum time to wait for server shutdown (in milliseconds).',
-                ge=0,
-            ),
-        ]
-        | None
-    ) = 5000
-
-
 FlowResult = Annotated[
     FlowResultSuccess | FlowResultSkipped | FlowResultFailed,
     Meta(description='The results of a step execution.', title='FlowResult'),
 ]
-
-
-class ComponentInfoResult(Struct, kw_only=True):
-    info: Annotated[ComponentInfo, Meta(description='Information about the component.')]
-
-
-class EvaluateFlowResult(Struct, kw_only=True):
-    result: Annotated[
-        FlowResult, Meta(description='The result of the flow evaluation.')
-    ]
 
 
 class MethodError(Struct, kw_only=True):
@@ -405,57 +247,33 @@ class Notification(Struct, kw_only=True):
     jsonrpc: JsonRpc | None = '2.0'
 
 
-class Reference(Struct, kw_only=True):
-    field_from: Annotated[BaseRef, Meta(description='The source of the reference.')] = (
-        field(name='$from')
-    )
-    path: (
-        Annotated[
-            JsonPath,
-            Meta(
-                description='JSON path expression to apply to the referenced value.\n\nDefaults to `$` (the whole referenced value).\nMay also be a bare field name (without the leading $) if\nthe referenced value is an object.'
-            ),
-        ]
-        | None
-    ) = None
-    onSkip: SkipAction | None = None
-
-
-Expr = Annotated[
-    Reference | EscapedLiteral | Value,
-    Meta(
-        description='An expression that can be either a literal value or a template expression.'
-    ),
-]
-
-
-ValueTemplate = Annotated[
-    Expr | bool | float | str | List['ValueTemplate'] | Dict[str, 'ValueTemplate'] | None,
-    Meta(
-        description='A value that can be either a literal JSON value or an expression that references other values using the $from syntax'
-    ),
-]
-
-
-class TestCase(Struct, kw_only=True):
-    name: Annotated[str, Meta(description='Unique identifier for the test case.')]
-    input: Annotated[
-        Value, Meta(description='Input data for the workflow in this test case.')
+class MethodRequest(Struct, kw_only=True):
+    id: RequestId
+    method: Annotated[Method, Meta(description='The method being called.')]
+    params: Annotated[
+        InitializeParams
+        | ComponentExecuteParams
+        | ComponentInfoParams
+        | ComponentListParams
+        | GetBlobParams
+        | PutBlobParams
+        | EvaluateFlowParams,
+        Meta(
+            description='The parameters for the method call. Set on method requests.',
+            title='MethodParams',
+        ),
     ]
-    description: (
-        Annotated[
-            str | None,
-            Meta(description='Optional description of what this test case verifies.'),
-        ]
-        | None
-    ) = None
-    output: (
-        Annotated[
-            FlowResult | None,
-            Meta(description='Expected output from the workflow for this test case.'),
-        ]
-        | None
-    ) = None
+    jsonrpc: JsonRpc | None = '2.0'
+
+
+class ComponentInfoResult(Struct, kw_only=True):
+    info: Annotated[ComponentInfo, Meta(description='Information about the component.')]
+
+
+class EvaluateFlowResult(Struct, kw_only=True):
+    result: Annotated[
+        FlowResult, Meta(description='The result of the flow evaluation.')
+    ]
 
 
 class MethodSuccess(Struct, kw_only=True):
@@ -476,156 +294,15 @@ class MethodSuccess(Struct, kw_only=True):
     jsonrpc: JsonRpc | None = '2.0'
 
 
-class OnErrorDefault(Struct, kw_only=True):
-    action: Literal['useDefault']
-    defaultValue: ValueTemplate | None = None
-
-
-ErrorAction = OnErrorFail | OnErrorSkip | OnErrorDefault | OnErrorRetry
-
-
-class TestConfig(Struct, kw_only=True):
-    servers: (
-        Annotated[
-            Dict[str, TestServerConfig],
-            Meta(
-                description='Test servers to start before running tests.\nKey is the server name, value is the server configuration.'
-            ),
-        ]
-        | None
-    ) = None
-    config: (
-        Annotated[
-            Any,
-            Meta(
-                description='Stepflow configuration specific to tests.\nCan reference server URLs using placeholders like {server_name.url}.'
-            ),
-        ]
-        | None
-    ) = None
-    cases: (
-        Annotated[List[TestCase], Meta(description='Test cases for the workflow.')]
-        | None
-    ) = None
-
-
-MethodResponse = Annotated[
-    MethodSuccess | MethodError, Meta(description='Response to a method request.')
-]
-
-
-class Step(Struct, kw_only=True):
-    id: Annotated[str, Meta(description='Identifier for the step')]
-    component: Annotated[
-        Component, Meta(description='The component to execute in this step')
-    ]
-    inputSchema: (
-        Annotated[Schema | None, Meta(description='The input schema for this step.')]
-        | None
-    ) = None
-    outputSchema: (
-        Annotated[Schema | None, Meta(description='The output schema for this step.')]
-        | None
-    ) = None
-    skipIf: (
-        Annotated[
-            Expr | None,
-            Meta(
-                description='If set and the referenced value is truthy, this step will be skipped.'
-            ),
-        ]
-        | None
-    ) = None
-    onError: ErrorAction | None = None
-    input: (
-        Annotated[
-            ValueTemplate,
-            Meta(description='Arguments to pass to the component for this step'),
-        ]
-        | None
-    ) = None
-
-
-class Flow1(Struct, kw_only=True):
-    steps: Annotated[List[Step], Meta(description='The steps to execute for the flow.')]
-    schema_: Literal['https://stepflow.org/schemas/v1/flow.json'] = field(name='schema')
-    name: Annotated[str | None, Meta(description='The name of the flow.')] | None = None
-    description: (
-        Annotated[str | None, Meta(description='The description of the flow.')] | None
-    ) = None
-    version: (
-        Annotated[str | None, Meta(description='The version of the flow.')] | None
-    ) = None
-    inputSchema: (
-        Annotated[Schema | None, Meta(description='The input schema of the flow.')]
-        | None
-    ) = None
-    outputSchema: (
-        Annotated[Schema | None, Meta(description='The output schema of the flow.')]
-        | None
-    ) = None
-    output: (
-        Annotated[
-            ValueTemplate,
-            Meta(
-                description='The outputs of the flow, mapping output names to their values.'
-            ),
-        ]
-        | None
-    ) = None
-    test: (
-        Annotated[
-            TestConfig | None, Meta(description='Test configuration for the flow.')
-        ]
-        | None
-    ) = None
-    examples: (
-        Annotated[
-            List[ExampleInput],
-            Meta(
-                description='Example inputs for the workflow that can be used for testing and UI dropdowns.'
-            ),
-        ]
-        | None
-    ) = None
-
-
-Flow = Annotated[
-    Flow1,
-    Meta(
-        description='A workflow consisting of a sequence of steps and their outputs.\n\nA flow represents a complete workflow that can be executed. It contains:\n- A sequence of steps to execute\n- Named outputs that can reference step outputs\n\nFlows should not be cloned. They should generally be stored and passed as a\nreference or inside an `Arc`.'
-    ),
-]
-
-
-class EvaluateFlowParams(Struct, kw_only=True):
-    flow: Annotated[Flow, Meta(description='The flow to evaluate.')]
-    input: Annotated[Value, Meta(description='The input to provide to the flow.')]
-
-
-class MethodRequest(Struct, kw_only=True):
-    id: RequestId
-    method: Annotated[Method, Meta(description='The method being called.')]
-    params: Annotated[
-        InitializeParams
-        | ComponentExecuteParams
-        | ComponentInfoParams
-        | ComponentListParams
-        | GetBlobParams
-        | PutBlobParams
-        | EvaluateFlowParams,
-        Meta(
-            description='The parameters for the method call. Set on method requests.',
-            title='MethodParams',
-        ),
-    ]
-    jsonrpc: JsonRpc | None = '2.0'
-
-
 Message = Annotated[
     MethodRequest | MethodSuccess | MethodError | Notification,
     Meta(
         description='The messages supported by the StepFlow protocol. These correspond to JSON-RPC 2.0 messages.\n\nNote that this defines a superset containing both client-sent and server-sent messages.',
         title='Message',
     ),
+]
+
+
+MethodResponse = Annotated[
+    MethodSuccess | MethodError, Meta(description='Response to a method request.')
 ]

--- a/sdks/python/src/stepflow_py/value.py
+++ b/sdks/python/src/stepflow_py/value.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from .generated_protocol import (
+from .generated_flow import (
     EscapedLiteral,
     Reference,
     SkipAction,
@@ -28,7 +28,7 @@ from .generated_protocol import (
     WorkflowRef,
     WorkflowReference,
 )
-from .generated_protocol import (
+from .generated_flow import (
     StepReference as GeneratedStepReference,
 )
 

--- a/sdks/python/tests/test_value.py
+++ b/sdks/python/tests/test_value.py
@@ -20,7 +20,7 @@ from stepflow_py import (
     OnSkipSkip,
 )
 from stepflow_py.flow_builder import FlowBuilder
-from stepflow_py.generated_protocol import EscapedLiteral
+from stepflow_py.generated_flow import EscapedLiteral
 from stepflow_py.value import JsonPath, StepReference, Value, WorkflowInput
 
 

--- a/stepflow-rs/crates/stepflow-analysis/src/types.rs
+++ b/stepflow-rs/crates/stepflow-analysis/src/types.rs
@@ -16,7 +16,7 @@ use indexmap::IndexMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use stepflow_core::workflow::{Flow, FlowHash};
+use stepflow_core::{BlobId, workflow::Flow};
 
 use crate::{
     diagnostics::Diagnostics,
@@ -71,8 +71,8 @@ impl AnalysisResult {
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FlowAnalysis {
-    /// The workflow hash for this analysis
-    pub flow_hash: FlowHash,
+    /// The workflow ID for this analysis
+    pub flow_id: BlobId,
     /// The workflow reference
     pub flow: Arc<Flow>,
     /// Step-by-step analysis keyed by step ID for easy lookup

--- a/stepflow-rs/crates/stepflow-analysis/src/validation.rs
+++ b/stepflow-rs/crates/stepflow-analysis/src/validation.rs
@@ -281,16 +281,26 @@ fn validate_references(
     diagnostics: &mut Diagnostics,
 ) {
     use stepflow_core::values::ValueTemplateRepr;
+    use stepflow_core::workflow::Expr;
 
     match template.as_ref() {
         ValueTemplateRepr::Expression(expr) => {
-            validate_expression_references(
-                expr,
-                path,
-                available_steps,
-                current_step_id,
-                diagnostics,
-            );
+            // Check if this is an EscapedLiteral - if so, don't validate its contents
+            match expr {
+                Expr::EscapedLiteral { .. } => {
+                    // EscapedLiteral expressions are opaque - don't validate their internal structure
+                    // against the outer flow's context
+                }
+                _ => {
+                    validate_expression_references(
+                        expr,
+                        path,
+                        available_steps,
+                        current_step_id,
+                        diagnostics,
+                    );
+                }
+            }
         }
         ValueTemplateRepr::Object(obj) => {
             // Recursively validate object fields

--- a/stepflow-rs/crates/stepflow-builtins/src/iterate.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/iterate.rs
@@ -91,7 +91,9 @@ impl BuiltinComponent for IterateComponent {
             .change_context(BuiltinError::InvalidInput)?;
 
         let flow = Arc::new(input.flow);
-        let workflow_hash = Flow::hash(&flow);
+        // Generate flow ID from content
+        let flow_id =
+            stepflow_core::BlobId::from_flow(&flow).change_context(BuiltinError::Internal)?;
         let mut current_input = input.initial_input;
         let mut iterations = 0;
 
@@ -110,7 +112,7 @@ impl BuiltinComponent for IterateComponent {
 
             // Execute the workflow
             let result = context
-                .execute_flow(flow.clone(), workflow_hash.clone(), current_input)
+                .execute_flow(flow.clone(), flow_id.clone(), current_input)
                 .await
                 .change_context(BuiltinError::Internal)?;
 

--- a/stepflow-rs/crates/stepflow-builtins/src/map.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/map.rs
@@ -82,7 +82,9 @@ impl BuiltinComponent for MapComponent {
             .change_context(BuiltinError::InvalidInput)?;
 
         let flow = Arc::new(input.workflow);
-        let workflow_hash = Flow::hash(&flow);
+        // Generate flow ID from content
+        let flow_id =
+            stepflow_core::BlobId::from_flow(&flow).change_context(BuiltinError::Internal)?;
 
         let mut successful = 0u32;
         let mut failed = 0u32;
@@ -92,11 +94,11 @@ impl BuiltinComponent for MapComponent {
         let tasks = input.items.into_iter().map(|item| {
             let context = context.clone();
             let flow = flow.clone();
-            let workflow_hash = workflow_hash.clone();
+            let flow_id = flow_id.clone();
 
             tokio::spawn(async move {
                 context
-                    .execute_flow(flow, workflow_hash, item)
+                    .execute_flow(flow, flow_id, item)
                     .await
                     .change_context(BuiltinError::Internal)
             })

--- a/stepflow-rs/crates/stepflow-builtins/src/mock_context.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/mock_context.rs
@@ -13,9 +13,8 @@
 
 use std::path::Path;
 use std::{pin::Pin, sync::Arc};
-use stepflow_core::workflow::FlowHash;
 use stepflow_core::{
-    FlowResult,
+    BlobId, FlowResult,
     workflow::{Flow, ValueRef},
 };
 use stepflow_plugin::ExecutionContext;
@@ -61,7 +60,7 @@ impl stepflow_plugin::Context for MockExecutor {
     fn submit_flow(
         &self,
         _flow: Arc<Flow>,
-        _workflow_hash: FlowHash,
+        _flow_id: BlobId,
         _input: ValueRef,
     ) -> Pin<Box<dyn std::future::Future<Output = stepflow_plugin::Result<Uuid>> + Send + '_>> {
         Box::pin(async { Ok(Uuid::new_v4()) })

--- a/stepflow-rs/crates/stepflow-components-mcp/tests/integration_test.rs
+++ b/stepflow-rs/crates/stepflow-components-mcp/tests/integration_test.rs
@@ -33,7 +33,7 @@ fn create_test_context() -> (Arc<dyn stepflow_plugin::Context>, ExecutionContext
         fn submit_flow(
             &self,
             _flow: Arc<stepflow_core::workflow::Flow>,
-            _workflow_hash: stepflow_core::workflow::FlowHash,
+            _flow_id: stepflow_core::BlobId,
             _input: ValueRef,
         ) -> futures::future::BoxFuture<'_, stepflow_plugin::Result<uuid::Uuid>> {
             async move { Ok(Uuid::new_v4()) }.boxed()

--- a/stepflow-rs/crates/stepflow-core/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-core/src/lib.rs
@@ -20,3 +20,6 @@ pub mod workflow;
 
 mod flow_result;
 pub use flow_result::*;
+
+// Re-export commonly used types
+pub use blob::{BlobData, BlobId, BlobType};

--- a/stepflow-rs/crates/stepflow-core/src/values.rs
+++ b/stepflow-rs/crates/stepflow-core/src/values.rs
@@ -11,7 +11,7 @@
 // or implied.  See the License for the specific language governing permissions and limitations under
 // the License.
 
-//! Value handling and resolution for StepFlow workflows.
+//! Value handling and resolution for StepFlow flows.
 //!
 //! This module contains all value-related functionality including:
 //! - `ValueRef`: References to concrete JSON values

--- a/stepflow-rs/crates/stepflow-execution/src/error.rs
+++ b/stepflow-rs/crates/stepflow-execution/src/error.rs
@@ -11,7 +11,8 @@
 // or implied.  See the License for the specific language governing permissions and limitations under
 // the License.
 
-use stepflow_core::workflow::{BaseRef, FlowHash, ValueRef};
+use stepflow_core::BlobId;
+use stepflow_core::workflow::{BaseRef, ValueRef};
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -58,7 +59,7 @@ pub enum ExecutionError {
     #[error("execution '{0}' not found")]
     ExecutionNotFound(Uuid),
     #[error("workflow '{0}' not found")]
-    WorkflowNotFound(FlowHash),
+    WorkflowNotFound(BlobId),
     #[error("failed to resolve value")]
     ValueResolverFailure,
 }

--- a/stepflow-rs/crates/stepflow-main/src/cli.rs
+++ b/stepflow-rs/crates/stepflow-main/src/cli.rs
@@ -11,8 +11,9 @@
 // or implied.  See the License for the specific language governing permissions and limitations under
 // the License.
 
+use error_stack::ResultExt as _;
 use std::{path::PathBuf, sync::Arc};
-use stepflow_core::workflow::Flow;
+use stepflow_core::{BlobId, workflow::Flow};
 use url::Url;
 
 use crate::{
@@ -186,8 +187,9 @@ impl Cli {
 
                 let input = input_args.parse_input(true)?;
 
-                let workflow_hash = Flow::hash(&flow);
-                let output = run(executor, flow, workflow_hash, input).await?;
+                let flow_id =
+                    BlobId::from_flow(&flow).change_context(crate::MainError::Configuration)?;
+                let output = run(executor, flow, flow_id, input).await?;
                 output_args.write_output(output)?;
             }
             Command::Serve { port, config_args } => {

--- a/stepflow-rs/crates/stepflow-main/src/run.rs
+++ b/stepflow-rs/crates/stepflow-main/src/run.rs
@@ -15,18 +15,18 @@ use std::sync::Arc;
 
 use crate::{MainError, Result};
 use error_stack::ResultExt as _;
-use stepflow_core::{FlowResult, workflow::Flow, workflow::FlowHash};
+use stepflow_core::{BlobId, FlowResult, workflow::Flow};
 use stepflow_execution::StepFlowExecutor;
 use stepflow_plugin::Context as _;
 
 pub async fn run(
     executor: Arc<StepFlowExecutor>,
     flow: Arc<Flow>,
-    workflow_hash: FlowHash,
+    flow_id: BlobId,
     input: stepflow_core::workflow::ValueRef,
 ) -> Result<FlowResult> {
     let run_id = executor
-        .submit_flow(flow, workflow_hash, input)
+        .submit_flow(flow, flow_id, input)
         .await
         .change_context(MainError::FlowExecution)?;
     let output = executor

--- a/stepflow-rs/crates/stepflow-main/src/serve.rs
+++ b/stepflow-rs/crates/stepflow-main/src/serve.rs
@@ -45,9 +45,9 @@ use stepflow_execution::StepFlowExecutor;
 /// ### 3. Flow Management
 /// Store and retrieve workflow definitions by content-based hash:
 /// ```
-/// POST /flows                        # Store workflow definition, get hash
-/// GET  /flows/{flow_hash}            # Retrieve workflow by hash
-/// DELETE /flows/{flow_hash}          # Delete workflow (placeholder)
+/// POST /flows                        # Store workflow definition, get id
+/// GET  /flows/{flow_id}              # Retrieve workflow by id
+/// DELETE /flows/{flow_id}            # Delete workflow (placeholder)
 /// ```
 ///
 /// ### 4. Execution Management

--- a/stepflow-rs/crates/stepflow-main/src/submit.rs
+++ b/stepflow-rs/crates/stepflow-main/src/submit.rs
@@ -61,14 +61,14 @@ pub async fn submit(service_url: Url, flow: Flow, input: ValueRef) -> Result<Flo
     })?;
 
     // Check if the workflow was stored successfully
-    let flow_hash = store_result.flow_hash.ok_or_else(|| {
+    let flow_id = store_result.flow_id.ok_or_else(|| {
         tracing::error!("Workflow validation failed - flow was not stored");
         MainError::Configuration
     })?;
 
     // Step 2: Execute the workflow by hash
     let execute_request = CreateRunRequest {
-        flow_hash,
+        flow_id,
         input,
         debug: false, // TODO: Add debug option to CLI
     };

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_json.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_json.snap
@@ -68,20 +68,9 @@ exit_code: 0
         "description": "Input for the eval component",
         "type": "object",
         "properties": {
-          "workflow": {
-            "description": "The workflow to execute",
-            "$ref": "#/$defs/Flow"
-          },
-          "workflow_hash": {
-            "description": "Precomputed hash of the workflow.",
-            "anyOf": [
-              {
-                "$ref": "#/$defs/FlowHash"
-              },
-              {
-                "type": "null"
-              }
-            ]
+          "flow_id": {
+            "description": "The ID of the workflow to execute (blob ID)",
+            "$ref": "#/$defs/BlobId"
           },
           "input": {
             "description": "The input to pass to the workflow",
@@ -89,7 +78,7 @@ exit_code: 0
           }
         },
         "required": [
-          "workflow",
+          "flow_id",
           "input"
         ]
       },
@@ -419,10 +408,15 @@ exit_code: 0
         "properties": {
           "data": {
             "description": "The JSON data to store as a blob"
+          },
+          "blob_type": {
+            "description": "The type of blob to store",
+            "$ref": "#/$defs/BlobType"
           }
         },
         "required": [
-          "data"
+          "data",
+          "blob_type"
         ]
       },
       "output_schema": {

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_yaml.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_yaml.snap
@@ -50,19 +50,14 @@ components:
     description: Input for the eval component
     type: object
     properties:
-      workflow:
-        description: The workflow to execute
-        $ref: '#/$defs/Flow'
-      workflow_hash:
-        description: Precomputed hash of the workflow.
-        anyOf:
-        - $ref: '#/$defs/FlowHash'
-        - type: 'null'
+      flow_id:
+        description: The ID of the workflow to execute (blob ID)
+        $ref: '#/$defs/BlobId'
       input:
         description: The input to pass to the workflow
         $ref: '#/$defs/Value'
     required:
-    - workflow
+    - flow_id
     - input
   output_schema:
     description: |-
@@ -294,8 +289,12 @@ components:
     properties:
       data:
         description: The JSON data to store as a blob
+      blob_type:
+        description: The type of blob to store
+        $ref: '#/$defs/BlobType'
     required:
     - data
+    - blob_type
   output_schema:
     description: Output from the put_blob component
     type: object

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_with_schemas.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_with_schemas.snap
@@ -65,20 +65,9 @@ Component: /eval (plugin: builtin)
       "description": "Input for the eval component",
       "type": "object",
       "properties": {
-        "workflow": {
-          "description": "The workflow to execute",
-          "$ref": "#/$defs/Flow"
-        },
-        "workflow_hash": {
-          "description": "Precomputed hash of the workflow.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/FlowHash"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "flow_id": {
+          "description": "The ID of the workflow to execute (blob ID)",
+          "$ref": "#/$defs/BlobId"
         },
         "input": {
           "description": "The input to pass to the workflow",
@@ -86,7 +75,7 @@ Component: /eval (plugin: builtin)
         }
       },
       "required": [
-        "workflow",
+        "flow_id",
         "input"
       ]
     }
@@ -380,10 +369,15 @@ Component: /put_blob (plugin: builtin)
       "properties": {
         "data": {
           "description": "The JSON data to store as a blob"
+        },
+        "blob_type": {
+          "description": "The type of blob to store",
+          "$ref": "#/$defs/BlobType"
         }
       },
       "required": [
-        "data"
+        "data",
+        "blob_type"
       ]
     }
   Output Schema:

--- a/stepflow-rs/crates/stepflow-plugin/src/context.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/context.rs
@@ -14,9 +14,8 @@
 use futures::future::{BoxFuture, FutureExt as _};
 use std::path::Path;
 use std::sync::Arc;
-use stepflow_core::workflow::FlowHash;
 use stepflow_core::{
-    FlowResult,
+    BlobId, FlowResult,
     workflow::{Flow, ValueRef},
 };
 use stepflow_state::StateStore;
@@ -31,7 +30,7 @@ pub trait Context: Send + Sync {
     fn submit_flow(
         &self,
         flow: Arc<Flow>,
-        workflow_hash: FlowHash,
+        flow_id: BlobId,
         input: ValueRef,
     ) -> BoxFuture<'_, crate::Result<Uuid>>;
 
@@ -42,12 +41,53 @@ pub trait Context: Send + Sync {
     fn execute_flow(
         &self,
         flow: Arc<Flow>,
-        workflow_hash: FlowHash,
+        flow_id: BlobId,
         input: ValueRef,
     ) -> BoxFuture<'_, crate::Result<FlowResult>> {
         async move {
-            let run_id = self.submit_flow(flow, workflow_hash, input).await?;
+            let run_id = self.submit_flow(flow, flow_id, input).await?;
             self.flow_result(run_id).await
+        }
+        .boxed()
+    }
+
+    /// Executes a flow by blob ID - combines blob retrieval, deserialization, and execution.
+    ///
+    /// This is a convenience method that handles the common pattern of:
+    /// 1. Retrieving a flow blob by ID from the state store
+    /// 2. Deserializing the flow from blob data  
+    /// 3. Executing the flow with given input
+    ///
+    /// # Arguments
+    /// * `flow_id` - The blob ID of the flow to execute
+    /// * `input` - The input data for the flow
+    ///
+    /// # Returns
+    /// The result of the flow execution
+    fn execute_flow_by_id(
+        &self,
+        flow_id: &BlobId,
+        input: ValueRef,
+    ) -> BoxFuture<'_, crate::Result<FlowResult>> {
+        let flow_id = flow_id.clone();
+        async move {
+            use error_stack::ResultExt as _;
+
+            // Retrieve the flow from the blob store
+            let blob_data = self
+                .state_store()
+                .get_blob(&flow_id)
+                .await
+                .change_context(crate::PluginError::Execution)?;
+
+            // Deserialize the flow from blob data
+            let flow = blob_data
+                .as_flow()
+                .ok_or_else(|| error_stack::report!(crate::PluginError::Execution))?
+                .clone();
+
+            // Execute the flow
+            self.execute_flow(flow, flow_id, input).await
         }
         .boxed()
     }
@@ -92,10 +132,10 @@ impl Context for ExecutionContext {
     fn submit_flow(
         &self,
         flow: Arc<Flow>,
-        workflow_hash: FlowHash,
+        flow_id: BlobId,
         input: ValueRef,
     ) -> BoxFuture<'_, crate::Result<Uuid>> {
-        self.context.submit_flow(flow, workflow_hash, input)
+        self.context.submit_flow(flow, flow_id, input)
     }
 
     /// Get the result of a workflow execution.
@@ -107,10 +147,10 @@ impl Context for ExecutionContext {
     fn execute_flow(
         &self,
         flow: Arc<Flow>,
-        workflow_hash: FlowHash,
+        flow_id: BlobId,
         input: ValueRef,
     ) -> BoxFuture<'_, crate::Result<FlowResult>> {
-        self.context.execute_flow(flow, workflow_hash, input)
+        self.context.execute_flow(flow, flow_id, input)
     }
 
     fn working_directory(&self) -> &Path {

--- a/stepflow-rs/crates/stepflow-protocol/src/handlers/blob_handlers.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/handlers/blob_handlers.rs
@@ -102,7 +102,7 @@ impl MethodHandler for PutBlobHandler {
             |request: crate::protocol::PutBlobParams| async move {
                 let blob_id = context
                     .state_store()
-                    .put_blob(request.data)
+                    .put_blob(request.data, request.blob_type)
                     .await
                     .map_err(|e| {
                         tracing::error!("Failed to put blob: {e}");
@@ -129,7 +129,7 @@ impl MethodHandler for GetBlobHandler {
             request,
             response_tx,
             |request: crate::protocol::GetBlobParams| async move {
-                let data = context
+                let blob_data = context
                     .state_store()
                     .get_blob(&request.blob_id)
                     .await
@@ -137,7 +137,10 @@ impl MethodHandler for GetBlobHandler {
                         tracing::error!("Failed to get blob: {e}");
                         Error::internal("Failed to get blob")
                     })?;
-                Ok(crate::protocol::GetBlobResult { data })
+                Ok(crate::protocol::GetBlobResult {
+                    data: blob_data.data(),
+                    blob_type: blob_data.blob_type(),
+                })
             },
         )
         .boxed()

--- a/stepflow-rs/crates/stepflow-protocol/src/handlers/flow_handlers.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/handlers/flow_handlers.rs
@@ -13,7 +13,6 @@
 
 use futures::future::{BoxFuture, FutureExt as _};
 use std::sync::Arc;
-use stepflow_core::workflow::Flow;
 use stepflow_plugin::Context;
 use tokio::sync::mpsc;
 
@@ -36,11 +35,9 @@ impl MethodHandler for EvaluateFlowHandler {
             request,
             response_tx,
             |request: crate::protocol::EvaluateFlowParams| async move {
-                let flow = Arc::new(request.flow);
-                let workflow_hash = Flow::hash(&flow);
-
+                // Execute the flow using the shared utility
                 let result = context
-                    .execute_flow(flow, workflow_hash, request.input)
+                    .execute_flow_by_id(&request.flow_id, request.input)
                     .await
                     .map_err(|e| {
                         tracing::error!("Failed to evaluate flow: {e}");

--- a/stepflow-rs/crates/stepflow-protocol/src/http/client.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/http/client.rs
@@ -440,8 +440,8 @@ mod tests {
     use std::path::Path;
     use std::sync::Arc;
     use stepflow_core::{
-        FlowResult,
-        workflow::{Flow, FlowHash, ValueRef},
+        BlobId, FlowResult,
+        workflow::{Flow, ValueRef},
     };
     use stepflow_plugin::{Context, Result as PluginResult};
     use stepflow_state::{InMemoryStateStore, StateStore};
@@ -464,7 +464,7 @@ mod tests {
         fn submit_flow(
             &self,
             _flow: Arc<Flow>,
-            _workflow_hash: FlowHash,
+            _flow_id: BlobId,
             _input: ValueRef,
         ) -> BoxFuture<'_, PluginResult<Uuid>> {
             async { Ok(Uuid::new_v4()) }.boxed()

--- a/stepflow-rs/crates/stepflow-protocol/src/protocol/blobs.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/protocol/blobs.rs
@@ -13,8 +13,8 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use stepflow_core::blob::BlobId;
 use stepflow_core::workflow::ValueRef;
+use stepflow_core::{BlobId, BlobType};
 
 use crate::protocol::Method;
 
@@ -27,10 +27,11 @@ pub struct GetBlobParams {
     pub blob_id: BlobId,
 }
 
-/// Sent from the StepFlow back to the component server with the content of the requested blob.
+/// Sent from the StepFlow back to the component server with the blob data and metadata.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct GetBlobResult {
     pub data: ValueRef,
+    pub blob_type: BlobType,
 }
 
 impl ProtocolMethod for GetBlobParams {
@@ -42,6 +43,7 @@ impl ProtocolMethod for GetBlobParams {
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct PutBlobParams {
     pub data: ValueRef,
+    pub blob_type: BlobType,
 }
 
 /// Sent from the StepFlow back to the component server with the ID of the stored blob.

--- a/stepflow-rs/crates/stepflow-protocol/src/protocol/flows.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/protocol/flows.rs
@@ -13,8 +13,8 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use stepflow_core::FlowResult;
-use stepflow_core::workflow::{Flow, ValueRef};
+use stepflow_core::workflow::ValueRef;
+use stepflow_core::{BlobId, FlowResult};
 
 use crate::protocol::Method;
 
@@ -23,8 +23,8 @@ use super::ProtocolMethod;
 /// Sent from the component server to the StepFlow to evaluate a flow with the provided input.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct EvaluateFlowParams {
-    /// The flow to evaluate.
-    pub flow: Flow,
+    /// The ID of the flow to evaluate (blob ID of the flow).
+    pub flow_id: BlobId,
     /// The input to provide to the flow.
     pub input: ValueRef,
 }

--- a/stepflow-rs/crates/stepflow-protocol/tests/http_integration_test.rs
+++ b/stepflow-rs/crates/stepflow-protocol/tests/http_integration_test.rs
@@ -21,7 +21,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use stepflow_core::FlowResult;
-use stepflow_core::workflow::{Flow, FlowHash, ValueRef};
+use stepflow_core::{
+    BlobId,
+    workflow::{Flow, ValueRef},
+};
 use stepflow_plugin::{Context, ExecutionContext, Plugin as _, PluginConfig as _, PluginError};
 use stepflow_protocol::{StepflowPluginConfig, StepflowTransport};
 use stepflow_state::{InMemoryStateStore, StateStore};
@@ -54,7 +57,7 @@ impl Context for MockContext {
     fn submit_flow(
         &self,
         _flow: Arc<Flow>,
-        _flow_hash: FlowHash,
+        _flow_id: BlobId,
         _input: ValueRef,
     ) -> Pin<Box<dyn Future<Output = Result<Uuid, error_stack::Report<PluginError>>> + Send>> {
         Box::pin(async { Err(PluginError::Execution.into()) })

--- a/stepflow-rs/crates/stepflow-server/src/api.rs
+++ b/stepflow-rs/crates/stepflow-server/src/api.rs
@@ -36,7 +36,7 @@ pub use runs::{CreateRunRequest, CreateRunResponse};
 #[openapi(
     info(
         title = "StepFlow API",
-        description = "API for StepFlow workflows and executions",
+        description = "API for StepFlow flows and runs",
         version = env!("CARGO_PKG_VERSION")
     ),
     tags(

--- a/stepflow-rs/crates/stepflow-server/src/error.rs
+++ b/stepflow-rs/crates/stepflow-server/src/error.rs
@@ -13,8 +13,8 @@
 
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use stepflow_core::BlobId;
 use stepflow_core::status::ExecutionStatus;
-use stepflow_core::workflow::FlowHash;
 use uuid::Uuid;
 
 /// Error response structure.
@@ -36,7 +36,7 @@ pub enum ServerError {
     #[error("Execution '{0}' not found")]
     ExecutionNotFound(Uuid),
     #[error("Workflow '{0}' not found")]
-    WorkflowNotFound(FlowHash),
+    WorkflowNotFound(BlobId),
     #[error("Run '{run_id}' cannot be cancelled (status: {status:?})")]
     ExecutionNotCancellable {
         run_id: Uuid,

--- a/stepflow-rs/crates/stepflow-server/tests/integration_tests.rs
+++ b/stepflow-rs/crates/stepflow-server/tests/integration_tests.rs
@@ -242,12 +242,12 @@ async fn test_flow_crud_operations() {
         .unwrap();
     let store_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-    let flow_hash = store_response["flowHash"].as_str().unwrap();
-    assert!(!flow_hash.is_empty());
+    let flow_id = store_response["flowId"].as_str().unwrap();
+    assert!(!flow_id.is_empty());
 
     // Get flow
     let get_request = Request::builder()
-        .uri(format!("/api/v1/flows/{flow_hash}"))
+        .uri(format!("/api/v1/flows/{flow_id}"))
         .body(Body::empty())
         .unwrap();
 
@@ -259,12 +259,12 @@ async fn test_flow_crud_operations() {
         .unwrap();
     let get_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-    assert_eq!(get_response["flowHash"], flow_hash);
+    assert_eq!(get_response["flowId"], flow_id);
     assert_eq!(get_response["flow"]["name"], "test_workflow");
 
     // Check that analysis is included in the get_flow response
     assert!(get_response["analysis"].is_object());
-    assert_eq!(get_response["analysis"]["flowHash"], flow_hash);
+    assert_eq!(get_response["analysis"]["flowId"], flow_id);
     assert!(get_response["analysis"]["steps"].is_object());
 }
 
@@ -295,7 +295,7 @@ async fn test_hash_based_execution() {
         .await
         .unwrap();
     let store_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    let flow_hash = store_response["flowHash"].as_str().unwrap();
+    let flow_id = store_response["flowId"].as_str().unwrap();
 
     // Execute flow using hash (non-debug mode)
     let execute_request = Request::builder()
@@ -304,7 +304,7 @@ async fn test_hash_based_execution() {
         .header("content-type", "application/json")
         .body(Body::from(
             serde_json::to_string(&json!({
-                "flowHash": flow_hash,
+                "flowId": flow_id,
                 "input": {"message": "test input"},
                 "debug": false
             }))
@@ -353,7 +353,7 @@ async fn test_run_details() {
         .await
         .unwrap();
     let store_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    let flow_hash = store_response["flowHash"].as_str().unwrap();
+    let flow_id = store_response["flowId"].as_str().unwrap();
 
     let execute_request = Request::builder()
         .uri("/api/v1/runs")
@@ -361,7 +361,7 @@ async fn test_run_details() {
         .header("content-type", "application/json")
         .body(Body::from(
             serde_json::to_string(&json!({
-                "flowHash": flow_hash,
+                "flowId": flow_id,
                 "input": {"message": "test input"},
                 "debug": false
             }))
@@ -391,7 +391,7 @@ async fn test_run_details() {
     let details_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(details_response["runId"], run_id);
-    assert_eq!(details_response["flowHash"], flow_hash);
+    assert_eq!(details_response["flowId"], flow_id);
     assert_eq!(details_response["status"], "completed");
     assert!(details_response["input"].is_object());
 
@@ -409,7 +409,7 @@ async fn test_run_details() {
         .unwrap();
     let flow_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-    assert_eq!(flow_response["flowHash"], flow_hash);
+    assert_eq!(flow_response["flowId"], flow_id);
     assert_eq!(flow_response["flow"]["name"], "test_workflow");
 
     // Get run steps
@@ -608,7 +608,7 @@ async fn test_status_updates_during_regular_execution() {
         .await
         .unwrap();
     let store_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    let flow_hash = store_response["flowHash"].as_str().unwrap();
+    let flow_id = store_response["flowId"].as_str().unwrap();
 
     // Execute workflow in regular mode
     let execute_request = Request::builder()
@@ -617,7 +617,7 @@ async fn test_status_updates_during_regular_execution() {
         .header("content-type", "application/json")
         .body(Body::from(
             serde_json::to_string(&json!({
-                "flowHash": flow_hash,
+                "flowId": flow_id,
                 "input": {},
                 "debug": false
             }))
@@ -730,7 +730,7 @@ async fn test_status_updates_during_debug_execution() {
         .await
         .unwrap();
     let store_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    let flow_hash = store_response["flowHash"].as_str().unwrap();
+    let flow_id = store_response["flowId"].as_str().unwrap();
 
     // Execute workflow in debug mode
     let execute_request = Request::builder()
@@ -739,7 +739,7 @@ async fn test_status_updates_during_debug_execution() {
         .header("content-type", "application/json")
         .body(Body::from(
             serde_json::to_string(&json!({
-                "flowHash": flow_hash,
+                "flowId": flow_id,
                 "input": {},
                 "debug": true
             }))
@@ -851,7 +851,7 @@ async fn test_status_transitions_with_error_handling() {
         .await
         .unwrap();
     let store_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    let flow_hash = store_response["flowHash"].as_str().unwrap();
+    let flow_id = store_response["flowId"].as_str().unwrap();
 
     // Execute workflow (should fail)
     let execute_request = Request::builder()
@@ -860,7 +860,7 @@ async fn test_status_transitions_with_error_handling() {
         .header("content-type", "application/json")
         .body(Body::from(
             serde_json::to_string(&json!({
-                "flowHash": flow_hash,
+                "flowId": flow_id,
                 "input": {},
                 "debug": false
             }))

--- a/stepflow-rs/crates/stepflow-state/src/error.rs
+++ b/stepflow-rs/crates/stepflow-state/src/error.rs
@@ -33,9 +33,6 @@ pub enum StateError {
     #[error("Step result not found for run {run_id}, step id '{step_id}'")]
     StepResultNotFoundById { run_id: Uuid, step_id: String },
 
-    #[error("Workflow not found: {workflow_hash}")]
-    WorkflowNotFound { workflow_hash: String },
-
     #[error("Run not found: {run_id}")]
     RunNotFound { run_id: Uuid },
 

--- a/tests/builtins/blob_test.yaml
+++ b/tests/builtins/blob_test.yaml
@@ -21,6 +21,7 @@ steps:
       $from:
         workflow: input
       path: data
+    blob_type: "data"
 - id: get_blob
   component: /builtin/get_blob
   input_schema: null

--- a/tests/builtins/nested_eval.yaml
+++ b/tests/builtins/nested_eval.yaml
@@ -2,12 +2,10 @@ schema: https://stepflow.org/schemas/v1/flow.json
 name: nested_eval_test
 description: Test nested flow execution with eval component
 steps:
-- id: nested_flow
-  component: /builtin/eval
-  inputSchema: null
-  outputSchema: null
+- id: create_nested_flow
+  component: /builtin/put_blob
   input:
-    workflow:
+    data:
       $literal:
         schema: https://stepflow.org/schemas/v1/flow.json
         name: simple_nested
@@ -20,6 +18,14 @@ steps:
           result:
             $from:
               step: inner_step
+    blob_type: "flow"
+
+- id: nested_flow
+  component: /builtin/eval
+  inputSchema: null
+  outputSchema: null
+  input:
+    flow_id: { $from: { step: create_nested_flow }, path: "blob_id" }
     input: {}
 output:
   nested_result:

--- a/tests/python/blob_integration.yaml
+++ b/tests/python/blob_integration.yaml
@@ -21,6 +21,7 @@ steps:
     component: /builtin/put_blob
     input:
       data: { $from: { workflow: input }, path: user_data }
+      blob_type: "data"
 
   # Step 2: Create blob for Python function definition
   - id: create_process_data_blob
@@ -59,6 +60,7 @@ steps:
                   'summary': f'Processed {len(original_data)} fields'
               }
         function_name: process_data
+      blob_type: "data"
 
   # Step 3: Python UDF retrieves blob and processes it
   - id: process_blob_data

--- a/tests/python/blob_simple.yaml
+++ b/tests/python/blob_simple.yaml
@@ -31,6 +31,7 @@ steps:
           workflow: input
         path: number
       timestamp: 2024-01-01T00:00:00Z
+    blob_type: "data"
 # Create blob for Python function definition
 - id: create_store_data_blob
   component: /builtin/put_blob
@@ -60,6 +61,7 @@ steps:
           blob_id = await context.put_blob(enhanced_data)
           return {'blob_id': blob_id, 'status': 'success'}
       function_name: store_data
+    blob_type: "data"
 - id: store_with_python
   component: /python/udf
   input_schema: null

--- a/tests/python/udf_function.yaml
+++ b/tests/python/udf_function.yaml
@@ -39,6 +39,7 @@ steps:
         - data
       code: "def analyze_scores(input):\n    scores = [item['score'] for item in input['data']]\n    \n    if not scores:\n        return {\n            'count': 0,\n            'average': 0,\n            'min': 0,\n            'max': 0,\n            'top_performer': None\n        }\n    \n    average = sum(scores) / len(scores)\n    min_score = min(scores)\n    max_score = max(scores)\n    \n    # Find top performer\n    top_performer = None\n    for item in input['data']:\n        if item['score'] == max_score:\n            top_performer = item['name']\n            break\n    \n    return {\n        'count': len(scores),\n        'average': round(average, 2),\n        'min': min_score,\n        'max': max_score,\n        'top_performer': top_performer\n    }\n"
       function_name: analyze_scores
+    blob_type: "data"
 - id: analyze_scores
   component: /python/udf
   input_schema: null

--- a/tests/python/udf_simple.yaml
+++ b/tests/python/udf_simple.yaml
@@ -34,6 +34,7 @@ steps:
         - x
         - y
       code: input['x'] + input['y']
+    blob_type: "data"
 - id: create_multiplication_blob
   component: /builtin/put_blob
   input_schema: null
@@ -51,6 +52,7 @@ steps:
         - x
         - y
       code: input['x'] * input['y']
+    blob_type: "data"
 - id: create_complex_calculation_blob
   component: /builtin/put_blob
   input_schema: null
@@ -68,6 +70,7 @@ steps:
         - sum
         - product
       code: math.sqrt(input['sum'] ** 2 + input['product'] ** 2)
+    blob_type: "data"
 # Execute functions using blob_ids
 - id: simple_addition
   component: /python/udf

--- a/tests/python/udf_text_processing.yaml
+++ b/tests/python/udf_text_processing.yaml
@@ -57,6 +57,7 @@ steps:
             'word_length_distribution': word_lengths,
             'most_common_words': [{'word': word, 'count': count} for word, count in most_common]
         }
+    blob_type: "data"
 - id: create_pattern_search_blob
   component: /builtin/put_blob
   input_schema: null
@@ -82,6 +83,7 @@ steps:
             return [{'match': match, 'index': i} for i, match in enumerate(matches)]
         except:
             return []
+    blob_type: "data"
 - id: create_sentiment_analysis_blob
   component: /builtin/put_blob
   input_schema: null
@@ -113,6 +115,7 @@ steps:
         # Return score between -1 (very negative) and 1 (very positive)
         sentiment_score = (positive_count - negative_count) / total_sentiment_words
         return round(sentiment_score, 2)
+    blob_type: "data"
 # Execute functions using blob_ids
 - id: word_analysis
   component: /python/udf


### PR DESCRIPTION
This introduces a "blob type" which allows blobs to record whether they
store data, flows, etc.

This replaces the separate flow storage with the typed blob storage.

This changes to pass the flow ID rather than the flow itself when
evaluating a flow. This reduces the need to copy the flow (eg., when
executing it for each item of a list, it only needs to be sent once to
get the blob ID).

This also changes some code to standardize towards the term "flow"
rather than "workflow".

This also introduces a `execute_flow_by_id` method which allows
executing a flow by its ID, rather than needing to fetch the flow first.
This allows sharing logic between the `eval` builtin and the `execute`
method.