### PR TITLE
feat: Enhance error responses with full stack traces and attachments

### DIFF
--- a/stepflow-rs/crates/stepflow-main/src/submit.rs
+++ b/stepflow-rs/crates/stepflow-main/src/submit.rs
@@ -12,11 +12,70 @@
 
 use crate::{Result, error::MainError, validation_display::display_diagnostics};
 use error_stack::ResultExt as _;
+use serde::Deserialize;
 use std::sync::Arc;
 use stepflow_core::FlowResult;
 use stepflow_core::workflow::{Flow, ValueRef};
 use stepflow_server::{CreateRunRequest, CreateRunResponse, StoreFlowRequest, StoreFlowResponse};
 use url::Url;
+
+/// Error response structure for client-side deserialization
+#[derive(Debug, Deserialize)]
+struct ErrorResponse {
+    pub message: String,
+    #[serde(default)]
+    pub stack: Vec<ErrorStackEntry>,
+}
+
+/// A single entry in the error stack
+#[derive(Debug, Deserialize)]
+struct ErrorStackEntry {
+    pub error: String,
+    #[serde(default)]
+    pub attachments: Vec<String>,
+    pub backtrace: Option<String>,
+}
+
+/// Display a server error response with enhanced stack information
+fn display_server_error(status: reqwest::StatusCode, response_text: &str, context: &str) {
+    // Try to parse as structured error response first
+    if let Ok(error_response) = serde_json::from_str::<ErrorResponse>(response_text) {
+        tracing::error!("Server returned error {}: {}", context, error_response.message);
+
+        if !error_response.stack.is_empty() {
+            tracing::error!("Error stack trace:");
+            for (i, entry) in error_response.stack.iter().enumerate() {
+                tracing::error!("  {}. {}", i + 1, entry.error);
+
+                // Display attachments if present
+                if !entry.attachments.is_empty() {
+                    for attachment in &entry.attachments {
+                        tracing::error!("     • {}", attachment);
+                    }
+                }
+
+                // Display backtrace if present (truncated for readability)
+                if let Some(backtrace) = &entry.backtrace {
+                    let lines: Vec<_> = backtrace.lines().collect();
+                    if !lines.is_empty() {
+                        tracing::error!("     Backtrace ({} frames):", lines.len());
+                        // Show first few frames for context
+                        lines.iter().take(5).for_each(|line| {
+                            tracing::error!("       {}", line);
+                        });
+                        if lines.len() > 5 {
+                            tracing::error!("       ... ({} more frames)", lines.len() - 5);
+                            tracing::error!("       Set RUST_LOG=debug for full backtrace");
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        // Fallback to simple error display if parsing fails
+        tracing::error!("Server returned error {} {}: {}", context, status, response_text);
+    }
+}
 
 /// Submit a workflow to a Stepflow service for execution
 pub async fn submit(service_url: Url, flow: Flow, input: ValueRef) -> Result<FlowResult> {
@@ -47,11 +106,7 @@ pub async fn submit(service_url: Url, flow: Flow, input: ValueRef) -> Result<Flo
             .text()
             .await
             .unwrap_or_else(|_| "Unknown error".to_string());
-        tracing::error!(
-            "Server returned error storing workflow {}: {}",
-            status,
-            error_text
-        );
+        display_server_error(status, &error_text, "storing workflow");
         return Err(MainError::Configuration.into());
     };
 
@@ -101,11 +156,7 @@ pub async fn submit(service_url: Url, flow: Flow, input: ValueRef) -> Result<Flo
             .text()
             .await
             .unwrap_or_else(|_| "Unknown error".to_string());
-        tracing::error!(
-            "Server returned error executing workflow {}: {}",
-            status,
-            error_text
-        );
+        display_server_error(status, &error_text, "executing workflow");
         return Err(MainError::Configuration.into());
     }
 
@@ -121,5 +172,87 @@ pub async fn submit(service_url: Url, flow: Flow, input: ValueRef) -> Result<Flo
             tracing::error!("No result in response");
             Err(MainError::Configuration.into())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_server_error_structured() {
+        // Test parsing and display of structured error response
+        let error_json = r#"{
+            "code": 404,
+            "message": "Execution not found",
+            "stack": [
+                {
+                    "error": "Execution '12345' not found",
+                    "attachments": ["Test execution not found", "Looking for execution: 12345"]
+                },
+                {
+                    "error": "State store unavailable",
+                    "attachments": ["Database connection failed"]
+                }
+            ]
+        }"#;
+
+        // This should not panic and should display structured error
+        display_server_error(reqwest::StatusCode::NOT_FOUND, error_json, "test operation");
+    }
+
+    #[test]
+    fn test_display_server_error_with_backtrace() {
+        // Test parsing and display of error response with backtrace
+        let error_json = r#"{
+            "code": 500,
+            "message": "Internal server error",
+            "stack": [
+                {
+                    "error": "Database connection failed",
+                    "attachments": [
+                        "Connection timeout after 30s",
+                        "Retry attempts: 3",
+                        "Last error: Connection refused"
+                    ],
+                    "backtrace": "   0: std::backtrace_rs::backtrace::libunwind::trace\n             at /rustc/.../backtrace/src/backtrace/libunwind.rs:117:9\n   1: std::backtrace::Backtrace::create\n             at /rustc/.../library/std/src/backtrace.rs:331:13\n   2: stepflow_server::api::health::health_check\n             at ./crates/stepflow-server/src/api/health.rs:77:33\n   3: <F as axum::handler::Handler<(M,T1),S>>::call\n             at /Users/.../axum-0.8.4/src/handler/mod.rs:239:43\n   4: tower::util::oneshot::Oneshot<S,Req>\n             at /Users/.../tower-0.5.2/src/util/oneshot.rs:97:42\n   5: hyper::proto::h1::dispatch::Dispatcher<D,Bs,I,T>::poll_write\n             at /Users/.../hyper-1.7.0/src/proto/h1/dispatch.rs:336:72"
+                }
+            ]
+        }"#;
+
+        // Test that this doesn't panic - actual output verification would require
+        // tracing subscriber setup which is complex for unit tests
+        display_server_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, error_json, "executing workflow");
+    }
+
+    #[test]
+    fn test_display_server_error_fallback() {
+        // Test fallback for non-JSON error response
+        let error_text = "Internal Server Error";
+
+        // This should fallback to simple error display
+        display_server_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, error_text, "test operation");
+    }
+
+    #[test]
+    fn test_error_response_parsing() {
+        let error_json = r#"{
+            "code": 500,
+            "message": "Internal error",
+            "stack": [
+                {
+                    "error": "Database error",
+                    "attachments": ["Connection timeout"],
+                    "backtrace": "   0: test::function\n   1: another::function\n"
+                }
+            ]
+        }"#;
+
+        let parsed: ErrorResponse = serde_json::from_str(error_json).expect("Should parse");
+        assert_eq!(parsed.message, "Internal error");
+        assert_eq!(parsed.stack.len(), 1);
+        assert_eq!(parsed.stack[0].error, "Database error");
+        assert_eq!(parsed.stack[0].attachments.len(), 1);
+        assert!(parsed.stack[0].backtrace.is_some());
     }
 }

