### PR TITLE
test: add comprehensive file input tests for document QA

### DIFF
--- a/integrations/langflow/uv.lock
+++ b/integrations/langflow/uv.lock
@@ -9060,7 +9060,7 @@ dev = [
 
 [[package]]
 name = "stepflow-py"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../../sdks/python" }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
Add two new integration tests to verify file input support:

1. test_document_qa_file_via_tweaks: Demonstrates passing file paths via the tweaks parameter instead of workflow input, allowing runtime file configuration without modifying input data.

2. test_document_qa_with_txt_file: Verifies .txt file support in addition to .md files, confirming text file parsing works correctly.

Both file input methods now have test coverage:
- Via workflow input: input_data={"file_path": "/path/to/file"}
- Via tweaks: tweaks={"File-b2gOG": {"path": ["/path/to/file"]}}

The existing file input implementation already supports both single files and lists of files through the FileInput field's list capability.

Closes #382