### PR TITLE
feat: switch to uuid v7

### DIFF
--- a/stepflow-rs/Cargo.toml
+++ b/stepflow-rs/Cargo.toml
@@ -89,7 +89,7 @@ url = { version = "2.5.4", features = ["serde"]}
 utoipa = { version = "5.3", features = ["axum_extras", "chrono", "indexmap", "rc_schema", "url", "uuid"] }
 utoipa-axum = "0.2"
 utoipa-swagger-ui = { version = "9.0", features = ["axum"] }
-uuid = { version = "1.16.0", features = ["v4", "serde"]}
+uuid = { version = "1.16.0", features = ["v7", "serde"]}
 walkdir = "2.5.0"
 which = { version = "7.0.3", features = ["tracing"] }
 strum = { version = "0.26", features = ["derive"] }

--- a/stepflow-rs/crates/stepflow-builtins/src/mock_context.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/mock_context.rs
@@ -42,7 +42,7 @@ impl MockContext {
     pub fn execution_context(&self) -> ExecutionContext {
         ExecutionContext::new(
             self.executor.clone(),
-            Uuid::new_v4(),
+            Uuid::now_v7(),
             Some("test_step".to_string()),
         )
     }
@@ -72,7 +72,7 @@ impl stepflow_plugin::Context for MockExecutor {
         &self,
         _params: stepflow_core::SubmitFlowParams,
     ) -> Pin<Box<dyn std::future::Future<Output = stepflow_plugin::Result<Uuid>> + Send + '_>> {
-        Box::pin(async { Ok(Uuid::new_v4()) })
+        Box::pin(async { Ok(Uuid::now_v7()) })
     }
 
     fn flow_result(
@@ -100,7 +100,7 @@ impl stepflow_plugin::Context for MockExecutor {
     ) -> Pin<Box<dyn std::future::Future<Output = stepflow_plugin::Result<Uuid>> + Send + '_>> {
         let batches = self.batches.clone();
         Box::pin(async move {
-            let batch_id = Uuid::new_v4();
+            let batch_id = Uuid::now_v7();
             batches.lock().unwrap().insert(
                 batch_id,
                 MockBatch {

--- a/stepflow-rs/crates/stepflow-cli/src/repl.rs
+++ b/stepflow-rs/crates/stepflow-cli/src/repl.rs
@@ -78,7 +78,7 @@ impl LastRun {
         executor: &Arc<StepflowExecutor>,
     ) -> Result<&mut WorkflowExecutor> {
         let state_store = executor.state_store();
-        let run_id = uuid::Uuid::new_v4();
+        let run_id = uuid::Uuid::now_v7();
         let workflow_executor = WorkflowExecutor::new(
             executor.clone(),
             self.flow.clone(),

--- a/stepflow-rs/crates/stepflow-components-mcp/tests/integration_test.rs
+++ b/stepflow-rs/crates/stepflow-components-mcp/tests/integration_test.rs
@@ -33,7 +33,7 @@ fn create_test_context() -> (Arc<dyn stepflow_plugin::Context>, ExecutionContext
             &self,
             _params: stepflow_core::SubmitFlowParams,
         ) -> futures::future::BoxFuture<'_, stepflow_plugin::Result<uuid::Uuid>> {
-            async move { Ok(Uuid::new_v4()) }.boxed()
+            async move { Ok(Uuid::now_v7()) }.boxed()
         }
         fn flow_result(
             &self,
@@ -51,7 +51,7 @@ fn create_test_context() -> (Arc<dyn stepflow_plugin::Context>, ExecutionContext
             &self,
             _params: stepflow_core::SubmitBatchParams,
         ) -> futures::future::BoxFuture<'_, stepflow_plugin::Result<uuid::Uuid>> {
-            async move { Ok(Uuid::new_v4()) }.boxed()
+            async move { Ok(Uuid::now_v7()) }.boxed()
         }
         fn get_batch(
             &self,
@@ -78,7 +78,7 @@ fn create_test_context() -> (Arc<dyn stepflow_plugin::Context>, ExecutionContext
     });
     let exec_context = ExecutionContext::new(
         test_context.clone(),
-        Uuid::new_v4(),
+        Uuid::now_v7(),
         Some("test_step".to_string()),
     );
 

--- a/stepflow-rs/crates/stepflow-core/src/values/value_resolver.rs
+++ b/stepflow-rs/crates/stepflow-core/src/values/value_resolver.rs
@@ -410,7 +410,7 @@ mod tests {
     async fn test_resolve_template() {
         let workflow_input = ValueRef::new(json!({"name": "Alice"}));
         let loader = MockValueLoader::new(workflow_input.clone());
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
         let flow = create_test_flow();
 
         let resolver = ValueResolver::new(run_id, workflow_input, loader, flow);
@@ -430,7 +430,7 @@ mod tests {
     async fn test_resolve_variable() {
         let workflow_input = ValueRef::new(json!({}));
         let loader = MockValueLoader::new(workflow_input.clone());
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
 
         // Create flow with variables schema
         let variables_schema_json = json!({
@@ -509,7 +509,7 @@ mod tests {
     async fn test_resolve_undefined_variable() {
         let workflow_input = ValueRef::new(json!({}));
         let loader = MockValueLoader::new(workflow_input.clone());
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
         let flow = create_test_flow(); // Flow without variables
 
         let resolver = ValueResolver::new(run_id, workflow_input, loader, flow);
@@ -570,7 +570,7 @@ mod tests {
         );
         variables.insert("username".to_string(), ValueRef::new(json!("alice")));
 
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
         let workflow_input = ValueRef::new(json!({}));
         let loader = MockValueLoader::new(workflow_input.clone());
 
@@ -625,7 +625,7 @@ mod tests {
     async fn test_resolve_variable_with_path() {
         let workflow_input = ValueRef::new(json!({}));
         let loader = MockValueLoader::new(workflow_input.clone());
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
         let flow = create_test_flow();
 
         // Set up variables with nested object

--- a/stepflow-rs/crates/stepflow-execution/src/executor.rs
+++ b/stepflow-rs/crates/stepflow-execution/src/executor.rs
@@ -180,7 +180,7 @@ impl Context for StepflowExecutor {
         let executor = self.executor();
 
         async move {
-            let run_id = Uuid::new_v4();
+            let run_id = Uuid::now_v7();
 
             // Ensure the flow is stored as a blob (idempotent operation)
             let flow_value = ValueRef::new(serde_json::to_value(params.flow.as_ref()).unwrap());
@@ -214,7 +214,7 @@ impl Context for StepflowExecutor {
                 // - trace_id represents the distributed trace tree, not business ID
                 let span_context = params.parent_context.unwrap_or_else(|| {
                     // Generate fresh trace_id for new trace
-                    SpanContext::new(TraceId(Uuid::new_v4().as_u128()), SpanId::default())
+                    SpanContext::new(TraceId(Uuid::now_v7().as_u128()), SpanId::default())
                 });
 
                 let span = Span::root("flow_execution", span_context)
@@ -328,7 +328,7 @@ impl Context for StepflowExecutor {
         let executor = self.executor();
 
         async move {
-            let batch_id = Uuid::new_v4();
+            let batch_id = Uuid::now_v7();
             let state_store = executor.state_store();
 
             let total_runs = params.inputs.len();
@@ -348,7 +348,7 @@ impl Context for StepflowExecutor {
             // Create run records and collect (run_id, input, index) tuples
             let mut run_inputs = Vec::with_capacity(total_runs);
             for (idx, input) in params.inputs.into_iter().enumerate() {
-                let run_id = Uuid::new_v4();
+                let run_id = Uuid::now_v7();
 
                 // Create run record
                 let mut run_params = stepflow_state::CreateRunParams::new(
@@ -389,7 +389,7 @@ impl Context for StepflowExecutor {
                 // Design: Always use unique trace_id, store batch_id as span attribute
                 let batch_span_context = params.parent_context.unwrap_or_else(|| {
                     // Generate fresh trace_id for new trace
-                    SpanContext::new(TraceId(Uuid::new_v4().as_u128()), SpanId::default())
+                    SpanContext::new(TraceId(Uuid::now_v7().as_u128()), SpanId::default())
                 });
 
                 let _batch_span = Span::root("batch_execution", batch_span_context)

--- a/stepflow-rs/crates/stepflow-execution/src/workflow_executor.rs
+++ b/stepflow-rs/crates/stepflow-execution/src/workflow_executor.rs
@@ -1205,7 +1205,7 @@ mod tests {
     ) -> Result<FlowResult> {
         let (executor, flow, flow_id) =
             create_workflow_from_yaml_simple(yaml_str, mock_behaviors).await;
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
         let state_store: Arc<dyn StateStore> = Arc::new(InMemoryStateStore::new());
         let input_ref = ValueRef::new(input);
 
@@ -1229,7 +1229,7 @@ mod tests {
     ) -> Result<WorkflowExecutor> {
         let (executor, flow, flow_id) =
             create_workflow_from_yaml_simple(yaml_str, mock_behaviors).await;
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
         let state_store: Arc<dyn StateStore> = Arc::new(InMemoryStateStore::new());
         let input_ref = ValueRef::new(input);
 
@@ -1466,7 +1466,7 @@ output:
         let workflow: Arc<Flow> = Arc::new(serde_yaml_ng::from_str(workflow_yaml).unwrap());
         let flow_id = BlobId::from_flow(&workflow).unwrap();
         let executor = StepflowExecutor::new_in_memory();
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
         let input = ValueRef::new(json!({}));
 
         // Create a workflow executor
@@ -1562,7 +1562,7 @@ output:
         let workflow: Arc<Flow> = Arc::new(serde_yaml_ng::from_str(workflow_yaml).unwrap());
         let flow_id = BlobId::from_flow(&workflow).unwrap();
         let executor = StepflowExecutor::new_in_memory();
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
         let input = ValueRef::new(json!({}));
 
         let workflow_executor = WorkflowExecutor::new(
@@ -1659,7 +1659,7 @@ output:
         let workflow: Arc<Flow> = Arc::new(serde_yaml_ng::from_str(workflow_yaml).unwrap());
         let flow_id = BlobId::from_flow(&workflow).unwrap();
         let executor = StepflowExecutor::new_in_memory();
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
         let input = ValueRef::new(json!({}));
 
         let mut workflow_executor = WorkflowExecutor::new(
@@ -1740,7 +1740,7 @@ output:
         let workflow: Arc<Flow> = Arc::new(serde_yaml_ng::from_str(workflow_yaml).unwrap());
         let flow_id = BlobId::from_flow(&workflow).unwrap();
         let executor = StepflowExecutor::new_in_memory();
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
         let input = ValueRef::new(json!({}));
 
         let mut workflow_executor = WorkflowExecutor::new(

--- a/stepflow-rs/crates/stepflow-protocol/src/http/client.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/http/client.rs
@@ -508,7 +508,7 @@ mod tests {
             &self,
             _params: stepflow_core::SubmitFlowParams,
         ) -> BoxFuture<'_, PluginResult<Uuid>> {
-            async { Ok(Uuid::new_v4()) }.boxed()
+            async { Ok(Uuid::now_v7()) }.boxed()
         }
 
         fn flow_result(&self, _run_id: Uuid) -> BoxFuture<'_, PluginResult<FlowResult>> {
@@ -527,7 +527,7 @@ mod tests {
             &self,
             _params: stepflow_core::SubmitBatchParams,
         ) -> BoxFuture<'_, PluginResult<Uuid>> {
-            async { Ok(Uuid::new_v4()) }.boxed()
+            async { Ok(Uuid::now_v7()) }.boxed()
         }
 
         fn get_batch(
@@ -550,7 +550,7 @@ mod tests {
                 .unwrap();
                 let batch_details = stepflow_state::BatchDetails {
                     metadata: stepflow_state::BatchMetadata {
-                        batch_id: Uuid::new_v4(),
+                        batch_id: Uuid::now_v7(),
                         flow_id: dummy_flow_id,
                         flow_name: None,
                         total_inputs: 0,

--- a/stepflow-rs/crates/stepflow-protocol/src/protocol/messages.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/protocol/messages.rs
@@ -83,7 +83,7 @@ impl std::fmt::Display for RequestId {
 impl RequestId {
     /// Generate a new RequestId using a UUID string.
     pub fn new_uuid() -> Self {
-        RequestId::from(uuid::Uuid::new_v4())
+        RequestId::from(uuid::Uuid::now_v7())
     }
 }
 

--- a/stepflow-rs/crates/stepflow-protocol/tests/http_integration_test.rs
+++ b/stepflow-rs/crates/stepflow-protocol/tests/http_integration_test.rs
@@ -226,7 +226,7 @@ async fn test_http_protocol_integration() {
 
                                 let execution_context = ExecutionContext::for_step(
                                     context.clone(),
-                                    Uuid::new_v4(),
+                                    Uuid::now_v7(),
                                     "test_step".to_string(),
                                 );
 

--- a/stepflow-rs/crates/stepflow-server/src/api/health.rs
+++ b/stepflow-rs/crates/stepflow-server/src/api/health.rs
@@ -58,7 +58,7 @@ pub async fn health_check(
                 use error_stack::report;
                 let backtrace = std::backtrace::Backtrace::capture();
                 Err(
-                    report!(ServerError::ExecutionNotFound(uuid::Uuid::new_v4()))
+                    report!(ServerError::ExecutionNotFound(uuid::Uuid::now_v7()))
                         .attach(backtrace)
                         .change_context(std::io::Error::new(
                             std::io::ErrorKind::InvalidInput,
@@ -72,7 +72,7 @@ pub async fn health_check(
             }
             "not_found" => {
                 use error_stack::report;
-                let test_id = uuid::Uuid::new_v4();
+                let test_id = uuid::Uuid::now_v7();
                 Err(report!(ServerError::ExecutionNotFound(test_id))
                     .attach_printable("Test execution not found")
                     .attach_printable(format!("Looking for execution: {}", test_id))
@@ -91,7 +91,7 @@ pub async fn health_check(
                     std::io::ErrorKind::ConnectionRefused,
                     "State store unavailable",
                 ))
-                .change_context(ServerError::ExecutionNotFound(uuid::Uuid::new_v4()))
+                .change_context(ServerError::ExecutionNotFound(uuid::Uuid::now_v7()))
                 .attach_printable("Complex error stack for testing")
                 .attach_printable("Bottom layer: Database permission denied")
                 .attach_printable("Middle layer: Connection refused")

--- a/stepflow-rs/crates/stepflow-server/src/api/runs.rs
+++ b/stepflow-rs/crates/stepflow-server/src/api/runs.rs
@@ -125,7 +125,7 @@ pub async fn create_run(
     State(executor): State<Arc<StepflowExecutor>>,
     Json(req): Json<CreateRunRequest>,
 ) -> Result<Json<CreateRunResponse>, ErrorResponse> {
-    let run_id = Uuid::new_v4();
+    let run_id = Uuid::now_v7();
     let state_store = executor.state_store();
 
     // Get the flow from the state store

--- a/stepflow-rs/crates/stepflow-state-sql/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-state-sql/src/lib.rs
@@ -53,7 +53,7 @@ mod tests {
     #[tokio::test]
     async fn test_step_result_storage() {
         let store = SqliteStateStore::in_memory().await.unwrap();
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
 
         // First store a workflow
         let flow = FlowBuilder::new()

--- a/stepflow-rs/crates/stepflow-state/src/in_memory.rs
+++ b/stepflow-rs/crates/stepflow-state/src/in_memory.rs
@@ -1047,7 +1047,7 @@ mod tests {
         use stepflow_core::workflow::ValueRef;
 
         let store = InMemoryStateStore::new();
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
 
         // Test data
         let step1_result =
@@ -1075,7 +1075,7 @@ mod tests {
         assert!(result_by_idx.is_err());
 
         // Different execution ID should return empty list
-        let other_run_id = Uuid::new_v4();
+        let other_run_id = Uuid::now_v7();
         let other_results = store.list_step_results(other_run_id).await.unwrap();
         assert!(other_results.is_empty());
     }
@@ -1085,7 +1085,7 @@ mod tests {
         use stepflow_core::workflow::ValueRef;
 
         let store = InMemoryStateStore::new();
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
 
         // Record initial result
         let initial_result = FlowResult::Success(ValueRef::new(serde_json::json!({"attempt":1})));
@@ -1109,7 +1109,7 @@ mod tests {
     #[tokio::test]
     async fn test_step_result_ordering() {
         let store = InMemoryStateStore::new();
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
 
         // Insert steps out of order to test ordering
         let step2_result = FlowResult::Success(ValueRef::new(serde_json::json!({"step":2})));
@@ -1132,7 +1132,7 @@ mod tests {
     #[tokio::test]
     async fn test_execution_eviction() {
         let store = InMemoryStateStore::new();
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
 
         // Store some step results
         let step_result = FlowResult::Success(ValueRef::new(serde_json::json!({"output":"test"})));
@@ -1159,7 +1159,7 @@ mod tests {
         use crate::StateStore as _;
 
         let store = InMemoryStateStore::new();
-        let batch_id = Uuid::new_v4();
+        let batch_id = Uuid::now_v7();
         let flow_id = BlobId::new("a".repeat(64)).unwrap();
 
         // Create batch
@@ -1185,7 +1185,7 @@ mod tests {
         use crate::StateStore as _;
 
         let store = InMemoryStateStore::new();
-        let batch_id = Uuid::new_v4();
+        let batch_id = Uuid::now_v7();
         let flow_id = BlobId::new("a".repeat(64)).unwrap();
 
         // Create batch
@@ -1195,7 +1195,7 @@ mod tests {
             .unwrap();
 
         // Create some runs and add them to the batch
-        let run_ids: Vec<Uuid> = (0..3).map(|_| Uuid::new_v4()).collect();
+        let run_ids: Vec<Uuid> = (0..3).map(|_| Uuid::now_v7()).collect();
 
         for (idx, run_id) in run_ids.iter().enumerate() {
             // Create run
@@ -1248,7 +1248,7 @@ mod tests {
         use crate::StateStore as _;
 
         let store = InMemoryStateStore::new();
-        let batch_id = Uuid::new_v4();
+        let batch_id = Uuid::now_v7();
         let flow_id = BlobId::new("a".repeat(64)).unwrap();
 
         // Create batch
@@ -1258,7 +1258,7 @@ mod tests {
             .unwrap();
 
         // Create runs with different statuses
-        let run_ids: Vec<Uuid> = (0..5).map(|_| Uuid::new_v4()).collect();
+        let run_ids: Vec<Uuid> = (0..5).map(|_| Uuid::now_v7()).collect();
         let statuses = [
             ExecutionStatus::Completed,
             ExecutionStatus::Running,
@@ -1310,7 +1310,7 @@ mod tests {
         use crate::StateStore as _;
 
         let store = InMemoryStateStore::new();
-        let batch_id = Uuid::new_v4();
+        let batch_id = Uuid::now_v7();
         let flow_id = BlobId::new("a".repeat(64)).unwrap();
 
         // Create batch
@@ -1342,7 +1342,7 @@ mod tests {
         let flow_id = BlobId::new("a".repeat(64)).unwrap();
 
         // Create multiple batches
-        let batch_ids: Vec<Uuid> = (0..5).map(|_| Uuid::new_v4()).collect();
+        let batch_ids: Vec<Uuid> = (0..5).map(|_| Uuid::now_v7()).collect();
 
         // Create batches with different statuses and names
         for (idx, batch_id) in batch_ids.iter().enumerate() {
@@ -1418,7 +1418,7 @@ mod tests {
         use crate::StateStore as _;
 
         let store = InMemoryStateStore::new();
-        let batch_id = Uuid::new_v4();
+        let batch_id = Uuid::now_v7();
         let flow_id = BlobId::new("a".repeat(64)).unwrap();
 
         // Create batch
@@ -1428,7 +1428,7 @@ mod tests {
             .unwrap();
 
         // Create runs with different statuses
-        let run_ids: Vec<Uuid> = (0..5).map(|_| Uuid::new_v4()).collect();
+        let run_ids: Vec<Uuid> = (0..5).map(|_| Uuid::now_v7()).collect();
 
         for (idx, run_id) in run_ids.iter().enumerate() {
             store

--- a/stepflow-rs/crates/stepflow-state/src/state_store.rs
+++ b/stepflow-rs/crates/stepflow-state/src/state_store.rs
@@ -781,7 +781,7 @@ mod tests {
     #[test]
     fn test_run_details_serde_flatten() {
         let now = chrono::Utc::now();
-        let run_id = Uuid::new_v4();
+        let run_id = Uuid::now_v7();
         let flow_id = BlobId::new("a".repeat(64)).unwrap();
 
         let details = RunDetails {


### PR DESCRIPTION
This mainly affects the creation of Run IDs and Batch IDs. Assigning them using UUID v7 means they can be sorted by order of creation. This is useful for cases where we wish to delete or compact information about old runs by allowing us to scan the oldest runs first.