--- a/stepflow-rs/crates/stepflow-main/src/submit.rs
+++ b/stepflow-rs/crates/stepflow-main/src/submit.rs
@@ -12,29 +12,12 @@
 
 use crate::{Result, error::MainError, validation_display::display_diagnostics};
 use error_stack::ResultExt as _;
-use serde::Deserialize;
 use std::sync::Arc;
 use stepflow_core::FlowResult;
 use stepflow_core::workflow::{Flow, ValueRef};
 use stepflow_server::{CreateRunRequest, CreateRunResponse, StoreFlowRequest, StoreFlowResponse};
+use stepflow_server::error::ErrorResponse;
 use url::Url;
-
-/// Error response structure for client-side deserialization
-#[derive(Debug, Deserialize)]
-struct ErrorResponse {
-    pub message: String,
-    #[serde(default)]
-    pub stack: Vec<ErrorStackEntry>,
-}
-
-/// A single entry in the error stack
-#[derive(Debug, Deserialize)]
-struct ErrorStackEntry {
-    pub error: String,
-    #[serde(default)]
-    pub attachments: Vec<String>,
-    pub backtrace: Option<String>,
-}
 
 /// Display a server error response with enhanced stack information
 fn display_server_error(status: reqwest::StatusCode, response_text: &str, context: &str) {

--- a/stepflow-rs/crates/stepflow-main/src/submit.rs
+++ b/stepflow-rs/crates/stepflow-main/src/submit.rs
@@ -15,15 +15,19 @@ use error_stack::ResultExt as _;
 use std::sync::Arc;
 use stepflow_core::FlowResult;
 use stepflow_core::workflow::{Flow, ValueRef};
-use stepflow_server::{CreateRunRequest, CreateRunResponse, StoreFlowRequest, StoreFlowResponse};
 use stepflow_server::error::ErrorResponse;
+use stepflow_server::{CreateRunRequest, CreateRunResponse, StoreFlowRequest, StoreFlowResponse};
 use url::Url;
 
 /// Display a server error response with enhanced stack information
 fn display_server_error(status: reqwest::StatusCode, response_text: &str, context: &str) {
     // Try to parse as structured error response first
     if let Ok(error_response) = serde_json::from_str::<ErrorResponse>(response_text) {
-        tracing::error!("Server returned error {}: {}", context, error_response.message);
+        tracing::error!(
+            "Server returned error {}: {}",
+            context,
+            error_response.message
+        );
 
         if !error_response.stack.is_empty() {
             tracing::error!("Error stack trace:");
@@ -56,7 +60,12 @@ fn display_server_error(status: reqwest::StatusCode, response_text: &str, contex
         }
     } else {
         // Fallback to simple error display if parsing fails
-        tracing::error!("Server returned error {} {}: {}", context, status, response_text);
+        tracing::error!(
+            "Server returned error {} {}: {}",
+            context,
+            status,
+            response_text
+        );
     }
 }
 
@@ -205,7 +214,11 @@ mod tests {
 
         // Test that this doesn't panic - actual output verification would require
         // tracing subscriber setup which is complex for unit tests
-        display_server_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, error_json, "executing workflow");
+        display_server_error(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            error_json,
+            "executing workflow",
+        );
     }
 
     #[test]
@@ -214,7 +227,11 @@ mod tests {
         let error_text = "Internal Server Error";
 
         // This should fallback to simple error display
-        display_server_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, error_text, "test operation");
+        display_server_error(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            error_text,
+            "test operation",
+        );
     }
 
     #[test]

