### PR TITLE
refactor: Use StepId and DTOs uniformly

### DIFF
--- a/stepflow-rs/crates/stepflow-core/src/workflow/step_id.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow/step_id.rs
@@ -12,67 +12,350 @@
 
 use std::sync::Arc;
 
+use serde::{Deserialize, Serialize};
+
 use crate::workflow::Flow;
 
-/// A step identifier that combines the step index with a reference to the flow.
-/// This allows efficient lookup using the index while maintaining access to
-/// the step ID string and other step metadata through the flow reference.
+/// A step identifier that provides access to both the step index and name.
 ///
-/// NOTE: Using this will keep the Flow alive.
+/// This type has two variants:
+/// - `WithFlow`: Used during execution when you have access to the flow.
+///   More efficient as it doesn't allocate for the name string.
+/// - `Standalone`: Used in storage/serialization contexts where the flow
+///   isn't available.
+///
+/// # Choosing a Constructor
+///
+/// When you have access to `Arc<Flow>`, prefer [`StepId::for_step()`] as it
+/// avoids allocating a string for the step name. Use [`StepId::new()`] only
+/// when the flow reference is not available (e.g., deserializing from storage).
+///
+/// # Note on Flow Lifetime
+///
+/// The `WithFlow` variant keeps the `Arc<Flow>` alive. If you need to store
+/// a `StepId` without keeping the flow alive, use [`StepId::into_standalone()`]
+/// or [`StepId::to_standalone()`].
 #[derive(Clone)]
-pub struct StepId {
-    /// Reference to the flow containing this step
-    pub flow: Arc<Flow>,
-    /// The step index in the workflow
-    pub index: usize,
+pub enum StepId {
+    /// Step with flow reference - borrows name from flow, no allocation.
+    WithFlow {
+        /// Reference to the flow containing this step.
+        flow: Arc<Flow>,
+        /// The step index in the workflow.
+        index: usize,
+    },
+    /// Standalone step - owns the name string.
+    Standalone {
+        /// The step name/ID.
+        name: String,
+        /// The step index in the workflow.
+        index: usize,
+    },
 }
 
 impl StepId {
+    /// Create a StepId from a flow reference.
+    ///
+    /// This is the preferred constructor when you have access to `Arc<Flow>`
+    /// as it avoids allocating a string for the step name.
     pub fn for_step(flow: Arc<Flow>, index: usize) -> Self {
-        Self { flow, index }
+        Self::WithFlow { flow, index }
+    }
+
+    /// Create a standalone StepId without a flow reference.
+    ///
+    /// Use this only when the flow reference is not available, such as when
+    /// deserializing from storage. If you have access to `Arc<Flow>`, prefer
+    /// [`StepId::for_step()`] instead to avoid the string allocation.
+    pub fn new(name: String, index: usize) -> Self {
+        Self::Standalone { name, index }
+    }
+
+    /// Get the step index.
+    pub fn index(&self) -> usize {
+        match self {
+            Self::WithFlow { index, .. } => *index,
+            Self::Standalone { index, .. } => *index,
+        }
+    }
+
+    /// Get the step name.
+    pub fn name(&self) -> &str {
+        match self {
+            Self::WithFlow { flow, index } => &flow.steps[*index].id,
+            Self::Standalone { name, .. } => name,
+        }
+    }
+
+    /// Convert to a standalone StepId, cloning if necessary.
+    ///
+    /// This releases the flow reference if held. Useful when you need to
+    /// store the StepId without keeping the flow alive, or when serializing.
+    pub fn to_standalone(&self) -> Self {
+        match self {
+            Self::WithFlow { flow, index } => Self::Standalone {
+                name: flow.steps[*index].id.clone(),
+                index: *index,
+            },
+            Self::Standalone { name, index } => Self::Standalone {
+                name: name.clone(),
+                index: *index,
+            },
+        }
+    }
+
+    /// Convert into a standalone StepId, consuming self.
+    ///
+    /// This releases the flow reference if held. More efficient than
+    /// [`to_standalone()`](Self::to_standalone) when you don't need the original.
+    pub fn into_standalone(self) -> Self {
+        match self {
+            Self::WithFlow { flow, index } => Self::Standalone {
+                name: flow.steps[index].id.clone(),
+                index,
+            },
+            standalone @ Self::Standalone { .. } => standalone,
+        }
+    }
+
+    /// Returns true if this StepId holds a flow reference.
+    pub fn has_flow(&self) -> bool {
+        matches!(self, Self::WithFlow { .. })
+    }
+
+    /// Get the flow reference if this is a WithFlow variant.
+    pub fn flow(&self) -> Option<&Arc<Flow>> {
+        match self {
+            Self::WithFlow { flow, .. } => Some(flow),
+            Self::Standalone { .. } => None,
+        }
     }
 }
 
+// Equality is based on index and name, not flow identity.
+// Two StepIds are equal if they refer to the same step (same index and name).
 impl PartialEq for StepId {
     fn eq(&self, other: &Self) -> bool {
-        self.index == other.index && Arc::ptr_eq(&self.flow, &other.flow)
+        self.index() == other.index() && self.name() == other.name()
     }
 }
 
 impl Eq for StepId {}
 
-impl PartialOrd for StepId {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        if Arc::ptr_eq(&self.flow, &other.flow) {
-            Some(self.index.cmp(&other.index))
-        } else {
-            None
-        }
-    }
-}
-
 impl std::hash::Hash for StepId {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.index.hash(state);
-        Arc::as_ptr(&self.flow).hash(state);
+        self.index().hash(state);
+        self.name().hash(state);
     }
 }
 
