### PR TITLE
refactor: Reverse dep between stepflow-py and stepflow-orchestrator

### DIFF
--- a/integrations/langflow/uv.lock
+++ b/integrations/langflow/uv.lock
@@ -10101,11 +10101,11 @@ name = "stepflow-orchestrator"
 version = "0.8.0"
 source = { editable = "../../sdks/python/stepflow-orchestrator" }
 dependencies = [
-    { name = "stepflow-py" },
+    { name = "msgspec" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "stepflow-py", editable = "../../sdks/python/stepflow-py" }]
+requires-dist = [{ name = "msgspec", specifier = ">=0.19.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -10147,11 +10147,12 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2" },
     { name = "python-dateutil", specifier = ">=2.8.2" },
     { name = "sse-starlette", marker = "extra == 'http'", specifier = ">=1.6.5" },
+    { name = "stepflow-orchestrator", marker = "extra == 'local'", editable = "../../sdks/python/stepflow-orchestrator" },
     { name = "types-jsonschema", specifier = ">=4.17.0" },
     { name = "typing-extensions", specifier = ">=4.7.1" },
     { name = "uvicorn", marker = "extra == 'http'", specifier = ">=0.24.0" },
 ]
-provides-extras = ["http", "langchain"]
+provides-extras = ["http", "langchain", "local"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/sdks/python/stepflow-orchestrator/README.md
+++ b/sdks/python/stepflow-orchestrator/README.md
@@ -14,17 +14,40 @@ pip install stepflow-orchestrator
 from stepflow_orchestrator import StepflowOrchestrator, OrchestratorConfig
 
 # Start with default config (auto-assigned port)
-async with StepflowOrchestrator.start() as client:
-    # client is a StepflowClient connected to the subprocess
-    flow_id = client.store_flow(workflow_dict).flow_id
-    result = client.run(flow_id, {"input": "value"})
-    print(f"Result: {result}")
+async with StepflowOrchestrator.start() as orchestrator:
+    print(f"Server running at {orchestrator.url}")
+    # Use orchestrator.url with your preferred HTTP client
 
 # Start with custom config
-config = OrchestratorConfig(port=8080, log_level="debug")
-async with StepflowOrchestrator.start(config) as client:
-    # Use client.store_flow(), client.run(), etc.
+config = OrchestratorConfig(
+    port=8080,
+    log_level="debug",
+    config={"plugins": {"builtin": {"type": "builtin"}}}
+)
+async with StepflowOrchestrator.start(config) as orchestrator:
+    # orchestrator.url - server URL (e.g., "http://127.0.0.1:8080")
+    # orchestrator.port - bound port number
+    # orchestrator.is_running - check if process is alive
     pass
+```
+
+## With stepflow-py Client
+
+For a convenient combined experience, use `stepflow-py[local]`:
+
+```bash
+pip install stepflow-py[local]
+```
+
+```python
+from stepflow_py import StepflowClient
+from stepflow_py.config import StepflowConfig
+
+config = StepflowConfig(plugins={...}, routes={...})
+async with StepflowClient.local(config) as client:
+    # Client owns the orchestrator - both shut down on exit
+    response = await client.store_flow(workflow)
+    result = await client.run(response.flow_id, input_data)
 ```
 
 ## Development Mode

--- a/sdks/python/stepflow-orchestrator/pyproject.toml
+++ b/sdks/python/stepflow-orchestrator/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed"
 ]
 dependencies = [
-    "stepflow-py>=0.8.0",
+    "msgspec>=0.19.0",
 ]
 
 [project.urls]
@@ -41,9 +41,6 @@ Documentation = "https://stepflow-ai.github.io/stepflow/"
 Repository = "https://github.com/stepflow-ai/stepflow"
 "Bug Tracker" = "https://github.com/stepflow-ai/stepflow/issues"
 "Source Code" = "https://github.com/stepflow-ai/stepflow/tree/main/sdks/python/stepflow-orchestrator"
-
-[tool.uv.sources]
-stepflow-py = { workspace = true }
 
 [dependency-groups]
 dev = [

--- a/sdks/python/stepflow-orchestrator/src/stepflow_orchestrator/__init__.py
+++ b/sdks/python/stepflow-orchestrator/src/stepflow_orchestrator/__init__.py
@@ -19,19 +19,16 @@ binary as a subprocess with configuration management, health checking,
 and graceful shutdown.
 
 Example with default config:
-    async with StepflowOrchestrator.start() as client:
-        flow_id = client.store_flow(workflow)
-        result = client.run(flow_id, input_data)
+    async with StepflowOrchestrator.start() as orchestrator:
+        print(f"Server running at {orchestrator.url}")
+        # Use orchestrator.url with your preferred client
 
 Example with custom config:
     config = OrchestratorConfig(port=8080, log_level="debug")
-    async with StepflowOrchestrator.start(config) as client:
-        flow_id = client.store_flow(workflow)
-        result = client.run(flow_id, input_data)
+    async with StepflowOrchestrator.start(config) as orchestrator:
+        # orchestrator.url, orchestrator.port, orchestrator.is_running available
+        pass
 """
-
-# Re-export StepflowClient for convenience
-from stepflow_py import StepflowClient
 
 from stepflow_orchestrator.orchestrator import (
     OrchestratorConfig,
@@ -41,5 +38,4 @@ from stepflow_orchestrator.orchestrator import (
 __all__ = [
     "StepflowOrchestrator",
     "OrchestratorConfig",
-    "StepflowClient",
 ]

--- a/sdks/python/stepflow-orchestrator/src/stepflow_orchestrator/orchestrator.py
+++ b/sdks/python/stepflow-orchestrator/src/stepflow_orchestrator/orchestrator.py
@@ -25,13 +25,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
-import msgspec
-
-if TYPE_CHECKING:
-    from stepflow_py import StepflowClient
-    from stepflow_py.config import StepflowConfig
+from typing import Any
 
 
 @dataclass
@@ -48,7 +42,7 @@ class OrchestratorConfig:
 
     Configuration can be provided in two ways (mutually exclusive):
         - config_path: Path to a stepflow-config.yml file
-        - config: A StepflowConfig object or dict (passed to server via stdin)
+        - config: A dict representing the config (passed to server via stdin as JSON)
     """
 
     # Server settings
@@ -62,7 +56,7 @@ class OrchestratorConfig:
 
     # Configuration - either path or object (mutually exclusive)
     config_path: Path | None = None  # Path to stepflow-config.yml
-    config: StepflowConfig | dict[str, Any] | None = None  # Direct config object
+    config: dict[str, Any] | None = None  # JSON-serializable config dict
 
     # Logging
     log_level: str = "info"
@@ -98,17 +92,16 @@ class StepflowOrchestrator:
     """Context manager for running the Stepflow orchestrator as a subprocess.
 
     Usage with default config:
-        async with StepflowOrchestrator.start() as client:
-            flow_id = client.store_flow(workflow)
-            result = client.run(flow_id, input_data)
+        async with StepflowOrchestrator.start() as orchestrator:
+            print(f"Server running at {orchestrator.url}")
+            # Use orchestrator.url with a client library
 
     Usage with custom config:
         config = OrchestratorConfig(port=8080, log_level="debug")
-        async with StepflowOrchestrator.start(config) as client:
-            flow_id = client.store_flow(workflow)
-            result = client.run(flow_id, input_data)
+        async with StepflowOrchestrator.start(config) as orchestrator:
+            # orchestrator.url, orchestrator.port, orchestrator.is_running available
 
-    The context manager yields a StepflowClient connected to the subprocess.
+    The context manager yields the orchestrator instance for accessing server info.
     The subprocess is automatically started and stopped with the context.
     """
 
@@ -123,24 +116,18 @@ class StepflowOrchestrator:
     async def start(
         cls,
         config: OrchestratorConfig | None = None,
-    ) -> AsyncIterator[StepflowClient]:
-        """Start the orchestrator and return a connected client.
+    ) -> AsyncIterator[StepflowOrchestrator]:
+        """Start the orchestrator and return it for lifecycle management.
 
         Args:
             config: Configuration for the orchestrator. Uses defaults if not provided.
 
         Yields:
-            StepflowClient connected to the subprocess server.
+            StepflowOrchestrator instance with url, port, and is_running properties.
         """
-        from stepflow_py import StepflowClient
-
         orchestrator = cls(config)
         async with orchestrator:
-            client = StepflowClient.connect(orchestrator.url)
-            try:
-                yield client
-            finally:
-                await client.close()
+            yield orchestrator
 
     @property
     def port(self) -> int:
@@ -194,18 +181,12 @@ class StepflowOrchestrator:
             cmd.extend(["--config", str(self._config.config_path)])
         elif self._config.config is not None:
             cmd.append("--config-stdin")
-            # Serialize config to JSON - handle both msgspec structs and dicts
+            # Serialize config dict to JSON
             # Note: We need to remove None values because Rust's serde untagged
             # enum deserialization can fail with explicit null values for
             # optional fields (e.g., StepflowTransport).
-            if isinstance(self._config.config, dict):
-                cleaned = self._remove_none_values(self._config.config)
-                stdin_input = json.dumps(cleaned).encode("utf-8")
-            else:
-                # Assume it's a msgspec Struct - decode to dict, clean, re-encode
-                data = msgspec.json.decode(msgspec.json.encode(self._config.config))
-                cleaned = self._remove_none_values(data)
-                stdin_input = json.dumps(cleaned).encode("utf-8")
+            cleaned = self._remove_none_values(self._config.config)
+            stdin_input = json.dumps(cleaned).encode("utf-8")
 
         env = os.environ.copy()
         env.update(self._config.env)

--- a/sdks/python/stepflow-py/pyproject.toml
+++ b/sdks/python/stepflow-py/pyproject.toml
@@ -67,6 +67,9 @@ http = [
 langchain = [
     "langchain-core>=0.3",
 ]
+local = [
+    "stepflow-orchestrator~=0.8.0",
+]
 
 [dependency-groups]
 dev = [

--- a/sdks/python/stepflow-py/tests/integration/conftest.py
+++ b/sdks/python/stepflow-py/tests/integration/conftest.py
@@ -24,7 +24,6 @@ from pathlib import Path
 
 import pytest
 import pytest_asyncio
-from stepflow_orchestrator import OrchestratorConfig, StepflowOrchestrator
 
 from stepflow_py import StepflowClient
 from stepflow_py.config import (
@@ -78,7 +77,7 @@ def integration_config():
 
 @pytest_asyncio.fixture(scope="module")
 async def stepflow_client(integration_config):
-    """Start StepflowOrchestrator and return connected StepflowClient.
+    """Start local orchestrator and return connected StepflowClient.
 
     Requires STEPFLOW_DEV_BINARY environment variable to be set.
     """
@@ -90,21 +89,6 @@ async def stepflow_client(integration_config):
             "Set it to the path of the stepflow-server binary."
         )
 
-    # Create orchestrator config with StepflowConfig object (passed via stdin)
-    orch_config = OrchestratorConfig(
-        config=integration_config,
-        startup_timeout=60.0,
-    )
-
-    # Start orchestrator
-    orchestrator = StepflowOrchestrator(orch_config)
-    await orchestrator._start()
-
-    # Create client
-    client = StepflowClient.connect(orchestrator.url)
-
-    yield client
-
-    # Cleanup
-    await client.close()
-    await orchestrator._stop()
+    # Use StepflowClient.local() which handles orchestrator lifecycle
+    async with StepflowClient.local(integration_config, startup_timeout=60.0) as client:
+        yield client

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -1949,7 +1949,7 @@ name = "stepflow-orchestrator"
 version = "0.8.0"
 source = { editable = "stepflow-orchestrator" }
 dependencies = [
-    { name = "stepflow-py" },
+    { name = "msgspec" },
 ]
 
 [package.dev-dependencies]
@@ -1961,7 +1961,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "stepflow-py", editable = "stepflow-py" }]
+requires-dist = [{ name = "msgspec", specifier = ">=0.19.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1998,6 +1998,9 @@ http = [
 langchain = [
     { name = "langchain-core" },
 ]
+local = [
+    { name = "stepflow-orchestrator" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2032,11 +2035,12 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2" },
     { name = "python-dateutil", specifier = ">=2.8.2" },
     { name = "sse-starlette", marker = "extra == 'http'", specifier = ">=1.6.5" },
+    { name = "stepflow-orchestrator", marker = "extra == 'local'", editable = "stepflow-orchestrator" },
     { name = "types-jsonschema", specifier = ">=4.17.0" },
     { name = "typing-extensions", specifier = ">=4.7.1" },
     { name = "uvicorn", marker = "extra == 'http'", specifier = ">=0.24.0" },
 ]
-provides-extras = ["http", "langchain"]
+provides-extras = ["http", "langchain", "local"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
- Remove stepflow-py dependency from stepflow-orchestrator
- Add optional `local` extra to stepflow-py that depends on stepflow-orchestrator
- Add StepflowClient.local() method for convenient orchestrator management
- Change StepflowOrchestrator.start() to return orchestrator instead of client
- Update test fixtures to use new StepflowClient.local() API
- Remove StepflowClient re-export from stepflow-orchestrator

This enables independent versioning where stepflow-py X.Y.* uses stepflow-orchestrator X.Y.latest, allowing Rust binary patches without requiring Python SDK releases.