--- a/stepflow-rs/crates/stepflow-server/src/api.rs
+++ b/stepflow-rs/crates/stepflow-server/src/api.rs
@@ -67,6 +67,7 @@ pub use runs::{CreateRunRequest, CreateRunResponse};
         debug::DebugStepRequest,
         debug::DebugStepResponse,
         debug::DebugRunnableResponse,
+        health::HealthQuery,
         health::HealthResponse,
         runs::CreateRunRequest,
         runs::CreateRunResponse,

--- a/stepflow-rs/crates/stepflow-server/src/api/flows.rs
+++ b/stepflow-rs/crates/stepflow-server/src/api/flows.rs
@@ -96,6 +96,7 @@ pub async fn store_flow(
             .map_err(|_| ErrorResponse {
                 code: axum::http::StatusCode::INTERNAL_SERVER_ERROR,
                 message: "Failed to store flow".to_string(),
+                stack: vec![],
             })?;
         Some(flow_id)
     };
@@ -132,6 +133,7 @@ pub async fn get_flow(
         .map_err(|_| ErrorResponse {
             code: axum::http::StatusCode::NOT_FOUND,
             message: "Flow not found".to_string(),
+            stack: vec![],
         })?;
 
     // Check if it's a flow blob and deserialize
@@ -139,6 +141,7 @@ pub async fn get_flow(
         return Err(ErrorResponse {
             code: axum::http::StatusCode::BAD_REQUEST,
             message: "Blob is not a flow".to_string(),
+            stack: vec![],
         });
     }
 
@@ -146,6 +149,7 @@ pub async fn get_flow(
         serde_json::from_value(blob_data.data().as_ref().clone()).map_err(|_| ErrorResponse {
             code: axum::http::StatusCode::INTERNAL_SERVER_ERROR,
             message: "Failed to deserialize flow".to_string(),
+            stack: vec![],
         })?;
 
     let flow = Arc::new(flow);
@@ -164,6 +168,7 @@ pub async fn get_flow(
                 message: format!(
                     "Workflow validation failed with {fatal} fatal and {error} error diagnostics"
                 ),
+                stack: vec![],
             });
         }
     };