-impl StepId {
-    /// Get the step name/ID string from the flow
-    pub fn step_name(&self) -> &str {
-        &self.flow.steps[self.index].id
+impl PartialOrd for StepId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for StepId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.index().cmp(&other.index())
     }
 }
 
 impl std::fmt::Display for StepId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.step_name())
+        write!(f, "{}", self.name())
     }
 }
 
 impl std::fmt::Debug for StepId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.step_name())
+        f.debug_struct("StepId")
+            .field("index", &self.index())
+            .field("name", &self.name())
+            .finish()
+    }
+}
+
+// Serialization: Always serialize as the standalone form (index + name).
+// This ensures consistent serialization regardless of which variant is held.
+impl Serialize for StepId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct as _;
+        let mut state = serializer.serialize_struct("StepId", 2)?;
+        state.serialize_field("index", &self.index())?;
+        state.serialize_field("name", &self.name())?;
+        state.end()
+    }
+}
+
+// Deserialization: Always deserialize as Standalone since we don't have a flow.
+impl<'de> Deserialize<'de> for StepId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct StepIdData {
+            index: usize,
+            name: String,
+        }
+
+        let data = StepIdData::deserialize(deserializer)?;
+        Ok(Self::Standalone {
+            name: data.name,
+            index: data.index,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ValueExpr;
+    use crate::workflow::builders::{FlowBuilder, StepBuilder};
+    use serde_json::json;
+
+    fn create_test_flow() -> Arc<Flow> {
+        let step_one = StepBuilder::new("step_one")
+            .component("/builtin/eval")
+            .input_literal(json!({"expression": "1 + 1"}))
+            .build();
+        let step_two = StepBuilder::new("step_two")
+            .component("/builtin/eval")
+            .input_literal(json!({"expression": "2 + 2"}))
+            .build();
+
+        let flow = FlowBuilder::new()
+            .step(step_one)
+            .step(step_two)
+            .output(ValueExpr::step_output("step_two"))
+            .build();
+
+        Arc::new(flow)
+    }
+
+    #[test]
+    fn test_for_step_creation() {
+        let flow = create_test_flow();
+        let step_id = StepId::for_step(flow.clone(), 0);
+
+        assert_eq!(step_id.index(), 0);
+        assert_eq!(step_id.name(), "step_one");
+        assert!(step_id.has_flow());
+    }
+
+    #[test]
+    fn test_standalone_creation() {
+        let step_id = StepId::new("my_step".to_string(), 5);
+
+        assert_eq!(step_id.index(), 5);
+        assert_eq!(step_id.name(), "my_step");
+        assert!(!step_id.has_flow());
+    }
+
+    #[test]
+    fn test_to_standalone() {
+        let flow = create_test_flow();
+        let step_id = StepId::for_step(flow, 1);
+        let standalone = step_id.to_standalone();
+
+        assert_eq!(standalone.index(), 1);
+        assert_eq!(standalone.name(), "step_two");
+        assert!(!standalone.has_flow());
+    }
+
+    #[test]
+    fn test_into_standalone() {
+        let flow = create_test_flow();
+        let step_id = StepId::for_step(flow, 0);
+        let standalone = step_id.into_standalone();
+
+        assert_eq!(standalone.index(), 0);
+        assert_eq!(standalone.name(), "step_one");
+        assert!(!standalone.has_flow());
+    }
+
+    #[test]
+    fn test_equality_across_variants() {
+        let flow = create_test_flow();
+        let with_flow = StepId::for_step(flow, 0);
+        let standalone = StepId::new("step_one".to_string(), 0);
+
+        assert_eq!(with_flow, standalone);
+    }
+
+    #[test]
+    fn test_inequality_different_index() {
+        let step1 = StepId::new("step".to_string(), 0);
+        let step2 = StepId::new("step".to_string(), 1);
+
+        assert_ne!(step1, step2);
+    }
+
+    #[test]
+    fn test_inequality_different_name() {
+        let step1 = StepId::new("step_a".to_string(), 0);
+        let step2 = StepId::new("step_b".to_string(), 0);
+
+        assert_ne!(step1, step2);
+    }
+
+    #[test]
+    fn test_ordering() {
+        let step0 = StepId::new("z".to_string(), 0);
+        let step1 = StepId::new("a".to_string(), 1);
+        let step2 = StepId::new("m".to_string(), 2);
+
+        assert!(step0 < step1);
+        assert!(step1 < step2);
+    }
+
+    #[test]
+    fn test_hash_consistency() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let flow = create_test_flow();
+        let with_flow = StepId::for_step(flow, 0);
+        let standalone = StepId::new("step_one".to_string(), 0);
+
+        let mut hasher1 = DefaultHasher::new();
+        with_flow.hash(&mut hasher1);
+        let hash1 = hasher1.finish();
+
+        let mut hasher2 = DefaultHasher::new();
+        standalone.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
+
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let flow = create_test_flow();
+        let step_id = StepId::for_step(flow, 1);
+
+        let json = serde_json::to_string(&step_id).unwrap();
+        let deserialized: StepId = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(step_id, deserialized);
+        assert!(!deserialized.has_flow()); // Deserialized is always standalone
+    }
+
+    #[test]
+    fn test_display() {
+        let step_id = StepId::new("my_step".to_string(), 3);
+        assert_eq!(format!("{}", step_id), "my_step");
+    }
+
+    #[test]
+    fn test_debug() {
+        let step_id = StepId::new("my_step".to_string(), 3);
+        let debug_str = format!("{:?}", step_id);
+        assert!(debug_str.contains("index: 3"));
+        assert!(debug_str.contains("name: \"my_step\""));
     }
 }

