### PR TITLE
ci: change artifact names

### DIFF
--- a/.github/workflows/release_rust.yml
+++ b/.github/workflows/release_rust.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: stepflow-${{ matrix.target }}
+          name: artifact-stepflow-${{ matrix.target }}
           path: stepflow-rs/artifacts/stepflow-${{ matrix.target }}*
           retention-days: 7
 
@@ -206,7 +206,7 @@ jobs:
       - name: Download required binary
         uses: actions/download-artifact@v4
         with:
-          name: stepflow-${{ matrix.binary-target }}
+          name: artifact-stepflow-${{ matrix.binary-target }}
           path: ./binary/
 
       - name: Prepare binary
@@ -349,7 +349,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ./release-artifacts
-          pattern: stepflow-*
+          pattern: artifact-stepflow-*
           merge-multiple: true
 
       - name: Create release archives

--- a/stepflow-rs/CHANGELOG.md
+++ b/stepflow-rs/CHANGELOG.md
@@ -2,58 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## <a id="0.5.0"></a> [Stepflow 0.5.0](https://github.com/stepflow-ai/stepflow/releases/tag/stepflow-rs-0.5.0) - 2025-10-09
-### Bug Fixes
-
-- Update tracing-subscriber ([#242](https://github.com/stepflow-ai/stepflow/pull/242))
-
-### Documentation
-
-- Demonstrate operations concerns ([#171](https://github.com/stepflow-ai/stepflow/pull/171))
-- Update the CLI documentation ([#203](https://github.com/stepflow-ai/stepflow/pull/203))
-- Flesh out roadmap a little ([#211](https://github.com/stepflow-ai/stepflow/pull/211))
-- Update docs to use stepflow-ai GitHub org ([#212](https://github.com/stepflow-ai/stepflow/pull/212))
-- Lanchain mcp post and some concurency fixes resulting from such ([#241](https://github.com/stepflow-ai/stepflow/pull/241))
-
-### Features
-
-- Add schema field to flow ([#194](https://github.com/stepflow-ai/stepflow/pull/194))
-- Use blobs for flows ([#195](https://github.com/stepflow-ai/stepflow/pull/195))
-- Add extensible metadata to flows and steps ([#210](https://github.com/stepflow-ai/stepflow/pull/210))
-- Add a visualize command to the cli ([#221](https://github.com/stepflow-ai/stepflow/pull/221))
-- Allow empty flows ([#224](https://github.com/stepflow-ai/stepflow/pull/224))
-- Allow Python components/UDFs to signal skip ([#239](https://github.com/stepflow-ai/stepflow/pull/239))
-- Include process output in channel errors ([#323](https://github.com/stepflow-ai/stepflow/pull/323))
-- Share validation between submit and validate ([#331](https://github.com/stepflow-ai/stepflow/pull/331))
-- Enhance error responses with full stack traces and attachments ([#332](https://github.com/stepflow-ai/stepflow/pull/332))
-- Improve error reporting with stack traces ([#333](https://github.com/stepflow-ai/stepflow/pull/333))
-- Restart stdio subprocess; retry components ([#336](https://github.com/stepflow-ai/stepflow/pull/336))
-- Add batch execution support with CLI and REST API ([#345](https://github.com/stepflow-ai/stepflow/pull/345))
-- Protocol support for batch execution ([#348](https://github.com/stepflow-ai/stepflow/pull/348))
-- Kubernetes + load balancer demo ([#349](https://github.com/stepflow-ai/stepflow/pull/349))
-- Separate binaries and update release infrastructure ([#355](https://github.com/stepflow-ai/stepflow/pull/355))
-
-### Miscellaneous Tasks
-
-- Standardize on Stepflow capitalization ([#205](https://github.com/stepflow-ai/stepflow/pull/205))
-- All the plumbing, files, and scripts for ICLA setup and maintenance. ([#218](https://github.com/stepflow-ai/stepflow/pull/218))
-- License check revamp using correct license headers, configure licensure for such ([#223](https://github.com/stepflow-ai/stepflow/pull/223))
-- Update release scripts ([#228](https://github.com/stepflow-ai/stepflow/pull/228))
-- Undo dispatch changes ([#235](https://github.com/stepflow-ai/stepflow/pull/235))
-- Release stepflow-rs v0.3.0 ([#234](https://github.com/stepflow-ai/stepflow/pull/234))
-- Add Langflow to CI ([#243](https://github.com/stepflow-ai/stepflow/pull/243))
-- Release stepflow-rs v0.4.0 ([#341](https://github.com/stepflow-ai/stepflow/pull/341))
-- Release stepflow-rs v0.5.0 ([#356](https://github.com/stepflow-ai/stepflow/pull/356))
-- Remove verify-artifacts step; fix binaries ([#357](https://github.com/stepflow-ai/stepflow/pull/357))
-- Release stepflow-rs v0.5.0 ([#358](https://github.com/stepflow-ai/stepflow/pull/358))
-- No load balancer for windows ([#359](https://github.com/stepflow-ai/stepflow/pull/359))
-- Release stepflow-rs v0.5.0 ([#360](https://github.com/stepflow-ai/stepflow/pull/360))
-- Fix release script ([#362](https://github.com/stepflow-ai/stepflow/pull/362))
-
-### Refactoring
-
-- Introduce Step/Flow builders ([#238](https://github.com/stepflow-ai/stepflow/pull/238))
-
 ## <a id="0.4.0"></a> [Stepflow 0.4.0](https://github.com/stepflow-ai/stepflow/releases/tag/stepflow-rs-0.4.0) - 2025-10-02
 
 Skipped -- didn't go out due to bugs in the release script.

--- a/stepflow-rs/Cargo.lock
+++ b/stepflow-rs/Cargo.lock
@@ -3776,7 +3776,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stepflow-analysis"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "bit-set",
  "error-stack",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "stepflow-builtins"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "dynosaur",
  "error-stack",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "stepflow-cli"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "clap 4.5.48",
  "clap-markdown",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "stepflow-components-mcp"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "error-stack",
  "futures",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "stepflow-config"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "error-stack",
  "indexmap 2.11.4",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "stepflow-core"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "error-stack",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "stepflow-execution"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bit-set",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "stepflow-load-balancer"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "stepflow-mock"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "error-stack",
  "serde",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "stepflow-plugin"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "dynosaur",
  "error-stack",
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "stepflow-protocol"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "chrono",
@@ -4023,7 +4023,7 @@ dependencies = [
 
 [[package]]
 name = "stepflow-server"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "axum",
  "chrono",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "stepflow-state"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "bit-set",
  "chrono",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "stepflow-state-sql"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "bit-set",
  "chrono",

--- a/stepflow-rs/Cargo.toml
+++ b/stepflow-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 authors = ["Ben Chambers"]
 edition = "2024"
-version = "0.5.0"
+version = "0.4.0"
 license = "Apache-2.0"
 homepage = "https://fuzzy-journey-4j3y1we.pages.github.io/"
 repository = "https://github.com/stepflow-ai/stepflow"


### PR DESCRIPTION
Theory: The name `stepflow-` was also matching the results of dockerbuilds:

```
- stepflow-ai~stepflow~GTVB3J.dockerbuild (ID: 4221265994, Size: 35786, Expected Digest: sha256:ab301233b6750405e43b5b8f9ab15fc8c66f41f855aac6c642014a9e142dccf9)
- stepflow-ai~stepflow~ISNBPH.dockerbuild (ID: 4221260810, Size: 31062, Expected Digest: sha256:922c8a446d9c1b7e047efd7be58c7f2993374a37c71ec9ae84c00118d42daf97)
- stepflow-ai~stepflow~JXIM1U.dockerbuild (ID: 4221259604, Size: 32868, Expected Digest: sha256:dd4a57d81ebdaa3d72a805ab3571acf3fa5ab8cbe471a26596d4363bd956bfe0)
- stepflow-ai~stepflow~EMIRYJ.dockerbuild (ID: 4221259182, Size: 30996, Expected Digest: sha256:eab77c4657510c00825f1ad7bb1eed772efa1e5957f7963cff6ccdc17d59ebcc)
```

But those artifacts cause problems when downloading because they're not zip files: https://github.com/actions/download-artifact/issues/328#issuecomment-2199704064

Rather than using an alternative download action, this just names the artifacts differently so the dockerbuild files shouldn't match.