### PR TITLE
test: refactor langflow tests to use shared stepflow server

### DIFF
--- a/integrations/langflow/pyproject.toml
+++ b/integrations/langflow/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
     "types-PyYAML>=6.0.0",
     "pandas-stubs>=2.0.0",
     "httpx>=0.25.0", # For testing HTTP components
+    "requests>=2.31.0", # For Stepflow server health checks in tests
     "black>=25.1.0",
     "psutil>=5.9.0", # For memory monitoring in OOM tests
 ]

--- a/integrations/langflow/uv.lock
+++ b/integrations/langflow/uv.lock
@@ -9017,6 +9017,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "requests" },
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
@@ -9052,6 +9053,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
+    { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", specifier = ">=0.9.4" },
     { name = "types-pyyaml", specifier = ">=6.0.0" },
 ]


### PR DESCRIPTION
Refactor the Langflow integration tests to use a single shared Stepflow server instance for improved performance and better error diagnostics.

Changes:
- Add `StepflowServer` class for server lifecycle management with context manager support and stdout/stderr capture for debugging
- Add `start_server()` method to `StepflowBinaryRunner` to start the stepflow-server binary with health checks
- Add `submit_workflow()` method for server-based workflow execution
- Refactor `shared_config` fixture to return stable config path
- Add `stepflow_server` module-scoped fixture that shares one server across all tests
- Update `TestExecutor` to use `submit_workflow()` instead of `run_workflow()`
- Include server logs in test failure messages for better debugging
- Add `requests` dependency for health check HTTP calls
- Remove unused `run_workflow()` method (~150 lines of dead code)