--- a/stepflow-rs/crates/stepflow-execution/src/task.rs
+++ b/stepflow-rs/crates/stepflow-execution/src/task.rs
@@ -154,17 +154,19 @@ mod tests {
 
     #[test]
     fn test_task_result() {
+        use stepflow_core::workflow::StepId;
+
         let run_id = test_run_id();
         let task = Task::new(run_id, 0, 1);
         let result = FlowResult::Success(ValueRef::new(serde_json::json!(42)));
-        let step_result =
-            StepRunResult::new(1, "test_step".to_string(), "/mock/test".to_string(), result);
+        let step_id = StepId::new("test_step".to_string(), 1);
+        let step_result = StepRunResult::new(step_id, "/mock/test".to_string(), result);
         let task_result = TaskResult::new(task, step_result);
 
         assert_eq!(task_result.run_id, run_id);
         assert_eq!(task_result.item_index, 0);
         assert_eq!(task_result.step_index(), 1);
-        assert_eq!(task_result.step.step_id(), "test_step");
+        assert_eq!(task_result.step.step_name(), "test_step");
         assert!(task_result.is_success());
         match task_result.result() {
             FlowResult::Success(v) => assert_eq!(v.as_ref(), &serde_json::json!(42)),

--- a/stepflow-rs/crates/stepflow-plugin/src/context.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/context.rs
@@ -193,12 +193,15 @@ impl ExecutionContext {
 
     /// Get the step name for this context, if available.
     pub fn step_id(&self) -> Option<&str> {
-        self.step.as_ref().map(|s| s.step_name())
+        self.step.as_ref().map(|s| s.name())
     }
 
     /// Get the flow for this context, if available.
     pub fn flow(&self) -> Option<&Arc<Flow>> {
-        self.step.as_ref().map(|s| &s.flow).or(self.flow.as_ref())
+        self.step
+            .as_ref()
+            .and_then(|s| s.flow())
+            .or(self.flow.as_ref())
     }
 
     /// Get the flow ID for this context, if available.

--- a/stepflow-rs/crates/stepflow-server/src/api.rs
+++ b/stepflow-rs/crates/stepflow-server/src/api.rs
@@ -65,7 +65,7 @@ pub use runs::{CreateRunRequest, CreateRunResponse};
         runs::CreateRunResponse,
         runs::ListRunsResponse,
         runs::ListRunsQuery,
-        runs::ItemResult,
+        stepflow_dtos::ItemResult,
         runs::ListItemsResponse,
         stepflow_dtos::RunSummary,
         stepflow_dtos::RunDetails,

--- a/stepflow-rs/crates/stepflow-state-sql/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-state-sql/src/lib.rs
@@ -26,7 +26,7 @@ mod tests {
     use serde_json::json;
     use stepflow_core::workflow::{FlowBuilder, StepBuilder};
     use stepflow_core::{BlobType, FlowResult, ValueExpr, workflow::ValueRef};
-    use stepflow_dtos::StepResult;
+    use stepflow_dtos::{StepId, StepResult};
     use stepflow_state::StateStore as _;
     use uuid::Uuid;
 
@@ -86,7 +86,8 @@ mod tests {
 
         // Create test step result
         let flow_result = FlowResult::Success(ValueRef::new(json!({"result":"success"})));
-        let step_result = StepResult::new(0, "test_step", flow_result.clone());
+        let step_result =
+            StepResult::new(StepId::new("test_step".to_string(), 0), flow_result.clone());
 
         // Store step result
         store
@@ -106,8 +107,8 @@ mod tests {
         // List all results
         let all_results = store.list_step_results(run_id).await.unwrap();
         assert_eq!(all_results.len(), 1);
-        assert_eq!(all_results[0].step_idx(), 0);
-        assert_eq!(all_results[0].step_id(), "test_step");
+        assert_eq!(all_results[0].step_index(), 0);
+        assert_eq!(all_results[0].step_name(), "test_step");
         assert_eq!(*all_results[0].result(), flow_result);
     }
 


### PR DESCRIPTION
Convert StepId from a simple struct holding Arc<Flow> to an enum with two variants:
- `WithFlow`: Used during execution, borrows step name from flow (no allocation)
- `Standalone`: Used in storage/serialization, owns the step name string

This allows StepId to work efficiently in both execution contexts (where the flow is available) and storage/serialization contexts (where only the name and index are available).

Key changes:
- Remove duplicate ItemResult from server API (use stepflow_dtos version)
- StepId now has for_step() (preferred when flow available) and new() constructors
- Update StepResult, StepInfo, StepExecution, StepMetadata to use StepId
- Update state stores and server API to use new accessor methods

This closes #466.