--- a/stepflow-rs/crates/stepflow-server/src/api/health.rs
+++ b/stepflow-rs/crates/stepflow-server/src/api/health.rs
@@ -10,9 +10,19 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-use axum::response::Json;
+use axum::{extract::Query, response::Json};
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
+
+use crate::error::{ErrorResponse, ServerError};
+
+/// Health check query parameters
+#[derive(Debug, Deserialize, ToSchema, IntoParams)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthQuery {
+    /// Trigger an error for testing error response format
+    pub error: Option<String>,
+}
 
 /// Health check response
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -30,14 +40,64 @@ pub struct HealthResponse {
 #[utoipa::path(
     get,
     path = "/health",
+    params(HealthQuery),
     responses(
-        (status = 200, description = "Service is healthy", body = HealthResponse)
+        (status = 200, description = "Service is healthy", body = HealthResponse),
+        (status = 400, description = "Bad request - triggered by ?error=bad_request"),
+        (status = 404, description = "Not found - triggered by ?error=not_found"),
+        (status = 500, description = "Internal server error - triggered by ?error=internal or ?error=stack")
     )
 )]
-pub async fn health_check() -> Json<HealthResponse> {
-    Json(HealthResponse {
+pub async fn health_check(Query(params): Query<HealthQuery>) -> Result<Json<HealthResponse>, ErrorResponse> {
+    // Test error scenarios
+    if let Some(error_type) = params.error.as_ref() {
+        return match error_type.as_str() {
+            "bad_request" => {
+                use error_stack::{report, ResultExt};
+                let backtrace = std::backtrace::Backtrace::capture();
+                Err(report!(ServerError::ExecutionNotFound(uuid::Uuid::new_v4()))
+                    .attach(backtrace)
+                    .change_context(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Bad request triggered for testing"))
+                    .attach_printable("This is a test error with multiple layers")
+                    .attach_printable("Layer 1: User requested error via ?error=bad_request")
+                    .attach_printable("Layer 2: Simulating validation failure")
+                    .into())
+            },
+            "not_found" => {
+                use error_stack::report;
+                let test_id = uuid::Uuid::new_v4();
+                Err(report!(ServerError::ExecutionNotFound(test_id))
+                    .attach_printable("Test execution not found")
+                    .attach_printable(format!("Looking for execution: {}", test_id))
+                    .into())
+            },
+            "stack" => {
+                use error_stack::{report, ResultExt};
+                // Create a more complex error stack with backtrace
+                let backtrace = std::backtrace::Backtrace::capture();
+                Err(report!(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "Database connection failed"))
+                    .attach(backtrace)
+                    .change_context(std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "State store unavailable"))
+                    .change_context(ServerError::ExecutionNotFound(uuid::Uuid::new_v4()))
+                    .attach_printable("Complex error stack for testing")
+                    .attach_printable("Bottom layer: Database permission denied")
+                    .attach_printable("Middle layer: Connection refused")
+                    .attach_printable("Top layer: Execution not found")
+                    .into())
+            },
+            _ => {
+                use error_stack::report;
+                Err(report!(std::io::Error::new(std::io::ErrorKind::Other, "Generic test error"))
+                    .attach_printable("Unknown error type requested")
+                    .attach_printable(format!("Requested error type: {}", error_type))
+                    .into())
+            }
+        };
+    }
+
+    Ok(Json(HealthResponse {
         status: "healthy".to_string(),
         timestamp: chrono::Utc::now().to_rfc3339(),
         version: env!("CARGO_PKG_VERSION").to_string(),
-    })
+    }))
 }

