### PR TITLE
feat: Add RunContext for run-scoped bidirectional communication

### DIFF
--- a/stepflow-rs/crates/stepflow-plugin/src/context.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/context.rs
@@ -20,6 +20,44 @@ use stepflow_core::{
 use stepflow_state::{RunStatus, StateStore};
 use uuid::Uuid;
 
+/// Run hierarchy context for execution.
+///
+/// This captures the run tree context for a component execution,
+/// allowing bidirectional message handlers to know which run tree
+/// they're serving.
+#[derive(Debug, Clone)]
+pub struct RunContext {
+    /// The current run ID.
+    pub run_id: Uuid,
+    /// The root run ID for this execution tree.
+    ///
+    /// For top-level runs, this equals `run_id`.
+    /// For sub-flows, this is the original run that started the tree.
+    pub root_run_id: Uuid,
+}
+
+impl RunContext {
+    /// Create a new RunContext for a root (top-level) run.
+    ///
+    /// Sets `root_run_id` equal to `run_id`.
+    pub fn for_root(run_id: Uuid) -> Self {
+        Self {
+            run_id,
+            root_run_id: run_id,
+        }
+    }
+
+    /// Create a new RunContext for a sub-flow within an existing run tree.
+    ///
+    /// The `root_run_id` is inherited from the parent context.
+    pub fn for_subflow(&self, run_id: Uuid) -> Self {
+        Self {
+            run_id,
+            root_run_id: self.root_run_id,
+        }
+    }
+}
+
 /// Trait for interacting with the workflow runtime.
 pub trait Context: Send + Sync {
     /// Submit a run with 1 or N items.

--- a/stepflow-rs/crates/stepflow-plugin/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/lib.rs
@@ -15,6 +15,6 @@ mod error;
 mod plugin;
 pub mod routing;
 
-pub use context::{Context, ExecutionContext};
+pub use context::{Context, ExecutionContext, RunContext};
 pub use error::{PluginError, Result};
 pub use plugin::{DynPlugin, Plugin, PluginConfig};

--- a/stepflow-rs/crates/stepflow-protocol/src/handlers/blob_handlers.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/handlers/blob_handlers.rs
@@ -12,7 +12,7 @@
 
 use futures::future::{BoxFuture, FutureExt as _};
 use std::sync::Arc;
-use stepflow_plugin::Context;
+use stepflow_plugin::{Context, RunContext};
 use tokio::sync::mpsc;
 
 use super::handle_method_call;
@@ -29,6 +29,7 @@ impl MethodHandler for PutBlobHandler {
         request: &'a MethodRequest<'a>,
         response_tx: mpsc::Sender<String>,
         context: Arc<dyn Context>,
+        _run_context: Option<&'a Arc<RunContext>>,
     ) -> BoxFuture<'a, error_stack::Result<(), TransportError>> {
         handle_method_call(
             request,
@@ -58,6 +59,7 @@ impl MethodHandler for GetBlobHandler {
         request: &'a MethodRequest<'a>,
         response_tx: mpsc::Sender<String>,
         context: Arc<dyn Context>,
+        _run_context: Option<&'a Arc<RunContext>>,
     ) -> BoxFuture<'a, error_stack::Result<(), TransportError>> {
         handle_method_call(
             request,

--- a/stepflow-rs/crates/stepflow-protocol/src/handlers/flow_handlers.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/handlers/flow_handlers.rs
@@ -13,7 +13,7 @@
 use futures::future::{BoxFuture, FutureExt as _};
 use std::sync::Arc;
 use stepflow_core::GetRunOptions;
-use stepflow_plugin::Context;
+use stepflow_plugin::{Context, RunContext};
 use tokio::sync::mpsc;
 
 use crate::error::TransportError;
@@ -33,6 +33,7 @@ impl MethodHandler for SubmitRunHandler {
         request: &'a MethodRequest<'a>,
         response_tx: mpsc::Sender<String>,
         context: Arc<dyn Context>,
+        _run_context: Option<&'a Arc<RunContext>>,
     ) -> BoxFuture<'a, error_stack::Result<(), TransportError>> {
         handle_method_call(
             request,
@@ -79,6 +80,7 @@ impl MethodHandler for GetRunHandler {
         request: &'a MethodRequest<'a>,
         response_tx: mpsc::Sender<String>,
         context: Arc<dyn Context>,
+        _run_context: Option<&'a Arc<RunContext>>,
     ) -> BoxFuture<'a, error_stack::Result<(), TransportError>> {
         handle_method_call(
             request,

--- a/stepflow-rs/crates/stepflow-protocol/src/handlers/message_handler.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/handlers/message_handler.rs
@@ -13,7 +13,7 @@
 use futures::future::BoxFuture;
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
-use stepflow_plugin::Context;
+use stepflow_plugin::{Context, RunContext};
 use tokio::sync::mpsc;
 
 use super::blob_handlers::{GetBlobHandler, PutBlobHandler};
@@ -31,6 +31,9 @@ pub trait MethodHandler: Send + Sync {
     /// # Arguments
     /// * `request` - The method request to handle
     /// * `outgoing_tx` - Channel to send messages back to the component server
+    /// * `context` - The execution context (state store, etc.)
+    /// * `run_context` - Optional run context with run_id and root_run_id.
+    ///   Present during component execution, None for non-execution calls.
     ///
     /// # Returns
     /// Result indicating if the handling was successful
@@ -39,6 +42,7 @@ pub trait MethodHandler: Send + Sync {
         request: &'a MethodRequest<'a>,
         outgoing_tx: mpsc::Sender<String>,
         context: Arc<dyn Context>,
+        run_context: Option<&'a Arc<RunContext>>,
     ) -> BoxFuture<'a, error_stack::Result<(), TransportError>>;
 }
 


### PR DESCRIPTION
Add RunContext struct to track run hierarchy (run_id, root_run_id) and pass it through HTTP client method calls so bidirectional message handlers know which run tree they're serving.

Changes:
- Add RunContext with for_root() and for_subflow() constructors
- Update HttpClientHandle::method() to take Option<Arc<RunContext>>
- BidirectionalDriver requires RunContext for SSE mode
- MethodHandler trait receives Option<&Arc<RunContext>>
- StepflowPlugin::execute() builds and passes RunContext

This sets up infrastructure for future sub-flow routing where handlers can use root_run_id to route requests to the correct executor.