### PR TITLE
refactor: Introduce Step/Flow builders

### DIFF
--- a/stepflow-rs/crates/stepflow-analysis/src/dependency.rs
+++ b/stepflow-rs/crates/stepflow-analysis/src/dependency.rs
@@ -195,55 +195,26 @@ mod tests {
     use super::*;
     use crate::dependencies::ValueDependencies;
     use serde_json::json;
-    use stepflow_core::workflow::{Component, ErrorAction, Flow, FlowV1, JsonPath, Step};
+    use stepflow_core::workflow::{Component, ErrorAction, Flow, FlowV1, JsonPath, Step, FlowBuilder, StepBuilder};
 
     fn create_test_step(id: &str, input: serde_json::Value) -> Step {
-        Step {
-            id: id.to_string(),
-            component: Component::from_string("/mock/test"),
-            input: ValueTemplate::parse_value(input).unwrap(),
-            input_schema: None,
-            output_schema: None,
-            skip_if: None,
-            on_error: ErrorAction::Fail,
-            metadata: std::collections::HashMap::new(),
-        }
+        StepBuilder::mock_step(id)
+            .input_json(input)
+            .build()
     }
 
     fn create_test_flow() -> Flow {
-        Flow::V1(FlowV1 {
-            name: Some("test_workflow".to_string()),
-            description: None,
-            version: None,
-            input_schema: None,
-            output_schema: None,
-            steps: vec![
-                Step {
-                    id: "step1".to_string(),
-                    component: Component::from_string("/mock/test"),
-                    input: ValueTemplate::workflow_input(JsonPath::default()),
-                    input_schema: None,
-                    output_schema: None,
-                    skip_if: None,
-                    on_error: ErrorAction::Fail,
-                    metadata: std::collections::HashMap::new(),
-                },
-                Step {
-                    id: "step2".to_string(),
-                    component: Component::from_string("/mock/test"),
-                    input: ValueTemplate::step_ref("step1", JsonPath::default()),
-                    input_schema: None,
-                    output_schema: None,
-                    skip_if: None,
-                    on_error: ErrorAction::Fail,
-                    metadata: std::collections::HashMap::new(),
-                },
-            ],
-            output: ValueTemplate::step_ref("step2", JsonPath::default()),
-            test: None,
-            examples: None,
-            metadata: std::collections::HashMap::new(),
-        })
+        FlowBuilder::test_flow()
+            .steps(vec![
+                StepBuilder::mock_step("step1")
+                    .input(ValueTemplate::workflow_input(JsonPath::default()))
+                    .build(),
+                StepBuilder::mock_step("step2")
+                    .input(ValueTemplate::step_ref("step1", JsonPath::default()))
+                    .build(),
+            ])
+            .output(ValueTemplate::step_ref("step2", JsonPath::default()))
+            .build()
     }
 
     #[test]
@@ -428,21 +399,14 @@ mod tests {
 
     #[test]
     fn test_new_validation_api_invalid_workflow() {
-        let flow = Flow::V1(FlowV1 {
-            name: Some("invalid_workflow".to_string()),
-            description: None,
-            version: None,
-            input_schema: None,
-            output_schema: None,
-            steps: vec![
+        let flow = FlowBuilder::new()
+            .name("invalid_workflow")
+            .steps(vec![
                 create_test_step("step1", json!({"$from": {"step": "step2"}})), // Forward reference
                 create_test_step("step1", json!({"$from": {"workflow": "input"}})), // Duplicate ID
-            ],
-            output: ValueTemplate::step_ref("step1", JsonPath::default()),
-            test: None,
-            examples: None,
-            metadata: std::collections::HashMap::new(),
-        });
+            ])
+            .output(ValueTemplate::step_ref("step1", JsonPath::default()))
+            .build();
 
         let result = analyze_flow_dependencies(
             Arc::new(flow),

--- a/stepflow-rs/crates/stepflow-builtins/src/map.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/map.rs
@@ -139,21 +139,19 @@ mod tests {
     use super::*;
     use crate::mock_context::MockContext;
     use stepflow_core::values::ValueTemplate;
-    use stepflow_core::workflow::FlowV1;
+    use stepflow_core::workflow::FlowBuilder;
 
     #[tokio::test]
     async fn test_map_component_success() {
         let component = MapComponent::new();
 
         // Create a workflow that doubles the input value
-        let test_flow = Flow::V1(FlowV1 {
-            name: Some("test-double".to_string()),
-            steps: vec![],
-            output: ValueTemplate::literal(serde_json::json!({
+        let test_flow = FlowBuilder::new()
+            .name("test-double")
+            .output(ValueTemplate::literal(serde_json::json!({
                 "doubled": 42
-            })),
-            ..Default::default()
-        });
+            })))
+            .build();
 
         let input = MapInput {
             workflow: test_flow,
@@ -188,12 +186,10 @@ mod tests {
     async fn test_map_component_empty_list() {
         let component = MapComponent::new();
 
-        let test_flow = Flow::V1(FlowV1 {
-            name: Some("test-empty".to_string()),
-            steps: vec![],
-            output: ValueTemplate::literal(serde_json::json!({"result": "processed"})),
-            ..Default::default()
-        });
+        let test_flow = FlowBuilder::new()
+            .name("test-empty")
+            .output(ValueTemplate::literal(serde_json::json!({"result": "processed"})))
+            .build();
 
         let input = MapInput {
             workflow: test_flow,

--- a/stepflow-rs/crates/stepflow-core/src/values/value_resolver.rs
+++ b/stepflow-rs/crates/stepflow-core/src/values/value_resolver.rs
@@ -269,7 +269,7 @@ impl<L: ValueLoader> ValueResolver<L> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::workflow::{Component, ErrorAction, FlowV1, JsonPath, Step};
+    use crate::workflow::JsonPath;
     use async_trait::async_trait;
     use serde_json::json;
 
@@ -317,27 +317,14 @@ mod tests {
     }
 
     fn create_test_flow() -> Arc<Flow> {
-        Arc::new(Flow::V1(FlowV1 {
-            name: None,
-            description: None,
-            version: None,
-            input_schema: None,
-            output_schema: None,
-            steps: vec![Step {
-                id: "step1".to_string(),
-                component: Component::from_string("/mock/test"),
-                input: ValueTemplate::literal(json!({})),
-                input_schema: None,
-                output_schema: None,
-                skip_if: None,
-                on_error: ErrorAction::Fail,
-                metadata: HashMap::default(),
-            }],
-            output: ValueTemplate::literal(json!(null)),
-            test: None,
-            examples: None,
-            metadata: HashMap::default(),
-        }))
+        use crate::workflow::{FlowBuilder, StepBuilder};
+        
+        Arc::new(FlowBuilder::new()
+            .step(StepBuilder::mock_step("step1")
+                .input_literal(json!({}))
+                .build())
+            .output(ValueTemplate::literal(json!(null)))
+            .build())
     }
 
     #[tokio::test]

--- a/stepflow-rs/crates/stepflow-core/src/workflow.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow.rs
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
+mod builders;
 mod component;
 mod expr;
 mod flow;
@@ -17,6 +18,7 @@ mod json_path;
 mod step;
 mod step_id;
 
+pub use builders::*;
 pub use component::*;
 pub use expr::*;
 pub use flow::*;

--- a/stepflow-rs/crates/stepflow-core/src/workflow/builders.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow/builders.rs
@@ -1,0 +1,375 @@
+// Copyright 2025 DataStax Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+use std::collections::HashMap;
+
+use super::{Component, ErrorAction, Expr, ExampleInput, Flow, FlowV1, Step, TestConfig, ValueTemplate};
+use crate::schema::SchemaRef;
+use serde_json::json;
+
+/// Builder for creating Flow instances with reduced boilerplate.
+#[derive(Default)]
+pub struct FlowBuilder {
+    name: Option<String>,
+    description: Option<String>,
+    version: Option<String>,
+    input_schema: Option<SchemaRef>,
+    output_schema: Option<SchemaRef>,
+    steps: Vec<Step>,
+    output: Option<ValueTemplate>,
+    test: Option<TestConfig>,
+    examples: Option<Vec<ExampleInput>>,
+    metadata: HashMap<String, serde_json::Value>,
+}
+
+impl FlowBuilder {
+    /// Create a new FlowBuilder with default values.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Set the flow name.
+    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Set the flow description.
+    pub fn description<S: Into<String>>(mut self, desc: S) -> Self {
+        self.description = Some(desc.into());
+        self
+    }
+
+    /// Set the flow version.
+    pub fn version<S: Into<String>>(mut self, version: S) -> Self {
+        self.version = Some(version.into());
+        self
+    }
+
+    /// Set the input schema.
+    pub fn input_schema(mut self, schema: SchemaRef) -> Self {
+        self.input_schema = Some(schema);
+        self
+    }
+
+    /// Set the output schema.
+    pub fn output_schema(mut self, schema: SchemaRef) -> Self {
+        self.output_schema = Some(schema);
+        self
+    }
+
+    /// Add a single step to the flow.
+    pub fn step(mut self, step: Step) -> Self {
+        self.steps.push(step);
+        self
+    }
+
+    /// Add multiple steps to the flow.
+    pub fn steps<I: IntoIterator<Item = Step>>(mut self, steps: I) -> Self {
+        self.steps.extend(steps);
+        self
+    }
+
+    /// Set the flow output.
+    pub fn output(mut self, output: ValueTemplate) -> Self {
+        self.output = Some(output);
+        self
+    }
+
+    /// Set the test configuration.
+    pub fn test_config(mut self, test: TestConfig) -> Self {
+        self.test = Some(test);
+        self
+    }
+
+    /// Set the examples.
+    pub fn examples(mut self, examples: Vec<ExampleInput>) -> Self {
+        self.examples = Some(examples);
+        self
+    }
+
+    /// Add metadata.
+    pub fn metadata<S: Into<String>>(mut self, key: S, value: serde_json::Value) -> Self {
+        self.metadata.insert(key.into(), value);
+        self
+    }
+
+    /// Create a builder for a test flow with a default name.
+    pub fn test_flow() -> Self {
+        Self::new().name("test_workflow")
+    }
+
+    /// Create a builder for a mock flow with common test defaults.
+    pub fn mock_flow() -> Self {
+        Self::new()
+            .name("mock_flow")
+            .description("A test flow for mocking")
+    }
+
+    /// Build the final Flow instance.
+    pub fn build(self) -> Flow {
+        Flow::V1(FlowV1 {
+            name: self.name,
+            description: self.description,
+            version: self.version,
+            input_schema: self.input_schema,
+            output_schema: self.output_schema,
+            steps: self.steps,
+            output: self.output.unwrap_or_default(),
+            test: self.test,
+            examples: self.examples,
+            metadata: self.metadata,
+        })
+    }
+}
+
+/// Builder for creating Step instances with reduced boilerplate.
+pub struct StepBuilder {
+    id: Option<String>,
+    component: Option<Component>,
+    input: Option<ValueTemplate>,
+    input_schema: Option<SchemaRef>,
+    output_schema: Option<SchemaRef>,
+    skip_if: Option<Expr>,
+    on_error: ErrorAction,
+    metadata: HashMap<String, serde_json::Value>,
+}
+
+impl StepBuilder {
+    /// Create a new StepBuilder with the given step ID.
+    pub fn new<S: Into<String>>(id: S) -> Self {
+        Self {
+            id: Some(id.into()),
+            component: None,
+            input: None,
+            input_schema: None,
+            output_schema: None,
+            skip_if: None,
+            on_error: ErrorAction::default(),
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Set the component for this step.
+    pub fn component<S: Into<String>>(mut self, component: S) -> Self {
+        self.component = Some(Component::from_string(component.into()));
+        self
+    }
+
+    /// Set the input template for this step.
+    pub fn input(mut self, input: ValueTemplate) -> Self {
+        self.input = Some(input);
+        self
+    }
+
+    /// Set the input from a JSON value, parsing it as a ValueTemplate.
+    pub fn input_json(mut self, input: serde_json::Value) -> Self {
+        self.input = Some(ValueTemplate::parse_value(input).unwrap());
+        self
+    }
+
+    /// Set the input as a literal JSON value.
+    pub fn input_literal(mut self, input: serde_json::Value) -> Self {
+        self.input = Some(ValueTemplate::literal(input));
+        self
+    }
+
+    /// Set the input schema.
+    pub fn input_schema(mut self, schema: SchemaRef) -> Self {
+        self.input_schema = Some(schema);
+        self
+    }
+
+    /// Set the output schema.
+    pub fn output_schema(mut self, schema: SchemaRef) -> Self {
+        self.output_schema = Some(schema);
+        self
+    }
+
+    /// Set the skip condition.
+    pub fn skip_if(mut self, condition: Expr) -> Self {
+        self.skip_if = Some(condition);
+        self
+    }
+
+    /// Set the error action.
+    pub fn on_error(mut self, action: ErrorAction) -> Self {
+        self.on_error = action;
+        self
+    }
+
+    /// Add metadata.
+    pub fn metadata<S: Into<String>>(mut self, key: S, value: serde_json::Value) -> Self {
+        self.metadata.insert(key.into(), value);
+        self
+    }
+
+    /// Create a mock step with a default mock component.
+    pub fn mock_step<S: Into<String>>(id: S) -> Self {
+        Self::new(id).component("/mock/test")
+    }
+
+    /// Create a builtin step with the specified builtin component.
+    pub fn builtin_step<S: Into<String>>(id: S, component: S) -> Self {
+        Self::new(id).component(format!("/builtin/{}", component.into()))
+    }
+
+    /// Create a step that references another step's output.
+    pub fn step_ref<S: Into<String>>(id: S, ref_step: S) -> Self {
+        Self::new(id)
+            .component("/mock/test")
+            .input_json(json!({"$from": {"step": ref_step.into()}}))
+    }
+
+    /// Create a step that references workflow input.
+    pub fn workflow_input<S: Into<String>>(id: S) -> Self {
+        Self::new(id)
+            .component("/mock/test")
+            .input_json(json!({"$from": {"workflow": "input"}}))
+    }
+
+    /// Build the final Step instance.
+    pub fn build(self) -> Step {
+        Step {
+            id: self.id.expect("Step ID is required"),
+            component: self.component.unwrap_or_else(|| Component::from_string("/mock/test")),
+            input: self.input.unwrap_or_else(ValueTemplate::null),
+            input_schema: self.input_schema,
+            output_schema: self.output_schema,
+            skip_if: self.skip_if,
+            on_error: self.on_error,
+            metadata: self.metadata,
+        }
+    }
+}
+
+impl Flow {
+    /// Create a new FlowBuilder.
+    pub fn builder() -> FlowBuilder {
+        FlowBuilder::new()
+    }
+}
+
+impl Step {
+    /// Create a new StepBuilder with the given ID.
+    pub fn builder<S: Into<String>>(id: S) -> StepBuilder {
+        StepBuilder::new(id)
+    }
+}
+
+/// Create a FlowBuilder for a mock flow with common test defaults.
+pub fn mock_flow() -> FlowBuilder {
+    FlowBuilder::mock_flow()
+}
+
+/// Create a FlowBuilder for a test flow with a default name.
+pub fn test_flow() -> FlowBuilder {
+    FlowBuilder::test_flow()
+}
+
+/// Create a StepBuilder for a mock step.
+pub fn mock_step<S: Into<String>>(id: S) -> StepBuilder {
+    StepBuilder::mock_step(id)
+}
+
+/// Create a StepBuilder for a builtin step.
+pub fn builtin_step<S: Into<String>>(id: S, component: S) -> StepBuilder {
+    StepBuilder::builtin_step(id, component)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow::JsonPath;
+
+    #[test]
+    fn test_flow_builder_basic() {
+        let flow = FlowBuilder::new()
+            .name("test")
+            .description("A test flow")
+            .build();
+
+        match flow {
+            Flow::V1(flow_v1) => {
+                assert_eq!(flow_v1.name, Some("test".to_string()));
+                assert_eq!(flow_v1.description, Some("A test flow".to_string()));
+                assert!(flow_v1.steps.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn test_flow_builder_with_steps() {
+        let step1 = StepBuilder::mock_step("step1")
+            .input_literal(json!({"value": 42}))
+            .build();
+
+        let step2 = StepBuilder::step_ref("step2", "step1").build();
+
+        let flow = FlowBuilder::test_flow()
+            .description("Test with steps")
+            .step(step1)
+            .step(step2)
+            .output(ValueTemplate::step_ref("step2", JsonPath::default()))
+            .build();
+
+        match flow {
+            Flow::V1(flow_v1) => {
+                assert_eq!(flow_v1.name, Some("test_workflow".to_string()));
+                assert_eq!(flow_v1.steps.len(), 2);
+                assert_eq!(flow_v1.steps[0].id, "step1");
+                assert_eq!(flow_v1.steps[1].id, "step2");
+            }
+        }
+    }
+
+    #[test]
+    fn test_step_builder_basic() {
+        let step = StepBuilder::new("test_step")
+            .component("/test/component")
+            .input_literal(json!({"key": "value"}))
+            .build();
+
+        assert_eq!(step.id, "test_step");
+        assert_eq!(step.component.path(), "/test/component");
+        assert_eq!(step.on_error, ErrorAction::Fail);
+    }
+
+    #[test]
+    fn test_step_builder_convenience_methods() {
+        let mock_step = StepBuilder::mock_step("mock1").build();
+        assert_eq!(mock_step.component.path(), "/mock/test");
+
+        let builtin_step = StepBuilder::builtin_step("builtin1", "openai").build();
+        assert_eq!(builtin_step.component.path(), "/builtin/openai");
+
+        let workflow_input_step = StepBuilder::workflow_input("input1").build();
+        assert_eq!(workflow_input_step.component.path(), "/mock/test");
+
+        let step_ref = StepBuilder::step_ref("ref1", "step1").build();
+        assert_eq!(step_ref.component.path(), "/mock/test");
+    }
+
+    #[test]
+    fn test_convenience_functions() {
+        let flow = mock_flow()
+            .step(mock_step("step1").build())
+            .build();
+
+        match flow {
+            Flow::V1(flow_v1) => {
+                assert_eq!(flow_v1.name, Some("mock_flow".to_string()));
+                assert_eq!(flow_v1.steps.len(), 1);
+            }
+        }
+    }
+}

--- a/stepflow-rs/crates/stepflow-core/src/workflow/step.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow/step.rs
@@ -86,8 +86,7 @@ impl Default for ErrorAction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::workflow::Component;
-    use crate::workflow::ValueRef;
+    use crate::workflow::{Component, ValueRef, StepBuilder};
 
     #[test]
     fn test_error_action_serialization() {
@@ -146,18 +145,13 @@ mod tests {
 
     #[test]
     fn test_step_serialization_with_error_action() {
-        let step = Step {
-            id: "test_step".to_string(),
-            component: Component::from_string("/mock/test_component"),
-            input_schema: None,
-            output_schema: None,
-            skip_if: None,
-            on_error: ErrorAction::UseDefault {
+        let step = StepBuilder::new("test_step")
+            .component("/mock/test_component")
+            .on_error(ErrorAction::UseDefault {
                 default_value: Some(ValueRef::from("fallback").into()),
-            },
-            input: ValueTemplate::null(),
-            metadata: HashMap::default(),
-        };
+            })
+            .input(ValueTemplate::null())
+            .build();
 
         let yaml = serde_yaml_ng::to_string(&step).unwrap();
         assert!(yaml.contains("onError:"));
@@ -167,16 +161,10 @@ mod tests {
 
     #[test]
     fn test_step_default_error_action_not_serialized() {
-        let step = Step {
-            id: "test_step".to_string(),
-            component: Component::from_string("/mock/test_component"),
-            input_schema: None,
-            output_schema: None,
-            skip_if: None,
-            on_error: ErrorAction::Fail,
-            input: ValueTemplate::null(),
-            metadata: HashMap::default(),
-        };
+        let step = StepBuilder::new("test_step")
+            .component("/mock/test_component")
+            .input(ValueTemplate::null())
+            .build();
 
         let yaml = serde_yaml_ng::to_string(&step).unwrap();
         assert!(!yaml.contains("on_error:"));

--- a/stepflow-rs/crates/stepflow-execution/src/workflow_executor.rs
+++ b/stepflow-rs/crates/stepflow-execution/src/workflow_executor.rs
@@ -1020,7 +1020,7 @@ mod tests {
     use super::*;
     use serde_json::json;
     use stepflow_core::FlowError;
-    use stepflow_core::workflow::{Component, ErrorAction, Flow, FlowV1, Step, StepId};
+    use stepflow_core::workflow::{Component, ErrorAction, Flow, FlowV1, Step, StepId, FlowBuilder, StepBuilder, ValueTemplate, JsonPath};
     use stepflow_mock::{MockComponentBehavior, MockPlugin};
     use stepflow_state::InMemoryStateStore;
 
@@ -1120,31 +1120,16 @@ mod tests {
     }
 
     fn create_test_step(id: &str, input: serde_json::Value) -> Step {
-        Step {
-            id: id.to_string(),
-            component: Component::from_string("/mock/test"),
-            input_schema: None,
-            output_schema: None,
-            skip_if: None,
-            on_error: ErrorAction::Fail,
-            input: ValueTemplate::parse_value(input).unwrap(),
-            metadata: std::collections::HashMap::new(),
-        }
+        StepBuilder::mock_step(id)
+            .input_json(input)
+            .build()
     }
 
     fn create_test_flow(steps: Vec<Step>, output: ValueTemplate) -> Flow {
-        Flow::V1(FlowV1 {
-            name: None,
-            description: None,
-            version: None,
-            input_schema: None,
-            output_schema: None,
-            steps,
-            output,
-            test: None,
-            examples: None,
-            metadata: std::collections::HashMap::new(),
-        })
+        FlowBuilder::new()
+            .steps(steps)
+            .output(output)
+            .build()
     }
 
     #[tokio::test]

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_visualize__visualize_help.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_visualize__visualize_help.snap
@@ -54,13 +54,13 @@ Options:
 
       --format <FORMAT>
           Output format for the visualization
-          
-          [default: svg]
 
           Possible values:
           - dot: DOT graph format
           - svg: SVG image format
           - png: PNG image format
+          
+          [default: svg]
 
       --log-file <FILE>
           Write logs to a file instead of stderr

--- a/stepflow-rs/crates/stepflow-state-sql/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-state-sql/src/lib.rs
@@ -25,7 +25,7 @@ mod tests {
     use super::*;
     use serde_json::json;
     use stepflow_core::values::ValueTemplate;
-    use stepflow_core::workflow::FlowV1;
+    use stepflow_core::workflow::{FlowV1, FlowBuilder, StepBuilder};
     use stepflow_core::{BlobType, FlowResult, workflow::ValueRef};
     use stepflow_state::{StateStore as _, StepResult};
     use uuid::Uuid;
@@ -56,27 +56,13 @@ mod tests {
         let run_id = Uuid::new_v4();
 
         // First store a workflow
-        let flow = stepflow_core::workflow::Flow::V1(FlowV1 {
-            name: None,
-            description: None,
-            input_schema: None,
-            output_schema: None,
-            output: ValueTemplate::empty_object(),
-            steps: vec![stepflow_core::workflow::Step {
-                id: "test_step".to_string(),
-                component: stepflow_core::workflow::Component::from_string("/test/mock"),
-                input: ValueTemplate::empty_object(),
-                input_schema: None,
-                output_schema: None,
-                skip_if: None,
-                on_error: stepflow_core::workflow::ErrorAction::Fail,
-                metadata: std::collections::HashMap::new(),
-            }],
-            version: None,
-            test: None,
-            examples: None,
-            metadata: std::collections::HashMap::new(),
-        });
+        let flow = FlowBuilder::new()
+            .output(ValueTemplate::empty_object())
+            .step(StepBuilder::new("test_step")
+                .component("/test/mock")
+                .input(ValueTemplate::empty_object())
+                .build())
+            .build();
         let flow_arc = std::sync::Arc::new(flow);
         let flow_data = ValueRef::new(serde_json::to_value(flow_arc.as_ref()).unwrap());
         let flow_id = store.put_blob(flow_data, BlobType::Flow).await.unwrap();


### PR DESCRIPTION
These make it easier to update these structs without polluting all the (often unrelated) tests.