### PR TITLE
feat: Add HTTP protocol support for Langflow component server

### DIFF
--- a/integrations/langflow/src/stepflow_langflow_integration/executor/langflow_server.py
+++ b/integrations/langflow/src/stepflow_langflow_integration/executor/langflow_server.py
@@ -19,7 +19,7 @@ Clean architecture without CachedStepflowContext.
 
 from typing import Any
 
-from stepflow_py import StepflowContext, StepflowStdioServer
+from stepflow_py import StepflowContext, StepflowServer
 
 from .udf_executor import UDFExecutor
 
@@ -33,7 +33,7 @@ class StepflowLangflowServer:
 
     def __init__(self):
         """Initialize the Langflow component server."""
-        self.server = StepflowStdioServer()
+        self.server = StepflowServer()
         self.udf_executor = UDFExecutor()
 
         # Register components
@@ -60,9 +60,8 @@ class StepflowLangflowServer:
         # self.server.component(name="chat_input", func=self._chat_input)
 
     def run(self) -> None:
-        """Run the component server."""
-        # Langflow server starting
-        self.server.run()
+        """Run the component server in STDIO mode."""
+        self.server.start_stdio()
 
     async def serve(self, host: str = "localhost", port: int = 8000) -> None:
         """Run the component server in HTTP mode.
@@ -71,10 +70,7 @@ class StepflowLangflowServer:
             host: Server host
             port: Server port
         """
-        # This would require HTTP server implementation
-        # For now, fallback to stdio
-        _ = (host, port)  # Suppress unused parameter warnings
-        self.run()
+        await self.server.start_http(host=host, port=port)
 
 
 if __name__ == "__main__":

--- a/sdks/python/src/stepflow_py/__init__.py
+++ b/sdks/python/src/stepflow_py/__init__.py
@@ -31,6 +31,8 @@ from .generated_flow import (
     ValueTemplate,
 )
 from .server import StepflowServer
+
+# Legacy import for backward compatibility
 from .stdio_server import StepflowStdioServer
 from .value import JsonPath, StepReference, Valuable, Value, WorkflowInput
 

--- a/sdks/python/src/stepflow_py/http_server.py
+++ b/sdks/python/src/stepflow_py/http_server.py
@@ -375,6 +375,10 @@ class StepflowHttpServer:
         server = uvicorn.Server(config)
         await server.serve()
 
+    def component(self, *args, **kwargs):
+        """Delegate component registration to the underlying server."""
+        return self.server.component(*args, **kwargs)
+
     def langchain_component(self, *args, **kwargs):
         """Delegate langchain_component registration to the underlying server."""
         return self.server.langchain_component(*args, **kwargs)

--- a/sdks/python/src/stepflow_py/server.py
+++ b/sdks/python/src/stepflow_py/server.py
@@ -94,7 +94,7 @@ def _handle_exception(e: Exception, id: RequestId) -> MethodError:
 
 
 class StepflowServer:
-    """Core Stepflow server with component registry and business logic."""
+    """Unified Stepflow server with component registry and transport methods."""
 
     def __init__(self, include_builtins: bool = True):
         self._components: dict[str, ComponentEntry] = {}
@@ -559,3 +559,31 @@ class StepflowServer:
         if func is None:
             return decorator
         return decorator(func)
+
+    def start_stdio(
+        self,
+        stdin: Any = None,  # asyncio.StreamReader | None
+        stdout: Any = None,  # asyncio.StreamWriter | None
+    ) -> None:
+        """Start the server using STDIO transport.
+
+        Args:
+            stdin: Optional StreamReader to read from (defaults to sys.stdin)
+            stdout: Optional StreamWriter to write to (defaults to sys.stdout)
+        """
+        from .stdio_server import StepflowStdioServer
+
+        stdio_server = StepflowStdioServer(server=self)
+        stdio_server.run(stdin=stdin, stdout=stdout)
+
+    async def start_http(self, host: str = "localhost", port: int = 8080) -> None:
+        """Start the server using HTTP transport.
+
+        Args:
+            host: Server host (default: localhost)
+            port: Server port (default: 8080)
+        """
+        from .http_server import StepflowHttpServer
+
+        http_server = StepflowHttpServer(server=self, host=host, port=port)
+        await http_server.run()


### PR DESCRIPTION
This commit implements HTTP transport support for the Langflow integration and improves the Python SDK API with a unified server interface.

## Python SDK
- Refactor StepflowServer to include start_stdio() and start_http() methods
- Unified API: server.start_stdio() or await server.start_http(port=8080)
- Add component() method delegation to StepflowHttpServer
- Maintain backward compatibility with existing StepflowStdioServer

## Langflow Integration
- Update StepflowLangflowServer to use unified StepflowServer
- Add proper HTTP support via async serve() method
- Update CLI with --http flag for HTTP mode (default port 5264)

## Langflow Integration CLI
- convert-and-submit: Convert Langflow workflow and submit to remote server
- run-flow: Run Stepflow workflow with tweaks on remote server
- Both commands support tweaks and remote execution via stepflow submit

This closes #247.