### PR TITLE
refactor: Simplify environment handling

### DIFF
--- a/integrations/langflow/tests/helpers/fixture_preprocessing.py
+++ b/integrations/langflow/tests/helpers/fixture_preprocessing.py
@@ -1,0 +1,382 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Flow fixture preprocessing utilities.
+
+This module provides utilities for preprocessing Langflow JSON fixtures before
+conversion to Stepflow workflows. This replaces runtime environment variable
+resolution in the UDF executor with test-time preprocessing.
+
+Key benefits:
+- Separates test concerns from production component execution logic
+- Allows tests to override specific fixture fields without hardcoded fallbacks
+- Makes fixture parameterization explicit and controllable
+- Removes complex runtime environment variable resolution
+"""
+
+import json
+import os
+from typing import Any
+
+
+class FlowFixturePreprocessor:
+    """Preprocess Langflow fixtures with environment variable field overrides."""
+
+    def __init__(self, environment: dict[str, str] | None = None):
+        """Initialize preprocessor with optional environment override.
+
+        Args:
+            environment: Custom environment dict (defaults to os.environ)
+        """
+        self.environment = environment or dict(os.environ)
+
+    def preprocess_fixture(
+        self,
+        fixture_data: dict[str, Any],
+        field_overrides: dict[str, dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Preprocess a fixture with environment variable field overrides.
+
+        Args:
+            fixture_data: Original Langflow JSON fixture data
+            field_overrides: Dict mapping node_id -> {field_name: new_value}
+
+        Returns:
+            Preprocessed fixture data with substitutions applied
+        """
+        # Deep copy to avoid mutating original
+        processed = json.loads(json.dumps(fixture_data))
+        field_overrides = field_overrides or {}
+
+        # Process each node
+        for node in processed.get("data", {}).get("nodes", []):
+            node_id = node.get("id")
+            node_data = node.get("data", {})
+            template = node_data.get("node", {}).get("template", {})
+
+            # Apply field overrides first
+            if node_id in field_overrides:
+                for field_name, new_value in field_overrides[node_id].items():
+                    if field_name in template and isinstance(
+                        template[field_name], dict
+                    ):
+                        template[field_name]["value"] = new_value
+
+            # Apply environment variable substitution
+            for _field_name, field_config in template.items():
+                if isinstance(field_config, dict) and "value" in field_config:
+                    field_config["value"] = self._resolve_field_value(
+                        field_config["value"], field_config
+                    )
+
+        return processed
+
+    def _resolve_field_value(self, value: Any, field_config: dict[str, Any]) -> Any:
+        """Resolve a single field value with environment variable substitution.
+
+        Args:
+            value: Original field value
+            field_config: Field configuration with type info
+
+        Returns:
+            Resolved field value
+        """
+        if not isinstance(value, str):
+            return value
+
+        # Handle ${ENV_VAR} template format
+        if value.startswith("${") and value.endswith("}"):
+            env_var = value[2:-1]
+            return self.environment.get(env_var, value)  # Keep original if not found
+
+        # Handle direct environment variable names
+        if self._is_env_var_reference(value, field_config):
+            return self.environment.get(value, value)  # Keep original if not found
+
+        return value
+
+    def _is_env_var_reference(self, value: str, field_config: dict[str, Any]) -> bool:
+        """Check if a string value is an environment variable reference.
+
+        Args:
+            value: String value to check
+            field_config: Field configuration
+
+        Returns:
+            True if this appears to be an env var reference
+        """
+        # Common API key patterns
+        if value in [
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "ASTRA_DB_APPLICATION_TOKEN",
+            "ASTRA_DB_API_ENDPOINT",
+        ]:
+            return True
+
+        # SecretStrInput fields with uppercase underscore pattern
+        if (
+            field_config.get("_input_type") == "SecretStrInput"
+            and value.isupper()
+            and "_" in value
+        ):
+            return True
+
+        return False
+
+
+def load_and_preprocess_fixture(
+    fixture_name: str,
+    field_overrides: dict[str, dict[str, Any]] | None = None,
+    environment: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Load and preprocess a Langflow fixture file.
+
+    Args:
+        fixture_name: Name of fixture file (without .json extension)
+        field_overrides: Dict mapping node_id -> {field_name: new_value}
+        environment: Custom environment dict (defaults to os.environ)
+
+    Returns:
+        Preprocessed fixture data
+    """
+    from pathlib import Path
+
+    fixture_path = (
+        Path(__file__).parent.parent / "fixtures" / "langflow" / f"{fixture_name}.json"
+    )
+
+    with open(fixture_path) as f:
+        fixture_data = json.load(f)
+
+    preprocessor = FlowFixturePreprocessor(environment)
+    return preprocessor.preprocess_fixture(fixture_data, field_overrides)
+
+
+# Convenience functions for common test scenarios
+def preprocess_openai_fixture(
+    fixture_name: str, api_key: str | None = None
+) -> dict[str, Any]:
+    """Preprocess fixture with OpenAI API key substitution.
+
+    Args:
+        fixture_name: Name of fixture file
+        api_key: OpenAI API key (defaults to environment)
+
+    Returns:
+        Preprocessed fixture with OpenAI API key resolved
+    """
+    env = {}
+    if api_key:
+        env["OPENAI_API_KEY"] = api_key
+
+    return load_and_preprocess_fixture(fixture_name, environment=env)
+
+
+def preprocess_astradb_fixture(
+    fixture_name: str,
+    api_endpoint: str | None = None,
+    application_token: str | None = None,
+    database_name: str = "langflow-test",
+    collection_name: str = "test_collection",
+) -> dict[str, Any]:
+    """Preprocess fixture with AstraDB configuration.
+
+    Args:
+        fixture_name: Name of fixture file
+        api_endpoint: AstraDB API endpoint
+        application_token: AstraDB application token
+        database_name: Database name override
+        collection_name: Collection name override
+
+    Returns:
+        Preprocessed fixture with AstraDB configuration
+    """
+    env = {}
+    if api_endpoint:
+        env["ASTRA_DB_API_ENDPOINT"] = api_endpoint
+    if application_token:
+        env["ASTRA_DB_APPLICATION_TOKEN"] = application_token
+
+    # Find AstraDB nodes and override database/collection names
+    field_overrides = {}
+
+    # This is a simplified approach - in practice, you'd need to identify
+    # specific AstraDB node IDs in each fixture
+    # field_overrides["AstraDB-node-id"] = {
+    #     "database_name": database_name,
+    #     "collection_name": collection_name
+    # }
+
+    return load_and_preprocess_fixture(fixture_name, field_overrides, env)
+
+
+def substitute_component_inputs(
+    langflow_data: dict[str, Any],
+    component_id_prefix: str,
+    input_substitutions: dict[str, Any],
+) -> dict[str, Any]:
+    """Substitute input values in components matching a given ID prefix.
+
+    Args:
+        langflow_data: Raw langflow fixture data
+        component_id_prefix: Prefix to match component IDs (e.g., "AstraDB", "OpenAI")
+        input_substitutions: Dict mapping input names to new values
+
+    Returns:
+        Updated langflow data with substitutions applied
+    """
+    import copy
+
+    # Make a deep copy to avoid modifying the original
+    updated_data = copy.deepcopy(langflow_data)
+
+    if "data" not in updated_data or "nodes" not in updated_data["data"]:
+        return updated_data
+
+    # Find nodes matching the component prefix and apply substitutions
+    for node in updated_data["data"]["nodes"]:
+        node_id = node.get("id", "")
+        if node_id.startswith(component_id_prefix):
+            template = node.get("data", {}).get("node", {}).get("template", {})
+
+            # Apply each input substitution
+            for input_name, new_value in input_substitutions.items():
+                if input_name in template:
+                    # Update the value field of the input
+                    template[input_name]["value"] = new_value
+
+    return updated_data
+
+
+def substitute_astradb_inputs(langflow_data: dict[str, Any]) -> dict[str, Any]:
+    """Apply AstraDB-specific substitutions to components with AstraDB prefix.
+
+    Args:
+        langflow_data: Raw langflow fixture data
+
+    Returns:
+        Updated langflow data with AstraDB substitutions applied
+    """
+    import os
+
+    # Load environment variables from .env if available
+    env_vars = {}
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+        env_vars = dict(os.environ)
+    except ImportError:
+        env_vars = dict(os.environ)
+
+    # Get required AstraDB environment variables
+    astra_token = env_vars.get("ASTRA_DB_APPLICATION_TOKEN")
+    astra_endpoint = env_vars.get("ASTRA_DB_API_ENDPOINT")
+
+    if not astra_token:
+        import pytest
+
+        pytest.skip("ASTRA_DB_APPLICATION_TOKEN environment variable is required")
+
+    if not astra_endpoint:
+        import pytest
+
+        pytest.skip("ASTRA_DB_API_ENDPOINT environment variable is required")
+
+    # Define AstraDB-specific input substitutions
+    astradb_substitutions = {
+        "token": astra_token,
+        "api_endpoint": astra_endpoint,
+        "database_name": "langflow-test",
+        "collection_name": "test_collection",
+    }
+
+    return substitute_component_inputs(langflow_data, "AstraDB", astradb_substitutions)
+
+
+def substitute_openai_inputs(langflow_data: dict[str, Any]) -> dict[str, Any]:
+    """Apply OpenAI-specific substitutions to components that use OpenAI API keys.
+
+    Args:
+        langflow_data: Raw langflow fixture data
+
+    Returns:
+        Updated langflow data with OpenAI substitutions applied
+    """
+    import copy
+    import os
+
+    # Load environment variables from .env if available
+    env_vars = {}
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+        env_vars = dict(os.environ)
+    except ImportError:
+        env_vars = dict(os.environ)
+
+    # Get OpenAI API key
+    openai_key = env_vars.get("OPENAI_API_KEY")
+
+    if not openai_key:
+        import pytest
+
+        pytest.skip("OPENAI_API_KEY environment variable is required")
+
+    # Make a deep copy to avoid modifying the original
+    updated_data = copy.deepcopy(langflow_data)
+
+    if "data" not in updated_data or "nodes" not in updated_data["data"]:
+        return updated_data
+
+    # Find nodes that have OpenAI-related fields and apply substitutions
+    for node in updated_data["data"]["nodes"]:
+        template = node.get("data", {}).get("node", {}).get("template", {})
+
+        # Check if any field references OPENAI_API_KEY or has openai_api_key field
+        for field_name, field_def in template.items():
+            if isinstance(field_def, dict) and "value" in field_def:
+                value = field_def["value"]
+
+                # Substitute if field uses OPENAI_API_KEY reference or
+                # is an openai_api_key field
+                if value == "OPENAI_API_KEY" or field_name in [
+                    "openai_api_key",
+                    "api_key",
+                ]:
+                    field_def["value"] = openai_key
+
+    return updated_data
+
+
+def substitute_astradb_and_openai_inputs(
+    langflow_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Apply both AstraDB and OpenAI substitutions to a flow.
+
+    Args:
+        langflow_data: Raw langflow fixture data
+
+    Returns:
+        Updated langflow data with both AstraDB and OpenAI substitutions applied
+    """
+    # Apply AstraDB substitutions first
+    updated_data = substitute_astradb_inputs(langflow_data)
+
+    # Then apply OpenAI substitutions
+    updated_data = substitute_openai_inputs(updated_data)
+
+    return updated_data

--- a/integrations/langflow/tests/unit/test_fixture_preprocessing.py
+++ b/integrations/langflow/tests/unit/test_fixture_preprocessing.py
@@ -1,0 +1,517 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Tests for fixture preprocessing utilities."""
+
+from tests.helpers.fixture_preprocessing import (
+    FlowFixturePreprocessor,
+    preprocess_openai_fixture,
+)
+
+
+class TestFlowFixturePreprocessor:
+    """Test fixture preprocessing functionality."""
+
+    def test_environment_variable_substitution_template_format(self):
+        """Test ${ENV_VAR} format substitution."""
+        fixture = {
+            "data": {
+                "nodes": [
+                    {
+                        "id": "test-node",
+                        "data": {
+                            "type": "TestComponent",
+                            "node": {
+                                "template": {
+                                    "api_key": {
+                                        "value": "${OPENAI_API_KEY}",
+                                        "_input_type": "SecretStrInput",
+                                    }
+                                }
+                            },
+                        },
+                    }
+                ]
+            }
+        }
+
+        preprocessor = FlowFixturePreprocessor({"OPENAI_API_KEY": "test-key-123"})
+        result = preprocessor.preprocess_fixture(fixture)
+
+        api_key_value = result["data"]["nodes"][0]["data"]["node"]["template"][
+            "api_key"
+        ]["value"]
+        assert api_key_value == "test-key-123"
+
+    def test_direct_environment_variable_substitution(self):
+        """Test direct environment variable name substitution."""
+        fixture = {
+            "data": {
+                "nodes": [
+                    {
+                        "id": "test-node",
+                        "data": {
+                            "type": "TestComponent",
+                            "node": {
+                                "template": {
+                                    "api_key": {
+                                        "value": "OPENAI_API_KEY",
+                                        "_input_type": "SecretStrInput",
+                                    }
+                                }
+                            },
+                        },
+                    }
+                ]
+            }
+        }
+
+        preprocessor = FlowFixturePreprocessor({"OPENAI_API_KEY": "direct-key-456"})
+        result = preprocessor.preprocess_fixture(fixture)
+
+        api_key_value = result["data"]["nodes"][0]["data"]["node"]["template"][
+            "api_key"
+        ]["value"]
+        assert api_key_value == "direct-key-456"
+
+    def test_field_overrides(self):
+        """Test field override functionality."""
+        fixture = {
+            "data": {
+                "nodes": [
+                    {
+                        "id": "astra-node",
+                        "data": {
+                            "type": "AstraDB",
+                            "node": {
+                                "template": {
+                                    "database_name": {"value": ""},
+                                    "collection_name": {"value": "default"},
+                                }
+                            },
+                        },
+                    }
+                ]
+            }
+        }
+
+        field_overrides = {
+            "astra-node": {
+                "database_name": "test-db",
+                "collection_name": "test-collection",
+            }
+        }
+
+        preprocessor = FlowFixturePreprocessor()
+        result = preprocessor.preprocess_fixture(fixture, field_overrides)
+
+        template = result["data"]["nodes"][0]["data"]["node"]["template"]
+        assert template["database_name"]["value"] == "test-db"
+        assert template["collection_name"]["value"] == "test-collection"
+
+    def test_no_substitution_for_non_env_vars(self):
+        """Test that normal string values are left unchanged."""
+        fixture = {
+            "data": {
+                "nodes": [
+                    {
+                        "id": "test-node",
+                        "data": {
+                            "type": "TestComponent",
+                            "node": {
+                                "template": {
+                                    "normal_field": {"value": "normal_value"},
+                                    "number_field": {"value": 42},
+                                }
+                            },
+                        },
+                    }
+                ]
+            }
+        }
+
+        preprocessor = FlowFixturePreprocessor({"SOME_VAR": "some-value"})
+        result = preprocessor.preprocess_fixture(fixture)
+
+        template = result["data"]["nodes"][0]["data"]["node"]["template"]
+        assert template["normal_field"]["value"] == "normal_value"
+        assert template["number_field"]["value"] == 42
+
+    def test_missing_environment_variable_keeps_original(self):
+        """Test that missing environment variables keep original values."""
+        fixture = {
+            "data": {
+                "nodes": [
+                    {
+                        "id": "test-node",
+                        "data": {
+                            "type": "TestComponent",
+                            "node": {
+                                "template": {
+                                    "api_key": {
+                                        "value": "MISSING_API_KEY",
+                                        "_input_type": "SecretStrInput",
+                                    }
+                                }
+                            },
+                        },
+                    }
+                ]
+            }
+        }
+
+        preprocessor = FlowFixturePreprocessor({})  # Empty environment
+        result = preprocessor.preprocess_fixture(fixture)
+
+        api_key_value = result["data"]["nodes"][0]["data"]["node"]["template"][
+            "api_key"
+        ]["value"]
+        assert api_key_value == "MISSING_API_KEY"  # Should keep original
+
+
+class TestComponentBasedSubstitution:
+    """Test the new component-based substitution system."""
+
+    def test_substitute_component_inputs_basic(self):
+        """Test basic component input substitution by prefix."""
+        from tests.helpers.fixture_preprocessing import substitute_component_inputs
+
+        test_flow = {
+            "data": {
+                "nodes": [
+                    {
+                        "id": "AstraDB-test1",
+                        "data": {
+                            "node": {
+                                "template": {
+                                    "token": {"value": "ASTRA_DB_APPLICATION_TOKEN"},
+                                    "api_endpoint": {"value": ""},
+                                    "database_name": {"value": ""},
+                                }
+                            }
+                        },
+                    },
+                    {
+                        "id": "SomeOther-component",
+                        "data": {
+                            "node": {
+                                "template": {"token": {"value": "should_not_change"}}
+                            }
+                        },
+                    },
+                ]
+            }
+        }
+
+        substitutions = {
+            "token": "test-token-value",
+            "api_endpoint": "https://test-endpoint.com",
+            "database_name": "test-db",
+        }
+
+        result = substitute_component_inputs(test_flow, "AstraDB", substitutions)
+
+        # Check AstraDB component was updated
+        astra_template = result["data"]["nodes"][0]["data"]["node"]["template"]
+        assert astra_template["token"]["value"] == "test-token-value"
+        assert astra_template["api_endpoint"]["value"] == "https://test-endpoint.com"
+        assert astra_template["database_name"]["value"] == "test-db"
+
+        # Check other component was not changed
+        other_template = result["data"]["nodes"][1]["data"]["node"]["template"]
+        assert other_template["token"]["value"] == "should_not_change"
+
+    def test_substitute_astradb_inputs(self):
+        """Test AstraDB-specific substitution helper."""
+        import os
+
+        from tests.helpers.fixture_preprocessing import substitute_astradb_inputs
+
+        # Mock environment variables
+        original_env = {}
+        test_env = {
+            "ASTRA_DB_APPLICATION_TOKEN": "test-astra-token",
+            "ASTRA_DB_API_ENDPOINT": "https://test-astra-endpoint.com",
+        }
+
+        # Store original values and set test values
+        for key, value in test_env.items():
+            original_env[key] = os.environ.get(key)
+            os.environ[key] = value
+
+        try:
+            test_flow = {
+                "data": {
+                    "nodes": [
+                        {
+                            "id": "AstraDB-node1",
+                            "data": {
+                                "node": {
+                                    "template": {
+                                        "token": {
+                                            "value": "ASTRA_DB_APPLICATION_TOKEN"
+                                        },
+                                        "api_endpoint": {"value": ""},
+                                        "database_name": {"value": ""},
+                                        "collection_name": {"value": ""},
+                                    }
+                                }
+                            },
+                        }
+                    ]
+                }
+            }
+
+            result = substitute_astradb_inputs(test_flow)
+
+            template = result["data"]["nodes"][0]["data"]["node"]["template"]
+            assert template["token"]["value"] == "test-astra-token"
+            assert (
+                template["api_endpoint"]["value"] == "https://test-astra-endpoint.com"
+            )
+            assert template["database_name"]["value"] == "langflow-test"
+            assert template["collection_name"]["value"] == "test_collection"
+
+        finally:
+            # Restore original environment
+            for key, original_value in original_env.items():
+                if original_value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = original_value
+
+    def test_substitute_openai_inputs_with_prefix_component(self):
+        """Test OpenAI substitution with OpenAI-prefixed component."""
+        import os
+
+        from tests.helpers.fixture_preprocessing import substitute_openai_inputs
+
+        # Mock environment
+        original_key = os.environ.get("OPENAI_API_KEY")
+        os.environ["OPENAI_API_KEY"] = "test-openai-key-123"
+
+        try:
+            test_flow = {
+                "data": {
+                    "nodes": [
+                        {
+                            "id": "OpenAIEmbeddings-abc123",
+                            "data": {
+                                "node": {
+                                    "template": {
+                                        "openai_api_key": {"value": "OPENAI_API_KEY"},
+                                        "model": {"value": "text-embedding-3-small"},
+                                    }
+                                }
+                            },
+                        }
+                    ]
+                }
+            }
+
+            result = substitute_openai_inputs(test_flow)
+
+            template = result["data"]["nodes"][0]["data"]["node"]["template"]
+            assert template["openai_api_key"]["value"] == "test-openai-key-123"
+            assert template["model"]["value"] == "text-embedding-3-small"  # unchanged
+
+        finally:
+            if original_key is None:
+                os.environ.pop("OPENAI_API_KEY", None)
+            else:
+                os.environ["OPENAI_API_KEY"] = original_key
+
+    def test_substitute_openai_inputs_with_generic_component(self):
+        """Test OpenAI substitution with generic component using OpenAI API key."""
+        import os
+
+        from tests.helpers.fixture_preprocessing import substitute_openai_inputs
+
+        # Mock environment
+        original_key = os.environ.get("OPENAI_API_KEY")
+        os.environ["OPENAI_API_KEY"] = "test-generic-openai-key"
+
+        try:
+            test_flow = {
+                "data": {
+                    "nodes": [
+                        {
+                            "id": "LanguageModelComponent-xyz789",
+                            "data": {
+                                "node": {
+                                    "template": {
+                                        "api_key": {
+                                            "value": "OPENAI_API_KEY"
+                                        },  # References OpenAI
+                                        "model": {"value": "gpt-4"},
+                                        "temperature": {"value": 0.7},
+                                    }
+                                }
+                            },
+                        }
+                    ]
+                }
+            }
+
+            result = substitute_openai_inputs(test_flow)
+
+            template = result["data"]["nodes"][0]["data"]["node"]["template"]
+            assert template["api_key"]["value"] == "test-generic-openai-key"
+            assert template["model"]["value"] == "gpt-4"  # unchanged
+            assert template["temperature"]["value"] == 0.7  # unchanged
+
+        finally:
+            if original_key is None:
+                os.environ.pop("OPENAI_API_KEY", None)
+            else:
+                os.environ["OPENAI_API_KEY"] = original_key
+
+    def test_substitute_astradb_and_openai_inputs_combined(self):
+        """Test combined AstraDB and OpenAI substitution."""
+        import os
+
+        from tests.helpers.fixture_preprocessing import (
+            substitute_astradb_and_openai_inputs,
+        )
+
+        # Mock environment variables
+        original_env = {}
+        test_env = {
+            "ASTRA_DB_APPLICATION_TOKEN": "combined-astra-token",
+            "ASTRA_DB_API_ENDPOINT": "https://combined-astra.com",
+            "OPENAI_API_KEY": "combined-openai-key",
+        }
+
+        for key, value in test_env.items():
+            original_env[key] = os.environ.get(key)
+            os.environ[key] = value
+
+        try:
+            test_flow = {
+                "data": {
+                    "nodes": [
+                        {
+                            "id": "AstraDB-vector-store",
+                            "data": {
+                                "node": {
+                                    "template": {
+                                        "token": {
+                                            "value": "ASTRA_DB_APPLICATION_TOKEN"
+                                        },
+                                        "api_endpoint": {"value": ""},
+                                        "database_name": {"value": ""},
+                                    }
+                                }
+                            },
+                        },
+                        {
+                            "id": "OpenAIEmbeddings-embedder",
+                            "data": {
+                                "node": {
+                                    "template": {
+                                        "openai_api_key": {"value": "OPENAI_API_KEY"},
+                                    }
+                                }
+                            },
+                        },
+                        {
+                            "id": "LanguageModelComponent-llm",
+                            "data": {
+                                "node": {
+                                    "template": {"api_key": {"value": "OPENAI_API_KEY"}}
+                                }
+                            },
+                        },
+                    ]
+                }
+            }
+
+            result = substitute_astradb_and_openai_inputs(test_flow)
+
+            # Check AstraDB substitution
+            astra_template = result["data"]["nodes"][0]["data"]["node"]["template"]
+            assert astra_template["token"]["value"] == "combined-astra-token"
+            assert (
+                astra_template["api_endpoint"]["value"] == "https://combined-astra.com"
+            )
+            assert astra_template["database_name"]["value"] == "langflow-test"
+
+            # Check OpenAI substitutions - both prefixed and generic components
+            openai_template = result["data"]["nodes"][1]["data"]["node"]["template"]
+            assert openai_template["openai_api_key"]["value"] == "combined-openai-key"
+
+            llm_template = result["data"]["nodes"][2]["data"]["node"]["template"]
+            assert llm_template["api_key"]["value"] == "combined-openai-key"
+
+        finally:
+            # Restore original environment
+            for key, original_value in original_env.items():
+                if original_value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = original_value
+
+    def test_substitution_preserves_original_data(self):
+        """Test that substitution doesn't modify the original data structure."""
+        import copy
+
+        from tests.helpers.fixture_preprocessing import substitute_component_inputs
+
+        original_flow = {
+            "data": {
+                "nodes": [
+                    {
+                        "id": "TestComponent-123",
+                        "data": {
+                            "node": {
+                                "template": {"field1": {"value": "original_value"}}
+                            }
+                        },
+                    }
+                ]
+            }
+        }
+
+        # Make a copy to compare against
+        original_copy = copy.deepcopy(original_flow)
+
+        # Perform substitution
+        result = substitute_component_inputs(
+            original_flow, "TestComponent", {"field1": "new_value"}
+        )
+
+        # Verify original is unchanged
+        assert original_flow == original_copy
+
+        # Verify result has the substitution
+        assert (
+            result["data"]["nodes"][0]["data"]["node"]["template"]["field1"]["value"]
+            == "new_value"
+        )
+
+
+class TestConvenienceFunctions:
+    """Test convenience functions for common scenarios."""
+
+    def test_preprocess_openai_fixture(self):
+        """Test OpenAI fixture preprocessing."""
+        # This would normally load basic_prompting.json and process it
+        # For now, just test that the function exists and can be called
+        try:
+            result = preprocess_openai_fixture("basic_prompting", api_key="test-key")
+            assert isinstance(result, dict)
+            assert "data" in result
+        except FileNotFoundError:
+            # Expected if fixture path doesn't resolve properly in test
+            pass


### PR DESCRIPTION
This commit removes environment variable resolution, instead allowing
tests to update the template flow before translation and execution.

- Replaced runtime environment variable resolution with preprocessing
- Component-based substitution (see `fixture_preprocessing.py`)
- Removed dead code and complex execution method inference

This closes #307.