### PR TITLE
feat: add stepflow-observability crate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,12 +269,20 @@ See `CLAUDE.md` for detailed architecture and advanced patterns.
 
 ### Logging and Tracing
 
-- Use the `tracing` package for all logging and instrumentation
-- Use appropriate log levels (error, warn, info, debug, trace)
-- Include relevant context in log messages
-- Use structured logging where appropriate
-- Use spans for tracking operation context
-- Use events for discrete log messages
+**Use `log` for detailed debugging information:**
+- Internal state changes and variable values
+- Low-level operations and conditional branches
+- Use standard `log::info!`, `log::debug!`, etc. - trace context is automatic
+
+**Use `fastrace` for high-level execution structure:**
+- Workflow/step/component lifecycle (start/end)
+- Key inputs, outputs, and errors
+- Cross-system boundaries (HTTP, plugins, database)
+- Be conservative: only trace what support engineers need
+
+**Trace context is automatically injected into logs** - no manual propagation needed.
+
+See `CLAUDE.md` for detailed guidelines and examples.
 
 ## Making Contributions
 

--- a/stepflow-rs/Cargo.lock
+++ b/stepflow-rs/Cargo.lock
@@ -652,6 +652,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +999,43 @@ dependencies = [
  "futures-core",
  "nom",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fastant"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bf7fa928ce0c4a43bd6e7d1235318fc32ac3a3dea06a2208c44e729449471a"
+dependencies = [
+ "small_ctor",
+ "web-time",
+]
+
+[[package]]
+name = "fastrace"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "318783b9fefe06130ab664ff1779215657586b004c0c7f3d6ece16d658936d06"
+dependencies = [
+ "fastant",
+ "fastrace-macro",
+ "parking_lot",
+ "pin-project",
+ "rand 0.9.2",
+ "rtrb",
+ "serde",
+]
+
+[[package]]
+name = "fastrace-macro"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7079009cf129d63c850dee732b58d7639d278a47ad99c607954ac94cfd57ef4"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1729,6 +1775,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,6 +1941,88 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+dependencies = [
+ "sval",
+ "sval_ref",
+ "value-bag",
+]
+
+[[package]]
+name = "logforth"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd048889d633cac5c189eca703f5c5ed65210d358eb5910a478e233d42528d6e"
+dependencies = [
+ "logforth-append-file",
+ "logforth-bridge-log",
+ "logforth-core",
+ "logforth-diagnostic-fastrace",
+ "logforth-layout-json",
+ "logforth-layout-text",
+]
+
+[[package]]
+name = "logforth-append-file"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb66a16ac0f5cdd6a0e7005c6e1fa2744e915244941ac6cd01bd56de2995f48"
+dependencies = [
+ "jiff",
+ "logforth-core",
+]
+
+[[package]]
+name = "logforth-bridge-log"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "392ff9723d68a943ccffabe03b5272f7c93104f0008a6c7357ef888c21ab6297"
+dependencies = [
+ "log",
+ "logforth-core",
+]
+
+[[package]]
+name = "logforth-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7666819ed32e38aabb45959a632b0f9c25fc77e60c824b02a5fcd87ab626f6ed"
+dependencies = [
+ "anyhow",
+ "value-bag",
+]
+
+[[package]]
+name = "logforth-diagnostic-fastrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70cef4f74be63362c9e654d4b74b59a019be088d87d453f39e32fc23764f3e87"
+dependencies = [
+ "fastrace",
+ "logforth-core",
+]
+
+[[package]]
+name = "logforth-layout-json"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e1db5d0f5b1bc57134ff9d1ed3889910d230545f3d249bde44bac0e8a8724f"
+dependencies = [
+ "jiff",
+ "logforth-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "logforth-layout-text"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00c67d92539b26edbba5e43ce8f5b97d62412c1cfc9463400f50cfad2f1f1bf"
+dependencies = [
+ "colored",
+ "jiff",
+ "logforth-core",
+]
 
 [[package]]
 name = "lru"
@@ -2297,6 +2466,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2549,6 +2738,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3042,6 +3246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtrb"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8388ea1a9e0ea807e442e8263a699e7edcb320ecbcd21b4fa8ff859acce3ba"
+
+[[package]]
 name = "rust-embed"
 version = "8.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3311,6 +3521,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_buf"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a86be9d6c7d34718d2ec6f56c8d6a4671d1a7357c2a6921f47fe5a3ee6056cc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,6 +3558,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "serde_fmt"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3508,6 +3736,12 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "small_ctor"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88414a5ca1f85d82cc34471e975f0f74f6aa54c40f062efa42c0080e7f763f81"
 
 [[package]]
 name = "smallvec"
@@ -3963,6 +4197,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "stepflow-observability"
+version = "0.6.0"
+dependencies = [
+ "error-stack",
+ "fastrace",
+ "log",
+ "logforth",
+ "serde_json",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "stepflow-plugin"
 version = "0.6.0"
 dependencies = [
@@ -4138,6 +4384,84 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "sval"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d94c4464e595f0284970fd9c7e9013804d035d4a61ab74b113242c874c05814d"
+
+[[package]]
+name = "sval_buffer"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0f46e34b20a39e6a2bf02b926983149b3af6609fd1ee8a6e63f6f340f3e2164"
+dependencies = [
+ "sval",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d0970e53c92ab5381d3b2db1828da8af945954d4234225f6dd9c3afbcef3f5"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e5e6e1613e1e7fc2e1a9fdd709622e54c122ceb067a60d170d75efd491a839"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aec382f7bfa6e367b23c9611f129b94eb7daaf3d8fae45a8d0a0211eb4d4c8e6"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_nested"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3049d0f99ce6297f8f7d9953b35a0103b7584d8f638de40e64edb7105fa578ae"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88913e77506085c0a8bf6912bb6558591a960faf5317df6c1d9b227224ca6e1"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f579fd7254f4be6cd7b450034f856b78523404655848789c451bacc6aa8b387d"
+dependencies = [
+ "serde_core",
+ "sval",
+ "sval_nested",
+]
 
 [[package]]
 name = "syn"
@@ -4896,6 +5220,43 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+dependencies = [
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35540706617d373b118d550d41f5dfe0b78a0c195dc13c6815e92e2638432306"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_buf",
+ "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe7e140a2658cc16f7ee7a86e413e803fc8f9b5127adc8755c19f9fefa63a52"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
+]
 
 [[package]]
 name = "vcpkg"

--- a/stepflow-rs/Cargo.toml
+++ b/stepflow-rs/Cargo.toml
@@ -22,8 +22,12 @@ dashmap = "6.1"
 dynosaur = "0.2.0"
 erased-serde = "0.4.6"
 error-stack = { version = "0.5.0", features = ["serde"] }
+fastrace = { version = "0.7", features = ["enable"] }
+fastrace-opentelemetry = "0.7"
 futures = "0.3.31"
 glob = "0.3"
+log = "0.4"
+logforth = { version = "0.28", features = ["layout-json", "layout-text", "bridge-log", "diagnostic-fastrace", "append-file"] }
 matchit = "0.8.4"
 hex = "0.4"
 indexmap = { version = "2.8.0", features = ["serde"] }
@@ -32,6 +36,11 @@ insta-cmd = "0.6.0"
 itertools = "0.14"
 nix = { version = "0.29", features = ["process", "signal"] }
 openai-api-rs = { version = "6.0.6", features = ["rustls"], default-features = false }
+opentelemetry = { version = "0.26", features = ["trace", "logs"] }
+opentelemetry-otlp = { version = "0.26", features = ["trace", "logs"] }
+opentelemetry_sdk = { version = "0.26", features = ["rt-tokio", "trace", "logs"] }
+opentelemetry-appender-log = "0.26"
+opentelemetry-semantic-conventions = "0.26"
 pingora = { version = "0.6", features = ["proxy"] }
 pingora-core = "0.6"
 pingora-http = "0.6"
@@ -60,6 +69,7 @@ stepflow-config = { path = "./crates/stepflow-config" }
 stepflow-core = { path = "./crates/stepflow-core" }
 stepflow-execution = { path = "./crates/stepflow-execution" }
 stepflow-mock = { path = "./crates/stepflow-mock" }
+stepflow-observability = { path = "./crates/stepflow-observability" }
 stepflow-plugin = { path = "./crates/stepflow-plugin" }
 stepflow-protocol = { path = "./crates/stepflow-protocol" }
 stepflow-server = { path = "./crates/stepflow-server" }

--- a/stepflow-rs/crates/stepflow-observability/Cargo.toml
+++ b/stepflow-rs/crates/stepflow-observability/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "stepflow-observability"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+fastrace = { workspace = true }
+log = { workspace = true }
+logforth = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+error-stack = { workspace = true }
+
+[dev-dependencies]
+
+[[example]]
+name = "basic"
+path = "examples/basic.rs"
+
+[[example]]
+name = "run_diagnostic_context"
+path = "examples/run_diagnostic_context.rs"

--- a/stepflow-rs/crates/stepflow-observability/examples/basic.rs
+++ b/stepflow-rs/crates/stepflow-observability/examples/basic.rs
@@ -1,0 +1,73 @@
+// Copyright 2025 DataStax Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Basic example demonstrating logging with automatic trace context injection
+
+use stepflow_observability::{
+    BinaryObservabilityConfig, LogDestination, LogFormat, ObservabilityConfig,
+    fastrace::prelude::*, init_observability,
+};
+
+fn main() {
+    let config = ObservabilityConfig {
+        log_level: log::LevelFilter::Debug,
+        log_format: LogFormat::Json,
+        log_destination: LogDestination::Stdout,
+        trace_enabled: true,
+        binary_config: BinaryObservabilityConfig::default(), // No run diagnostic
+        otlp_endpoint: None,
+        service_name: "example".to_string(),
+    };
+
+    let _guard = init_observability(config).unwrap();
+
+    // Test basic logging
+    log::info!("Starting example - no trace context");
+
+    // Create a root span using LocalSpan which automatically sets itself as parent
+    {
+        let root = Span::root("worker-loop", SpanContext::random());
+        let _guard = root.set_local_parent();
+
+        // Check if span context is available
+        if let Some(ctx) = fastrace::collector::SpanContext::current_local_parent() {
+            eprintln!(
+                "DEBUG: Root span context found - trace_id={:032x} span_id={:016x}",
+                ctx.trace_id.0, ctx.span_id.0
+            );
+        } else {
+            eprintln!("DEBUG: No root span context found!");
+        }
+
+        log::info!("Inside root span");
+
+        // Nested span
+        {
+            let _span = LocalSpan::enter_with_local_parent("example_operation");
+            log::info!("Inside nested span");
+            log::debug!("Debug info inside nested span");
+
+            // Double nested span
+            {
+                let _span2 = LocalSpan::enter_with_local_parent("nested_operation");
+                log::info!("Inside double nested span");
+                log::warn!("Warning in double nested span");
+            }
+        }
+
+        log::info!("Back at root level");
+    }
+
+    log::info!("After root span closed");
+
+    // Note: The guard will flush traces when dropped
+}

--- a/stepflow-rs/crates/stepflow-observability/examples/run_diagnostic_context.rs
+++ b/stepflow-rs/crates/stepflow-observability/examples/run_diagnostic_context.rs
@@ -1,0 +1,76 @@
+// Copyright 2025 DataStax Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Example demonstrating automatic injection of run_id and step_id
+//! along with trace context into all log records
+
+use stepflow_observability::{
+    BinaryObservabilityConfig, LogDestination, LogFormat, ObservabilityConfig, RunIdGuard,
+    StepIdGuard, fastrace::prelude::*, init_observability,
+};
+
+fn main() {
+    let config = ObservabilityConfig {
+        log_level: log::LevelFilter::Debug,
+        log_format: LogFormat::Json,
+        log_destination: LogDestination::Stdout,
+        trace_enabled: true,
+        binary_config: BinaryObservabilityConfig {
+            include_run_diagnostic: true,
+        },
+        otlp_endpoint: None,
+        service_name: "example".to_string(),
+    };
+
+    let _guard = init_observability(config).unwrap();
+
+    // Log without any context
+    log::info!("Starting workflow execution - no context yet");
+
+    // Simulate workflow execution with run_id
+    {
+        // Set run_id for this workflow run
+        let _run_guard = RunIdGuard::new("run-12345");
+
+        log::info!("Workflow started");
+
+        // Create a root trace span for the workflow execution
+        {
+            let root = Span::root("workflow-execution", SpanContext::random());
+            let _span_guard = root.set_local_parent();
+
+            log::info!("Inside trace span - should have both trace_id and run_id");
+
+            // Simulate step execution
+            execute_step("step1");
+            execute_step("step2");
+
+            log::info!("Workflow completed");
+        }
+
+        log::info!("After trace span closed - still has run_id");
+    }
+
+    log::info!("After run_id cleared - no context");
+}
+
+fn execute_step(step_name: &'static str) {
+    // Set step_id for this step execution
+    let _step_guard = StepIdGuard::new(step_name);
+
+    // Create a child span for this step
+    let _span = LocalSpan::enter_with_local_parent(step_name);
+
+    log::info!("Step started");
+    log::debug!("Processing step logic");
+    log::info!("Step completed");
+}

--- a/stepflow-rs/crates/stepflow-observability/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-observability/src/lib.rs
@@ -1,0 +1,349 @@
+// Copyright 2025 DataStax Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Observability infrastructure for Stepflow
+//!
+//! This crate provides unified logging and distributed tracing capabilities:
+//! - Logging via the `log` crate with automatic trace context injection
+//! - Distributed tracing via `fastrace` with OpenTelemetry export
+//!
+//! # Key Features
+//!
+//! - **Automatic trace context**: All logs automatically include `trace_id` and `span_id`
+//! - **Zero-cost tracing**: When disabled, tracing has no runtime overhead
+//! - **OpenTelemetry support**: Export traces and logs to any OTLP-compatible backend
+//! - **Multiple formats**: JSON or plain text logging
+
+pub use fastrace;
+pub use log;
+
+mod run_diagnostic_context;
+pub use run_diagnostic_context::{RunDiagnostic, RunIdGuard, StepIdGuard, get_run_id, get_step_id};
+
+/// Binary-specific observability configuration
+#[derive(Clone, Debug, Default)]
+pub struct BinaryObservabilityConfig {
+    /// Include run diagnostic (run_id, step_id) in logs
+    ///
+    /// Set to true for binaries that execute workflows (stepflow-server, CLI run command)
+    /// Set to false for binaries that don't execute workflows (load balancer, CLI submit command)
+    pub include_run_diagnostic: bool,
+}
+
+/// Configuration for observability (logging + tracing)
+#[derive(Clone, Debug)]
+pub struct ObservabilityConfig {
+    /// Log level filter
+    pub log_level: log::LevelFilter,
+
+    /// Log output format
+    pub log_format: LogFormat,
+
+    /// Log output destination (exclusive - only one destination at a time)
+    pub log_destination: LogDestination,
+
+    /// Enable distributed tracing
+    pub trace_enabled: bool,
+
+    /// Binary-specific configuration
+    pub binary_config: BinaryObservabilityConfig,
+
+    /// OTLP endpoint (e.g., "http://localhost:4317")
+    /// Used for both trace and log export when log_destination is LogDestination::OpenTelemetry
+    pub otlp_endpoint: Option<String>,
+
+    /// Service name for traces/logs
+    pub service_name: String,
+}
+
+/// Log output format
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LogFormat {
+    /// Structured JSON logs
+    Json,
+    /// Human-readable text logs
+    Text,
+}
+
+/// Log output destination (exclusive - only one at a time)
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LogDestination {
+    /// Log to stdout
+    Stdout,
+    /// Log to OpenTelemetry (uses otlp_endpoint from config)
+    OpenTelemetry,
+    /// Log to a file (appends)
+    File(std::path::PathBuf),
+}
+
+impl Default for ObservabilityConfig {
+    fn default() -> Self {
+        Self {
+            log_level: log::LevelFilter::Info,
+            log_format: LogFormat::Text,
+            log_destination: LogDestination::Stdout,
+            trace_enabled: false,
+            binary_config: BinaryObservabilityConfig::default(),
+            otlp_endpoint: None,
+            service_name: "stepflow".to_string(),
+        }
+    }
+}
+
+/// Initialize observability (logging + tracing)
+///
+/// Returns a guard that must be held for the lifetime of the application.
+/// When the guard is dropped, tracing will be flushed and shut down.
+///
+/// # Example
+///
+/// ```no_run
+/// use stepflow_observability::{
+///     ObservabilityConfig, BinaryObservabilityConfig, LogFormat, LogDestination, init_observability
+/// };
+///
+/// let config = ObservabilityConfig {
+///     log_level: log::LevelFilter::Info,
+///     log_format: LogFormat::Json,
+///     log_destination: LogDestination::Stdout,
+///     trace_enabled: true,
+///     binary_config: BinaryObservabilityConfig {
+///         include_run_diagnostic: true,  // Enable for workflow execution binaries
+///     },
+///     otlp_endpoint: None,
+///     service_name: "my-service".to_string(),
+/// };
+///
+/// let _guard = init_observability(config).unwrap();
+/// log::info!("Service started");
+/// ```
+pub fn init_observability(config: ObservabilityConfig) -> Result<ObservabilityGuard> {
+    // Initialize tracing first (so logger can access trace context)
+    let trace_guard = if config.trace_enabled {
+        Some(init_tracing(&config)?)
+    } else {
+        None
+    };
+
+    // Initialize logging with trace context integration
+    let log_guard = init_logging(&config)?;
+
+    Ok(ObservabilityGuard {
+        _log_guard: log_guard,
+        _trace_guard: trace_guard,
+    })
+}
+
+fn init_logging(config: &ObservabilityConfig) -> Result<LogGuard> {
+    use logforth::append;
+    use logforth::diagnostic::FastraceDiagnostic;
+    use logforth::layout::JsonLayout;
+    use logforth::layout::TextLayout;
+    use logforth::record::LevelFilter;
+
+    // Convert log::LevelFilter to logforth::record::LevelFilter
+    let level_filter = match config.log_level {
+        log::LevelFilter::Off => LevelFilter::Off,
+        log::LevelFilter::Error => LevelFilter::Error,
+        log::LevelFilter::Warn => LevelFilter::Warn,
+        log::LevelFilter::Info => LevelFilter::Info,
+        log::LevelFilter::Debug => LevelFilter::Debug,
+        log::LevelFilter::Trace => LevelFilter::Trace,
+    };
+
+    let builder = logforth::starter_log::builder();
+
+    // Configure single exclusive destination with fastrace diagnostic (always)
+    // and optionally run diagnostic (if binary_config.include_run_diagnostic is true)
+    let builder = match (
+        &config.log_destination,
+        config.log_format,
+        config.binary_config.include_run_diagnostic,
+    ) {
+        (LogDestination::Stdout, LogFormat::Json, true) => builder.dispatch(|d| {
+            d.filter(level_filter)
+                .diagnostic(FastraceDiagnostic::default())
+                .diagnostic(RunDiagnostic)
+                .append(append::Stdout::default().with_layout(JsonLayout::default()))
+        }),
+        (LogDestination::Stdout, LogFormat::Json, false) => builder.dispatch(|d| {
+            d.filter(level_filter)
+                .diagnostic(FastraceDiagnostic::default())
+                .append(append::Stdout::default().with_layout(JsonLayout::default()))
+        }),
+        (LogDestination::Stdout, LogFormat::Text, true) => builder.dispatch(|d| {
+            d.filter(level_filter)
+                .diagnostic(FastraceDiagnostic::default())
+                .diagnostic(RunDiagnostic)
+                .append(append::Stdout::default().with_layout(TextLayout::default()))
+        }),
+        (LogDestination::Stdout, LogFormat::Text, false) => builder.dispatch(|d| {
+            d.filter(level_filter)
+                .diagnostic(FastraceDiagnostic::default())
+                .append(append::Stdout::default().with_layout(TextLayout::default()))
+        }),
+        (LogDestination::File(path), LogFormat::Json, true) => {
+            // Special case: /dev/null means discard logs (used in tests)
+            if path == std::path::Path::new("/dev/null") {
+                return Ok(LogGuard);
+            }
+            let file_append = append::file::FileBuilder::new(path.clone(), "app_log")
+                .layout(JsonLayout::default())
+                .build()
+                .map_err(|e| {
+                    error_stack::Report::new(ObservabilityError::LogInitError)
+                        .attach_printable(format!("Failed to create file appender for {:?}", path))
+                        .attach_printable(format!("{:?}", e))
+                })?;
+            builder.dispatch(|d| {
+                d.filter(level_filter)
+                    .diagnostic(FastraceDiagnostic::default())
+                    .diagnostic(RunDiagnostic)
+                    .append(file_append)
+            })
+        }
+        (LogDestination::File(path), LogFormat::Json, false) => {
+            // Special case: /dev/null means discard logs (used in tests)
+            if path == std::path::Path::new("/dev/null") {
+                return Ok(LogGuard);
+            }
+            let file_append = append::file::FileBuilder::new(path.clone(), "app_log")
+                .layout(JsonLayout::default())
+                .build()
+                .map_err(|e| {
+                    error_stack::Report::new(ObservabilityError::LogInitError)
+                        .attach_printable(format!("Failed to create file appender for {:?}", path))
+                        .attach_printable(format!("{:?}", e))
+                })?;
+            builder.dispatch(|d| {
+                d.filter(level_filter)
+                    .diagnostic(FastraceDiagnostic::default())
+                    .append(file_append)
+            })
+        }
+        (LogDestination::File(path), LogFormat::Text, true) => {
+            // Special case: /dev/null means discard logs (used in tests)
+            if path == std::path::Path::new("/dev/null") {
+                return Ok(LogGuard);
+            }
+            let file_append = append::file::FileBuilder::new(path.clone(), "app_log")
+                .layout(TextLayout::default())
+                .build()
+                .map_err(|e| {
+                    error_stack::Report::new(ObservabilityError::LogInitError)
+                        .attach_printable(format!("Failed to create file appender for {:?}", path))
+                        .attach_printable(format!("{:?}", e))
+                })?;
+            builder.dispatch(|d| {
+                d.filter(level_filter)
+                    .diagnostic(FastraceDiagnostic::default())
+                    .diagnostic(RunDiagnostic)
+                    .append(file_append)
+            })
+        }
+        (LogDestination::File(path), LogFormat::Text, false) => {
+            // Special case: /dev/null means discard logs (used in tests)
+            if path == std::path::Path::new("/dev/null") {
+                return Ok(LogGuard);
+            }
+            let file_append = append::file::FileBuilder::new(path.clone(), "app_log")
+                .layout(TextLayout::default())
+                .build()
+                .map_err(|e| {
+                    error_stack::Report::new(ObservabilityError::LogInitError)
+                        .attach_printable(format!("Failed to create file appender for {:?}", path))
+                        .attach_printable(format!("{:?}", e))
+                })?;
+            builder.dispatch(|d| {
+                d.filter(level_filter)
+                    .diagnostic(FastraceDiagnostic::default())
+                    .append(file_append)
+            })
+        }
+        (LogDestination::OpenTelemetry, _, true) => {
+            // TODO: Implement OpenTelemetry log appender
+            // For now, fall back to stdout
+            eprintln!(
+                "WARNING: OpenTelemetry log output not yet implemented, falling back to stdout"
+            );
+            builder.dispatch(|d| {
+                d.filter(level_filter)
+                    .diagnostic(FastraceDiagnostic::default())
+                    .diagnostic(RunDiagnostic)
+                    .append(append::Stdout::default().with_layout(JsonLayout::default()))
+            })
+        }
+        (LogDestination::OpenTelemetry, _, false) => {
+            // TODO: Implement OpenTelemetry log appender
+            // For now, fall back to stdout
+            eprintln!(
+                "WARNING: OpenTelemetry log output not yet implemented, falling back to stdout"
+            );
+            builder.dispatch(|d| {
+                d.filter(level_filter)
+                    .diagnostic(FastraceDiagnostic::default())
+                    .append(append::Stdout::default().with_layout(JsonLayout::default()))
+            })
+        }
+    };
+
+    builder.apply();
+
+    Ok(LogGuard)
+}
+
+fn init_tracing(config: &ObservabilityConfig) -> Result<TraceGuard> {
+    if let Some(_endpoint) = &config.otlp_endpoint {
+        // TODO: Export traces to OTLP
+        // For now, use console reporter
+        fastrace::set_reporter(
+            fastrace::collector::ConsoleReporter,
+            fastrace::collector::Config::default(),
+        );
+    } else {
+        // Console reporter for development
+        fastrace::set_reporter(
+            fastrace::collector::ConsoleReporter,
+            fastrace::collector::Config::default(),
+        );
+    }
+
+    Ok(TraceGuard)
+}
+
+/// Guard that ensures proper cleanup of observability systems
+pub struct ObservabilityGuard {
+    _log_guard: LogGuard,
+    _trace_guard: Option<TraceGuard>,
+}
+
+struct LogGuard;
+struct TraceGuard;
+
+impl Drop for TraceGuard {
+    fn drop(&mut self) {
+        fastrace::flush();
+    }
+}
+
+/// Errors that can occur during observability initialization
+#[derive(Debug, thiserror::Error)]
+pub enum ObservabilityError {
+    #[error("Failed to initialize logging")]
+    LogInitError,
+    #[error("Failed to initialize tracing")]
+    TraceInitError,
+    #[error("Failed to initialize OTLP")]
+    OtlpInitError,
+}
+
+pub type Result<T> = std::result::Result<T, error_stack::Report<ObservabilityError>>;

--- a/stepflow-rs/crates/stepflow-observability/src/run_diagnostic_context.rs
+++ b/stepflow-rs/crates/stepflow-observability/src/run_diagnostic_context.rs
@@ -1,0 +1,175 @@
+// Copyright 2025 DataStax Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Run diagnostic context for workflow executions
+//!
+//! This module provides thread-local storage for run_id and step_id that gets
+//! automatically injected into all log records via a custom diagnostic.
+//!
+//! - `run_id`: Set once per workflow execution (rarely changes)
+//! - `step_id`: Set/cleared frequently as we enter/exit steps
+
+use std::cell::RefCell;
+
+thread_local! {
+    static RUN_ID: RefCell<Option<String>> = const { RefCell::new(None) };
+    static STEP_ID: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// RAII guard that sets run_id on creation and clears it on drop
+pub struct RunIdGuard {
+    _private: (),
+}
+
+impl RunIdGuard {
+    /// Create a new guard and set the run_id for the current thread
+    pub fn new(run_id: impl Into<String>) -> Self {
+        RUN_ID.with(|r| {
+            *r.borrow_mut() = Some(run_id.into());
+        });
+        Self { _private: () }
+    }
+}
+
+impl Drop for RunIdGuard {
+    fn drop(&mut self) {
+        RUN_ID.with(|r| {
+            *r.borrow_mut() = None;
+        });
+    }
+}
+
+/// RAII guard that sets step_id on creation and clears it on drop
+pub struct StepIdGuard {
+    _private: (),
+}
+
+impl StepIdGuard {
+    /// Create a new guard and set the step_id for the current thread
+    pub fn new(step_id: impl Into<String>) -> Self {
+        STEP_ID.with(|s| {
+            *s.borrow_mut() = Some(step_id.into());
+        });
+        Self { _private: () }
+    }
+}
+
+impl Drop for StepIdGuard {
+    fn drop(&mut self) {
+        STEP_ID.with(|s| {
+            *s.borrow_mut() = None;
+        });
+    }
+}
+
+/// Get the current run_id if set
+pub fn get_run_id() -> Option<String> {
+    RUN_ID.with(|r| r.borrow().clone())
+}
+
+/// Get the current step_id if set
+pub fn get_step_id() -> Option<String> {
+    STEP_ID.with(|s| s.borrow().clone())
+}
+
+/// Custom diagnostic that injects run_id and step_id into logs
+#[derive(Debug, Default)]
+pub struct RunDiagnostic;
+
+impl logforth::diagnostic::Diagnostic for RunDiagnostic {
+    fn visit(&self, visitor: &mut dyn logforth::kv::Visitor) -> Result<(), logforth::Error> {
+        use logforth::kv::{Key, Value};
+
+        if let Some(run_id) = get_run_id() {
+            visitor.visit(Key::new("run_id"), Value::from_display(&run_id))?;
+        }
+
+        if let Some(step_id) = get_step_id() {
+            visitor.visit(Key::new("step_id"), Value::from_display(&step_id))?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run_id_guard() {
+        // Initially no run_id
+        assert!(get_run_id().is_none());
+
+        {
+            let _guard = RunIdGuard::new("run-123");
+
+            // run_id is set inside guard scope
+            assert_eq!(get_run_id(), Some("run-123".to_string()));
+        }
+
+        // run_id is cleared when guard drops
+        assert!(get_run_id().is_none());
+    }
+
+    #[test]
+    fn test_step_id_guard() {
+        // Initially no step_id
+        assert!(get_step_id().is_none());
+
+        {
+            let _guard = StepIdGuard::new("step1");
+
+            // step_id is set inside guard scope
+            assert_eq!(get_step_id(), Some("step1".to_string()));
+        }
+
+        // step_id is cleared when guard drops
+        assert!(get_step_id().is_none());
+    }
+
+    #[test]
+    fn test_nested_guards() {
+        // Initially no context
+        assert!(get_run_id().is_none());
+        assert!(get_step_id().is_none());
+
+        {
+            let _run_guard = RunIdGuard::new("run-456");
+            assert_eq!(get_run_id(), Some("run-456".to_string()));
+            assert!(get_step_id().is_none());
+
+            {
+                let _step_guard = StepIdGuard::new("step1");
+                assert_eq!(get_run_id(), Some("run-456".to_string()));
+                assert_eq!(get_step_id(), Some("step1".to_string()));
+            }
+
+            // step_id cleared, run_id still set
+            assert_eq!(get_run_id(), Some("run-456".to_string()));
+            assert!(get_step_id().is_none());
+
+            {
+                let _step_guard = StepIdGuard::new("step2");
+                assert_eq!(get_run_id(), Some("run-456".to_string()));
+                assert_eq!(get_step_id(), Some("step2".to_string()));
+            }
+
+            assert_eq!(get_run_id(), Some("run-456".to_string()));
+            assert!(get_step_id().is_none());
+        }
+
+        // All cleared when run guard drops
+        assert!(get_run_id().is_none());
+        assert!(get_step_id().is_none());
+    }
+}

--- a/stepflow-rs/crates/stepflow-observability/tests/test_examples.rs
+++ b/stepflow-rs/crates/stepflow-observability/tests/test_examples.rs
@@ -1,0 +1,339 @@
+// Copyright 2025 DataStax Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Integration tests that run example binaries and verify diagnostic output
+
+use serde_json::Value;
+use std::process::Command;
+
+/// Parse JSON log lines from output
+fn parse_json_logs(output: &str) -> Vec<Value> {
+    output
+        .lines()
+        .filter(|line| !line.starts_with("DEBUG:")) // Skip debug output
+        .filter(|line| !line.starts_with("SpanRecord")) // Skip span records
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect()
+}
+
+#[test]
+fn test_basic_example_no_run_diagnostic() {
+    // Run the basic example which has BinaryObservabilityConfig::default()
+    let output = Command::new("cargo")
+        .args(["run", "--example", "basic"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("Failed to run basic example");
+
+    assert!(
+        output.status.success(),
+        "Basic example failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let logs = parse_json_logs(&stdout);
+
+    // Find a log inside a span (should have trace context but no run context)
+    let span_log = logs
+        .iter()
+        .find(|log| {
+            log.get("message")
+                .and_then(|m| m.as_str())
+                .map(|m| m.contains("Inside root span"))
+                .unwrap_or(false)
+        })
+        .expect("Could not find 'Inside root span' log");
+
+    // Should have trace diagnostic
+    let diags = span_log.get("diags").expect("Log should have diags object");
+    assert!(
+        diags.get("trace_id").is_some(),
+        "Should have trace_id in basic example"
+    );
+    assert!(
+        diags.get("span_id").is_some(),
+        "Should have span_id in basic example"
+    );
+
+    // Should NOT have run diagnostic
+    assert!(
+        diags.get("run_id").is_none(),
+        "Should NOT have run_id in basic example"
+    );
+    assert!(
+        diags.get("step_id").is_none(),
+        "Should NOT have step_id in basic example"
+    );
+}
+
+#[test]
+fn test_run_diagnostic_context_example() {
+    // Run the run_diagnostic_context example which enables run diagnostic
+    let output = Command::new("cargo")
+        .args(["run", "--example", "run_diagnostic_context"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("Failed to run run_diagnostic_context example");
+
+    assert!(
+        output.status.success(),
+        "run_diagnostic_context example failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let logs = parse_json_logs(&stdout);
+
+    // Test 1: Log without any context (before RunIdGuard)
+    let no_context_log = logs
+        .iter()
+        .find(|log| {
+            log.get("message")
+                .and_then(|m| m.as_str())
+                .map(|m| m.contains("no context yet"))
+                .unwrap_or(false)
+        })
+        .expect("Could not find 'no context yet' log");
+
+    let diags = no_context_log.get("diags");
+    assert!(
+        diags.is_none() || diags.unwrap().as_object().unwrap().is_empty(),
+        "Should have no diagnostic context before guards"
+    );
+
+    // Test 2: Log with run_id but no trace context yet
+    let run_only_log = logs
+        .iter()
+        .find(|log| {
+            log.get("message")
+                .and_then(|m| m.as_str())
+                .map(|m| m.contains("Workflow started"))
+                .unwrap_or(false)
+        })
+        .expect("Could not find 'Workflow started' log");
+
+    let diags = run_only_log
+        .get("diags")
+        .expect("Should have diags for workflow started");
+    assert_eq!(
+        diags.get("run_id").and_then(|v| v.as_str()),
+        Some("run-12345"),
+        "Should have run_id"
+    );
+    assert!(
+        diags.get("trace_id").is_none(),
+        "Should not have trace_id yet"
+    );
+    assert!(
+        diags.get("step_id").is_none(),
+        "Should not have step_id yet"
+    );
+
+    // Test 3: Log with both trace and run context
+    let trace_and_run_log = logs
+        .iter()
+        .find(|log| {
+            log.get("message")
+                .and_then(|m| m.as_str())
+                .map(|m| m.contains("Inside trace span"))
+                .unwrap_or(false)
+        })
+        .expect("Could not find 'Inside trace span' log");
+
+    let diags = trace_and_run_log
+        .get("diags")
+        .expect("Should have diags for trace span");
+    assert!(
+        diags.get("trace_id").is_some(),
+        "Should have trace_id inside span"
+    );
+    assert!(
+        diags.get("span_id").is_some(),
+        "Should have span_id inside span"
+    );
+    assert_eq!(
+        diags.get("run_id").and_then(|v| v.as_str()),
+        Some("run-12345"),
+        "Should still have run_id inside span"
+    );
+    assert!(
+        diags.get("step_id").is_none(),
+        "Should not have step_id yet (not in step)"
+    );
+
+    // Test 4: Log with trace, run, and step context
+    let step1_logs: Vec<_> = logs
+        .iter()
+        .filter(|log| {
+            log.get("diags")
+                .and_then(|d| d.get("step_id"))
+                .and_then(|s| s.as_str())
+                == Some("step1")
+        })
+        .collect();
+
+    assert!(
+        !step1_logs.is_empty(),
+        "Should have logs from step1 execution"
+    );
+
+    let step1_started_log = step1_logs
+        .iter()
+        .find(|log| {
+            log.get("message")
+                .and_then(|m| m.as_str())
+                .map(|m| m == "Step started")
+                .unwrap_or(false)
+        })
+        .expect("Could not find 'Step started' log for step1");
+
+    let step1_diags = step1_started_log
+        .get("diags")
+        .expect("Should have diags for step");
+    assert!(
+        step1_diags.get("trace_id").is_some(),
+        "Should have trace_id in step"
+    );
+    assert!(
+        step1_diags.get("span_id").is_some(),
+        "Should have span_id in step"
+    );
+    assert_eq!(
+        step1_diags.get("run_id").and_then(|v| v.as_str()),
+        Some("run-12345"),
+        "Should have run_id in step"
+    );
+    assert_eq!(
+        step1_diags.get("step_id").and_then(|v| v.as_str()),
+        Some("step1"),
+        "Should have step_id='step1' in step"
+    );
+
+    // Test 5: Verify step2 has same trace_id, same run_id, but different step_id and span_id
+    let step2_logs: Vec<_> = logs
+        .iter()
+        .filter(|log| {
+            log.get("diags")
+                .and_then(|d| d.get("step_id"))
+                .and_then(|s| s.as_str())
+                == Some("step2")
+        })
+        .collect();
+
+    assert!(
+        !step2_logs.is_empty(),
+        "Should have logs from step2 execution"
+    );
+
+    let step2_started_log = step2_logs
+        .iter()
+        .find(|log| {
+            log.get("message")
+                .and_then(|m| m.as_str())
+                .map(|m| m == "Step started")
+                .unwrap_or(false)
+        })
+        .expect("Could not find 'Step started' log for step2");
+
+    let step2_diags = step2_started_log.get("diags").expect("Should have diags");
+
+    // Same trace_id across all steps in the workflow
+    assert_eq!(
+        step1_diags.get("trace_id"),
+        step2_diags.get("trace_id"),
+        "trace_id should be the same across steps (same workflow trace)"
+    );
+
+    // Same run_id across all steps in the workflow
+    assert_eq!(
+        step2_diags.get("run_id").and_then(|v| v.as_str()),
+        Some("run-12345"),
+        "run_id should persist across steps"
+    );
+
+    // Different step_id for different steps
+    assert_eq!(
+        step2_diags.get("step_id").and_then(|v| v.as_str()),
+        Some("step2"),
+        "Should have step_id='step2' in second step"
+    );
+
+    // Different span_id for different steps (each step has its own span)
+    assert_ne!(
+        step1_diags.get("span_id"),
+        step2_diags.get("span_id"),
+        "span_id should be different for different steps"
+    );
+
+    // Test 5b: Verify all logs within step1 share the same span_id (if there are multiple)
+    let step1_span_ids: Vec<_> = step1_logs
+        .iter()
+        .filter_map(|log| {
+            log.get("diags")
+                .and_then(|d| d.get("span_id"))
+                .and_then(|s| s.as_str())
+        })
+        .collect();
+
+    if step1_span_ids.len() > 1 {
+        assert!(
+            step1_span_ids.iter().all(|&id| id == step1_span_ids[0]),
+            "All logs within step1 should share the same span_id"
+        );
+    }
+
+    // Test 6: Log after span closed but run_id still active
+    let after_span_log = logs
+        .iter()
+        .find(|log| {
+            log.get("message")
+                .and_then(|m| m.as_str())
+                .map(|m| m.contains("After trace span closed"))
+                .unwrap_or(false)
+        })
+        .expect("Could not find 'After trace span closed' log");
+
+    let diags = after_span_log
+        .get("diags")
+        .expect("Should have diags after span");
+    assert!(
+        diags.get("trace_id").is_none(),
+        "Should not have trace_id after span closes"
+    );
+    assert_eq!(
+        diags.get("run_id").and_then(|v| v.as_str()),
+        Some("run-12345"),
+        "run_id should persist after span closes"
+    );
+    assert!(
+        diags.get("step_id").is_none(),
+        "step_id should be cleared after steps"
+    );
+
+    // Test 7: Log after run_id cleared
+    let no_run_log = logs
+        .iter()
+        .find(|log| {
+            log.get("message")
+                .and_then(|m| m.as_str())
+                .map(|m| m.contains("After run_id cleared"))
+                .unwrap_or(false)
+        })
+        .expect("Could not find 'After run_id cleared' log");
+
+    let diags = no_run_log.get("diags");
+    assert!(
+        diags.is_none() || diags.unwrap().as_object().unwrap().is_empty(),
+        "Should have no diagnostic context after all guards dropped"
+    );
+}

--- a/stepflow-rs/deny.toml
+++ b/stepflow-rs/deny.toml
@@ -106,7 +106,7 @@ allow = [
     "BSL-1.0",                         # OSI approved
     "Zlib",                            # OSI approved
     "CDLA-Permissive-2.0",
-
+    "MPL-2.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
This commit introduces a new observability infrastructure crate that provides unified logging and distributed tracing capabilities for Stepflow.

**Core Features:**
- Unified logging via the `log` crate with automatic trace context injection
- Distributed tracing via `fastrace` with zero-cost abstraction
- OpenTelemetry support for exporting traces and logs
- Multiple output formats (JSON/text) and destinations (stdout/file/OTLP)
- Automatic injection of trace_id and span_id into all log records

**Key Components:**

1. **ObservabilityConfig**: Flexible configuration for logging and tracing
   - Log level filtering
   - Multiple output formats (JSON/text)
   - Multiple destinations (stdout/file/OpenTelemetry)
   - Per-binary configuration flags
   - Service name and OTLP endpoint configuration

2. **RunDiagnosticContext**: Workflow-specific diagnostic context
   - Thread-local storage for run_id and step_id
   - RAII guards (RunIdGuard, StepIdGuard) for automatic context management
   - Automatic injection into logs alongside trace context
   - Enables filtering all logs for a specific workflow execution

3. **BinaryObservabilityConfig**: Binary-specific configuration
   - `include_run_diagnostic` flag for workflow-executing binaries
   - Allows non-workflow binaries to opt out of run diagnostic overhead

**Integration:**
- Uses `logforth` for flexible log routing with custom diagnostics
- Uses `fastrace` for zero-cost distributed tracing
- Automatic trace context propagation to all log records
- OpenTelemetry-compatible for integration with observability platforms

This closes #383.