--- a/stepflow-rs/crates/stepflow-server/src/api/health.rs
+++ b/stepflow-rs/crates/stepflow-server/src/api/health.rs
@@ -53,7 +53,7 @@ pub async fn health_check(Query(params): Query<HealthQuery>) -> Result<Json<Heal
     if let Some(error_type) = params.error.as_ref() {
         return match error_type.as_str() {
             "bad_request" => {
-                use error_stack::{report, ResultExt};
+                use error_stack::report;
                 let backtrace = std::backtrace::Backtrace::capture();
                 Err(report!(ServerError::ExecutionNotFound(uuid::Uuid::new_v4()))
                     .attach(backtrace)
@@ -72,7 +72,7 @@ pub async fn health_check(Query(params): Query<HealthQuery>) -> Result<Json<Heal
                     .into())
             },
             "stack" => {
-                use error_stack::{report, ResultExt};
+                use error_stack::report;
                 // Create a more complex error stack with backtrace
                 let backtrace = std::backtrace::Backtrace::capture();
                 Err(report!(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "Database connection failed"))

--- a/stepflow-rs/crates/stepflow-server/src/error.rs
+++ b/stepflow-rs/crates/stepflow-server/src/error.rs
@@ -28,6 +28,18 @@ pub struct ErrorResponse {
     #[serde(serialize_with = "serialize_status_code")]
     pub code: StatusCode,
     pub message: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub stack: Vec<ErrorStackEntry>,
+}
+
+/// A single entry in the error stack
+#[derive(Debug, serde::Serialize)]
+pub struct ErrorStackEntry {
+    pub error: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backtrace: Option<String>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -77,6 +89,7 @@ impl From<ServerError> for ErrorResponse {
         ErrorResponse {
             code: value.status_code(),
             message: value.to_string(),
+            stack: vec![],
         }
     }
 }
@@ -93,9 +106,69 @@ impl<T: error_stack::Context> From<error_stack::Report<T>> for ErrorResponse {
             })
             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
+        // Build the error stack
+        let mut stack: Vec<ErrorStackEntry> = Vec::new();
+        let mut current_attachments: Vec<String> = Vec::new();
+
+        // Extract global backtrace if available
+        let global_backtrace = {
+            let mut backtrace_iter = report.frames()
+                .into_iter()
+                .filter_map(|frame| {
+                    frame.sources()
+                        .into_iter()
+                        .find_map(|source| source.downcast_ref::<std::backtrace::Backtrace>())
+                });
+            backtrace_iter.next().map(|bt| bt.to_string())
+        };
+
+        for frame in report.frames() {
+            match frame.kind() {
+                error_stack::FrameKind::Context(context) => {
+                    // If we have accumulated attachments, add them to the previous entry
+                    if !current_attachments.is_empty() && !stack.is_empty() {
+                        if let Some(last_entry) = stack.last_mut() {
+                            last_entry.attachments.extend(current_attachments.drain(..));
+                        }
+                    }
+
+                    // Add the context as a new stack entry
+                    // Only include backtrace on the first (top-level) error to avoid duplication
+                    let backtrace = if stack.is_empty() { global_backtrace.clone() } else { None };
+
+                    stack.push(ErrorStackEntry {
+                        error: context.to_string(),
+                        attachments: vec![],
+                        backtrace,
+                    });
+                }
+                error_stack::FrameKind::Attachment(attachment_kind) => {
+                    match attachment_kind {
+                        error_stack::AttachmentKind::Printable(printable) => {
+                            current_attachments.push(printable.to_string());
+                        }
+                        error_stack::AttachmentKind::Opaque(opaque) => {
+                            current_attachments.push(format!("<opaque attachment: {:p}>", opaque));
+                        }
+                        _ => {
+                            current_attachments.push("<unknown attachment>".to_string());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add any remaining attachments to the last entry
+        if !current_attachments.is_empty() && !stack.is_empty() {
+            if let Some(last_entry) = stack.last_mut() {
+                last_entry.attachments.extend(current_attachments);
+            }
+        }
+
         ErrorResponse {
             code,
             message: report.to_string(),
+            stack,
         }
     }
 }

--- a/stepflow-rs/crates/stepflow-server/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-server/src/lib.rs
@@ -16,7 +16,7 @@
 //! It contains all the API endpoints, request/response types, and server startup logic.
 
 mod api;
-mod error;
+pub mod error;
 mod startup;
 
 pub use api::*;


### PR DESCRIPTION
- Add comprehensive error stack serialization in ErrorResponse
- Include backtrace information in error stack entries
- Add error testing endpoint to health check with ?error= parameter
- Implement structured error display in CLI submit command
- Support fallback to simple error display for non-JSON responses
- Add unit tests for error parsing and display functionality