### PR TITLE
fix: Improve check scripts failure handling and reproduce commands

### DIFF
--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -26,6 +26,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Source shared helpers
 source "$SCRIPT_DIR/_lib.sh"
+_LIB_PROJECT_ROOT="$PROJECT_ROOT"
 
 # Parse command line arguments
 parse_flags "$@"

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -27,6 +27,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Source shared helpers
 source "$SCRIPT_DIR/_lib.sh"
+_LIB_PROJECT_ROOT="$PROJECT_ROOT"
 
 # Parse command line arguments
 parse_flags "$@"
@@ -42,12 +43,10 @@ require_tool "pnpm" "npm install -g pnpm"
 # DOCUMENTATION CHECKS
 # =============================================================================
 
-run_check "Dependencies" pnpm install --frozen-lockfile
+run_check "Dependencies" pnpm install --frozen-lockfile || true
 
-run_check "Build" pnpm build
-if [ $? -ne 0 ]; then
+if ! run_check "Build" pnpm build; then
     print_fix "Fix build errors"
-    print_rerun "cd docs && pnpm build"
 fi
 
 # =============================================================================

--- a/scripts/check-licenses.sh
+++ b/scripts/check-licenses.sh
@@ -27,6 +27,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Source shared helpers
 source "$SCRIPT_DIR/_lib.sh"
+_LIB_PROJECT_ROOT="$PROJECT_ROOT"
 
 # Parse command line arguments
 parse_flags "$@"
@@ -42,8 +43,7 @@ require_tool "licensure" "cargo install licensure"
 # LICENSE HEADER CHECKS
 # =============================================================================
 
-run_check "License headers" licensure -c -p
-if [ $? -ne 0 ]; then
+if ! run_check "License headers" licensure -c -p; then
     print_fix "licensure -p --in-place"
 fi
 

--- a/scripts/check-python.sh
+++ b/scripts/check-python.sh
@@ -27,6 +27,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Source shared helpers
 source "$SCRIPT_DIR/_lib.sh"
+_LIB_PROJECT_ROOT="$PROJECT_ROOT"
 
 # Parse command line arguments
 parse_flags "$@"
@@ -42,48 +43,40 @@ require_tool "uv" "curl -LsSf https://astral.sh/uv/install.sh | sh"
 # PYTHON SDK SETUP
 # =============================================================================
 
-run_check "Python install" uv python install
-run_check "Dependencies" uv sync --all-extras --group dev
+run_check "Python install" uv python install || true
+run_check "Dependencies" uv sync --all-extras --group dev || true
 
 # =============================================================================
 # PYTHON SDK CHECKS
 # =============================================================================
 
-run_check "Codegen" uv run poe codegen-fix
+run_check "Codegen" uv run poe codegen-fix || true
 
-run_check "Formatting" uv run poe fmt-check
-if [ $? -ne 0 ]; then
+if ! run_check "Formatting" uv run poe fmt-check; then
     print_fix "uv run poe fmt-fix"
 fi
 
-run_check "Linting" uv run poe lint-check
-if [ $? -ne 0 ]; then
+if ! run_check "Linting" uv run poe lint-check; then
     print_fix "uv run poe lint-fix"
 fi
 
-run_check "Type checking" uv run poe type-check
-if [ $? -ne 0 ]; then
+if ! run_check "Type checking" uv run poe type-check; then
     print_fix "Fix type errors"
-    print_rerun "uv run poe type-check"
 fi
 
-run_check "Dep check" uv run poe dep-check
-if [ $? -ne 0 ]; then
+if ! run_check "Dep check" uv run poe dep-check; then
     print_fix "Fix dependency issues"
 fi
 
-run_check "Tests" uv run poe test
-if [ $? -ne 0 ]; then
+if ! run_check "Tests" uv run poe test; then
     print_fix "Fix failing tests"
-    print_rerun "uv run poe test"
 fi
 
 # =============================================================================
 # ADDITIONAL CHECKS
 # =============================================================================
 
-run_check "Codegen check" uv run poe codegen-check
-if [ $? -ne 0 ]; then
+if ! run_check "Codegen check" uv run poe codegen-check; then
     print_fix "uv run poe codegen-fix"
 fi
 

--- a/scripts/check-rust.sh
+++ b/scripts/check-rust.sh
@@ -27,6 +27,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Source shared helpers
 source "$SCRIPT_DIR/_lib.sh"
+_LIB_PROJECT_ROOT="$PROJECT_ROOT"
 
 # Parse command line arguments
 parse_flags "$@"
@@ -39,20 +40,15 @@ cd "$PROJECT_ROOT/stepflow-rs"
 # RUST STYLE & QUALITY CHECKS
 # =============================================================================
 
-run_check "Formatting" cargo fmt --check
-FMT_FAILED=$?
-
-if [ $FMT_FAILED -ne 0 ]; then
+if ! run_check "Formatting" cargo fmt --check; then
     print_fix "cargo fmt"
 fi
 
-run_optional_check "Security audit" "cargo-deny" cargo deny check
-if [ $? -ne 0 ]; then
+if ! run_optional_check "Security audit" "cargo-deny" cargo deny check; then
     print_fix "cargo deny check (review and fix security issues)"
 fi
 
-run_optional_check "Unused deps" "cargo-machete" cargo machete --with-metadata
-if [ $? -ne 0 ]; then
+if ! run_optional_check "Unused deps" "cargo-machete" cargo machete --with-metadata; then
     print_fix "cargo machete --fix --with-metadata"
 fi
 
@@ -60,14 +56,11 @@ fi
 # RUST BUILD & TEST CHECKS
 # =============================================================================
 
-run_check "Tests" cargo test
-if [ $? -ne 0 ]; then
+if ! run_check "Tests" cargo test; then
     print_fix "Fix failing tests"
-    print_rerun "cargo test"
 fi
 
-run_check "Clippy" cargo clippy -- -D warnings
-if [ $? -ne 0 ]; then
+if ! run_check "Clippy" cargo clippy -- -D warnings; then
     print_fix "cargo clippy --fix"
 fi
 
@@ -75,13 +68,11 @@ fi
 # ADDITIONAL CHECKS (not in CI but useful for local development)
 # =============================================================================
 
-run_check "Compilation" cargo check --all-targets --all-features
-if [ $? -ne 0 ]; then
+if ! run_check "Compilation" cargo check --all-targets --all-features; then
     print_fix "Fix compilation errors"
 fi
 
-run_check "Documentation" cargo doc --all --no-deps
-if [ $? -ne 0 ]; then
+if ! run_check "Documentation" cargo doc --all --no-deps; then
     print_fix "Fix documentation errors"
 fi
 


### PR DESCRIPTION
- Add specific reproduce commands on failure (e.g., `cd stepflow-rs && cargo fmt --check`) instead of generic "run with -v" advice
- Fix verbose mode ignoring failures by adding pipefail to capture exit codes through tee
- Fix output leaking in non-verbose mode by using print_verbose helper
- Fix print_fix blocks never running due to set -e by using `if ! run_check` pattern

Fixes #528