### PR TITLE
Update the docs for the OpenAI example with the right running script

### DIFF
--- a/examples/openai/README.md
+++ b/examples/openai/README.md
@@ -20,7 +20,7 @@ export OPENAI_API_KEY=your_api_key_here
 From the repository root, run:
 
 ```bash
-cargo run -- run --flow=examples/openai/openai_chat.yaml --input=examples/openai/input.json --config=examples/openai/stepflow-config.yml
+cargo run --manifest-path stepflow-rs/Cargo.toml -- run --flow=examples/openai/openai_chat.yaml --input=examples/openai/input.json --config=examples/openai/stepflow-config.yml
 ```
 
 ## Example Flow


### PR DESCRIPTION
The previous instructions to run the OpenAI sample were resulting in the error

```
error: could not find `Cargo.toml` in `stepflow-main` or any parent directory
```

To resolve this, we can provide the path to Cargo.toml which is in the `stepflow-rs` directory.