### PR TITLE
feat: Restructure stepflow release to include Python wheels

### DIFF
--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -10,10 +10,10 @@ permissions:
   actions: write
 
 jobs:
-  dispatch-rust-release:
-    name: Dispatch Rust Release Build
+  dispatch-stepflow-release:
+    name: Dispatch Stepflow Release Build
     runs-on: ubuntu-22.04
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release:stepflow-rs')
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release:stepflow')
 
     steps:
       - name: Checkout repository
@@ -27,30 +27,31 @@ jobs:
         run: |
           VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=stepflow-rs-$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=stepflow-$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 
       - name: Dispatch release build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run "Release - Rust" \
+          gh workflow run "Release - Stepflow" \
             --field version="${{ steps.version.outputs.version }}" \
             --field skip_tag_creation=false
 
       - name: Summary
         run: |
-          echo "## Release Build Dispatched" >> $GITHUB_STEP_SUMMARY
+          echo "## Stepflow Release Build Dispatched" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Dispatched release build for **stepflow-rs v${{ steps.version.outputs.version }}**" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Dispatched release build for **Stepflow v${{ steps.version.outputs.version }}**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Tag:** ${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "The release build workflow will:" >> $GITHUB_STEP_SUMMARY
           echo "1. Build binaries for all platforms" >> $GITHUB_STEP_SUMMARY
           echo "2. Build and push Docker images" >> $GITHUB_STEP_SUMMARY
-          echo "3. Verify all artifacts" >> $GITHUB_STEP_SUMMARY
-          echo "4. Create git tag and GitHub release" >> $GITHUB_STEP_SUMMARY
+          echo "3. Build Python wheels for all platforms" >> $GITHUB_STEP_SUMMARY
+          echo "4. Publish wheels to PyPI" >> $GITHUB_STEP_SUMMARY
+          echo "5. Create git tag and GitHub release" >> $GITHUB_STEP_SUMMARY
 
   dispatch-python-release:
     name: Dispatch Python SDK Release

--- a/.github/workflows/release_prepare.yml
+++ b/.github/workflows/release_prepare.yml
@@ -8,9 +8,9 @@ on:
         required: true
         type: choice
         options:
-          - stepflow-rs
+          - stepflow
           - stepflow-py
-        default: 'stepflow-rs'
+        default: 'stepflow'
       bump_type:
         description: 'Type of version bump'
         required: true
@@ -59,11 +59,11 @@ jobs:
       - name: Prepare release
         run: |
           case "${{ inputs.package }}" in
-            stepflow-rs)
+            stepflow)
               if [[ -n "${{ inputs.message }}" ]]; then
-                ./scripts/prepare-release-rust.sh ${{ inputs.bump_type }} --pr --message "${{ inputs.message }}"
+                ./scripts/prepare-release-stepflow.sh ${{ inputs.bump_type }} --pr --message "${{ inputs.message }}"
               else
-                ./scripts/prepare-release-rust.sh ${{ inputs.bump_type }} --pr
+                ./scripts/prepare-release-stepflow.sh ${{ inputs.bump_type }} --pr
               fi
               ;;
             stepflow-py)

--- a/.github/workflows/release_stepflow.yml
+++ b/.github/workflows/release_stepflow.yml
@@ -1,8 +1,8 @@
-name: Release - Rust
+name: Release - Stepflow
 
 on:
   repository_dispatch:
-    types: [build-release]
+    types: [build-stepflow-release]
   workflow_dispatch:
     inputs:
       version:
@@ -47,11 +47,11 @@ jobs:
             echo "Tag: ${{ github.event.client_payload.tag }}"
           else
             echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
-            echo "tag=stepflow-rs-${{ inputs.version }}" >> $GITHUB_OUTPUT
+            echo "tag=stepflow-${{ inputs.version }}" >> $GITHUB_OUTPUT
             echo "skip_tag=${{ inputs.skip_tag_creation }}" >> $GITHUB_OUTPUT
             echo "Source: manual workflow dispatch"
             echo "Version: ${{ inputs.version }}"
-            echo "Tag: stepflow-rs-${{ inputs.version }}"
+            echo "Tag: stepflow-${{ inputs.version }}"
             echo "Skip tag: ${{ inputs.skip_tag_creation }}"
           fi
 
@@ -199,10 +199,64 @@ jobs:
             ${{ needs.determine-version.outputs.version }} \
             ${{ env.REGISTRY }}/${{ github.repository }}
 
+  build-stepflow-wheels:
+    name: Build Python Wheels
+    runs-on: ubuntu-22.04
+    needs: [build-binaries, determine-version]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Download all binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./binaries
+          pattern: artifact-stepflow-*
+          merge-multiple: true
+
+      - name: Build platform-specific wheels
+        run: |
+          chmod +x ./scripts/build-stepflow-wheels.sh
+          ./scripts/build-stepflow-wheels.sh ./binaries ./wheels
+
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: stepflow-wheels
+          path: ./wheels/*.whl
+          retention-days: 7
+
+  publish-stepflow-wheels:
+    name: Publish Wheels to PyPI
+    runs-on: ubuntu-22.04
+    needs: [determine-version, build-stepflow-wheels]
+    if: needs.determine-version.outputs.skip_tag == 'false'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/stepflow-orchestrator
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: stepflow-wheels
+          path: ./wheels
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheels/
+          print-hash: true
+
   create-tag-and-release:
     name: Create Tag and Release
     runs-on: ubuntu-22.04
-    needs: [determine-version, build-binaries, build-docker]
+    needs: [determine-version, build-binaries, build-docker, build-stepflow-wheels, publish-stepflow-wheels]
     if: needs.determine-version.outputs.skip_tag == 'false'
     permissions:
       contents: write
@@ -276,11 +330,17 @@ jobs:
       - name: Create release notes
         run: |
           cat > release-notes.md << 'EOF'
-          ## Stepflow Rust Binary Release v${{ needs.determine-version.outputs.version }}
+          ## Stepflow Release v${{ needs.determine-version.outputs.version }}
 
           📋 **[View Release Changelog](https://github.com/${{ github.repository }}/blob/main/stepflow-rs/CHANGELOG.md#${{ needs.determine-version.outputs.version }})** | **[Full Changelog](https://github.com/${{ github.repository }}/blob/main/stepflow-rs/CHANGELOG.md)**
 
-          This release includes pre-built binaries for multiple platforms.
+          This release includes pre-built binaries for multiple platforms and Python wheels.
+
+          ### 🐍 Python Package (Recommended)
+          ```bash
+          pip install stepflow-orchestrator
+          ```
+          Platform-specific wheels are available on [PyPI](https://pypi.org/project/stepflow-orchestrator/).
 
           **Unix platforms** (Linux, macOS) include three binaries:
           - `stepflow` - CLI tool for running workflows
@@ -369,7 +429,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ needs.determine-version.outputs.tag }}" \
-            --title "Stepflow Rust v${{ needs.determine-version.outputs.version }}" \
+            --title "Stepflow v${{ needs.determine-version.outputs.version }}" \
             --notes-file release-notes.md \
             stepflow-rs/CHANGELOG.md \
             ./archives/stepflow-*.tar.gz \
@@ -378,39 +438,54 @@ jobs:
   summary:
     name: Build Summary
     runs-on: ubuntu-22.04
-    needs: [determine-version, build-binaries, build-docker, create-tag-and-release]
+    needs: [determine-version, build-binaries, build-docker, build-stepflow-wheels, publish-stepflow-wheels, create-tag-and-release]
     if: always()
 
     steps:
       - name: Check job results
         run: |
-          echo "## Build Summary ${{ needs.determine-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "## Stepflow Release Summary ${{ needs.determine-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Component | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-----------|--------|" >> $GITHUB_STEP_SUMMARY
 
           if [ "${{ needs.build-binaries.result }}" = "success" ]; then
-            echo "| Binary builds |  Success |" >> $GITHUB_STEP_SUMMARY
+            echo "| Binary builds | ✅ Success |" >> $GITHUB_STEP_SUMMARY
           else
-            echo "| Binary builds | L Failed |" >> $GITHUB_STEP_SUMMARY
+            echo "| Binary builds | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
           fi
 
           if [ "${{ needs.build-docker.result }}" = "success" ]; then
-            echo "| Docker builds & manifests |  Success |" >> $GITHUB_STEP_SUMMARY
+            echo "| Docker builds & manifests | ✅ Success |" >> $GITHUB_STEP_SUMMARY
           else
-            echo "| Docker builds & manifests | L Failed |" >> $GITHUB_STEP_SUMMARY
+            echo "| Docker builds & manifests | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ "${{ needs.build-stepflow-wheels.result }}" = "success" ]; then
+            echo "| Python wheel builds | ✅ Success |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Python wheel builds | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
           fi
 
           if [ "${{ needs.determine-version.outputs.skip_tag }}" = "false" ]; then
-            if [ "${{ needs.create-tag-and-release.result }}" = "success" ]; then
-              echo "| Release Creation |  Success |" >> $GITHUB_STEP_SUMMARY
-            elif [ "${{ needs.create-tag-and-release.result }}" = "skipped" ]; then
-              echo "| Release Creation |  Skipped |" >> $GITHUB_STEP_SUMMARY
+            if [ "${{ needs.publish-stepflow-wheels.result }}" = "success" ]; then
+              echo "| PyPI publish | ✅ Success |" >> $GITHUB_STEP_SUMMARY
+            elif [ "${{ needs.publish-stepflow-wheels.result }}" = "skipped" ]; then
+              echo "| PyPI publish | ⏭️ Skipped |" >> $GITHUB_STEP_SUMMARY
             else
-              echo "| Release Creation | L Failed |" >> $GITHUB_STEP_SUMMARY
+              echo "| PyPI publish | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
+            fi
+
+            if [ "${{ needs.create-tag-and-release.result }}" = "success" ]; then
+              echo "| GitHub Release | ✅ Success |" >> $GITHUB_STEP_SUMMARY
+            elif [ "${{ needs.create-tag-and-release.result }}" = "skipped" ]; then
+              echo "| GitHub Release | ⏭️ Skipped |" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "| GitHub Release | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
             fi
           else
-            echo "| Release Creation |  Skipped (testing mode) |" >> $GITHUB_STEP_SUMMARY
+            echo "| PyPI publish | ⏭️ Skipped (testing mode) |" >> $GITHUB_STEP_SUMMARY
+            echo "| GitHub Release | ⏭️ Skipped (testing mode) |" >> $GITHUB_STEP_SUMMARY
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -422,10 +497,12 @@ jobs:
           echo "  - stepflow-server (Debian + Alpine, amd64 + arm64)" >> $GITHUB_STEP_SUMMARY
           echo "  - stepflow-load-balancer (Debian + Alpine, amd64 + arm64)" >> $GITHUB_STEP_SUMMARY
           echo "  - stepflow (Debian + Alpine, amd64 + arm64)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Python Wheels**: 7 platform-specific wheels" >> $GITHUB_STEP_SUMMARY
 
           if [ "${{ needs.determine-version.outputs.skip_tag }}" = "false" ] && [ "${{ needs.create-tag-and-release.result }}" = "success" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### 🎉 Release Complete" >> $GITHUB_STEP_SUMMARY
             echo "**Tag:** ${{ needs.determine-version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
-            echo "**Release:** [Stepflow Rust v${{ needs.determine-version.outputs.version }}](https://github.com/${{ github.repository }}/releases/tag/${{ needs.determine-version.outputs.tag }})" >> $GITHUB_STEP_SUMMARY
+            echo "**GitHub Release:** [Stepflow v${{ needs.determine-version.outputs.version }}](https://github.com/${{ github.repository }}/releases/tag/${{ needs.determine-version.outputs.tag }})" >> $GITHUB_STEP_SUMMARY
+            echo "**PyPI:** [stepflow-orchestrator ${{ needs.determine-version.outputs.version }}](https://pypi.org/project/stepflow-orchestrator/${{ needs.determine-version.outputs.version }}/)" >> $GITHUB_STEP_SUMMARY
           fi

--- a/scripts/build-stepflow-wheels.sh
+++ b/scripts/build-stepflow-wheels.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+set -euo pipefail
+
+# Build platform-specific wheels for stepflow-orchestrator
+#
+# This script takes pre-built binaries and creates Python wheels with the
+# appropriate platform tags for each supported platform.
+#
+# Usage:
+#   ./scripts/build-orchestrator-wheels.sh <binaries-dir> [output-dir]
+#
+# Arguments:
+#   binaries-dir   Directory containing pre-built binaries named:
+#                    stepflow-server-<rust-target>[.exe]
+#   output-dir     Output directory for wheels (default: ./wheels)
+#
+# Expects binaries named:
+#   stepflow-server-x86_64-unknown-linux-gnu
+#   stepflow-server-aarch64-unknown-linux-gnu
+#   stepflow-server-x86_64-unknown-linux-musl
+#   stepflow-server-aarch64-unknown-linux-musl
+#   stepflow-server-x86_64-apple-darwin
+#   stepflow-server-aarch64-apple-darwin
+#   stepflow-server-x86_64-pc-windows-msvc.exe
+#
+# Example:
+#   # Build all wheels from release binaries
+#   ./scripts/build-orchestrator-wheels.sh ./binaries ./dist
+#
+#   # Build wheel for current platform only (development)
+#   cargo build --release -p stepflow-server
+#   mkdir /tmp/bins && cp target/release/stepflow-server /tmp/bins/stepflow-server-$(rustc -vV | grep host | cut -d' ' -f2)
+#   ./scripts/build-orchestrator-wheels.sh /tmp/bins ./wheels
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Help function
+show_help() {
+    cat << 'EOF'
+Usage: build-orchestrator-wheels.sh <binaries-dir> [output-dir]
+
+Build platform-specific wheels for stepflow-orchestrator from pre-built binaries.
+
+ARGUMENTS:
+    binaries-dir    Directory containing stepflow-server binaries
+    output-dir      Output directory for wheels (default: ./wheels)
+
+BINARY NAMING:
+    Binaries should be named: stepflow-server-<rust-target>[.exe]
+
+    Supported targets:
+      - x86_64-unknown-linux-gnu    -> manylinux_2_17_x86_64
+      - aarch64-unknown-linux-gnu   -> manylinux_2_17_aarch64
+      - x86_64-unknown-linux-musl   -> musllinux_1_2_x86_64
+      - aarch64-unknown-linux-musl  -> musllinux_1_2_aarch64
+      - x86_64-apple-darwin         -> macosx_11_0_x86_64
+      - aarch64-apple-darwin        -> macosx_11_0_arm64
+      - x86_64-pc-windows-msvc      -> win_amd64
+
+EXAMPLES:
+    # Build from CI artifacts
+    ./scripts/build-orchestrator-wheels.sh ./artifacts ./wheels
+
+    # Build for current platform (development)
+    cd stepflow-rs && cargo build --release -p stepflow-server
+    mkdir /tmp/bins
+    cp target/release/stepflow-server /tmp/bins/stepflow-server-$(rustc -vV | grep host | cut -d' ' -f2)
+    ./scripts/build-orchestrator-wheels.sh /tmp/bins ./wheels
+EOF
+}
+
+# Parse arguments
+if [[ $# -lt 1 ]] || [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+    show_help
+    exit 0
+fi
+
+BINARIES_DIR="$1"
+OUTPUT_DIR="${2:-./wheels}"
+
+# Validate binaries directory
+if [[ ! -d "$BINARIES_DIR" ]]; then
+    echo -e "${RED}Error: Binaries directory not found: $BINARIES_DIR${NC}" >&2
+    exit 1
+fi
+
+# Find project root and orchestrator package
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ORCHESTRATOR_DIR="$PROJECT_ROOT/sdks/python/stepflow-orchestrator"
+
+if [[ ! -d "$ORCHESTRATOR_DIR" ]]; then
+    echo -e "${RED}Error: Orchestrator package not found at: $ORCHESTRATOR_DIR${NC}" >&2
+    exit 1
+fi
+
+# Platform mappings: rust_target -> wheel_tag
+# Format: "rust_target:wheel_tag:binary_suffix"
+PLATFORMS=(
+    "x86_64-unknown-linux-gnu:manylinux_2_17_x86_64:"
+    "aarch64-unknown-linux-gnu:manylinux_2_17_aarch64:"
+    "x86_64-unknown-linux-musl:musllinux_1_2_x86_64:"
+    "aarch64-unknown-linux-musl:musllinux_1_2_aarch64:"
+    "x86_64-apple-darwin:macosx_11_0_x86_64:"
+    "aarch64-apple-darwin:macosx_11_0_arm64:"
+    "x86_64-pc-windows-msvc:win_amd64:.exe"
+)
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+# Create temporary directory for wheel building
+BUILD_TMPDIR=$(mktemp -d)
+trap "rm -rf '$BUILD_TMPDIR'" EXIT
+
+echo -e "${BLUE}Building stepflow-orchestrator wheels${NC}"
+echo "  Binaries dir: $BINARIES_DIR"
+echo "  Output dir:   $OUTPUT_DIR"
+echo ""
+
+# Get package version
+VERSION=$(grep '^version = ' "$ORCHESTRATOR_DIR/pyproject.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
+echo -e "${BLUE}Package version: ${GREEN}$VERSION${NC}"
+echo ""
+
+# Track which platforms we built
+BUILT_PLATFORMS=()
+SKIPPED_PLATFORMS=()
+
+# Build wheels for each platform
+for platform_spec in "${PLATFORMS[@]}"; do
+    IFS=':' read -r rust_target wheel_tag binary_suffix <<< "$platform_spec"
+
+    binary_name="stepflow-server-${rust_target}${binary_suffix}"
+    binary_path="$BINARIES_DIR/$binary_name"
+
+    # Check if binary exists
+    if [[ ! -f "$binary_path" ]]; then
+        echo -e "${YELLOW}Skipping $rust_target (binary not found: $binary_name)${NC}"
+        SKIPPED_PLATFORMS+=("$rust_target")
+        continue
+    fi
+
+    echo -e "${BLUE}Building wheel for ${GREEN}$rust_target${NC} -> ${GREEN}$wheel_tag${NC}"
+
+    # Create a clean copy of the package for this build
+    BUILD_DIR="$BUILD_TMPDIR/$rust_target"
+    cp -r "$ORCHESTRATOR_DIR" "$BUILD_DIR"
+
+    # Copy binary to bin directory
+    BIN_DIR="$BUILD_DIR/src/stepflow_orchestrator/bin"
+    mkdir -p "$BIN_DIR"
+
+    # Determine target binary name (stepflow-server or stepflow-server.exe)
+    if [[ -n "$binary_suffix" ]]; then
+        target_binary="stepflow-server${binary_suffix}"
+    else
+        target_binary="stepflow-server"
+    fi
+
+    cp "$binary_path" "$BIN_DIR/$target_binary"
+    chmod +x "$BIN_DIR/$target_binary"
+
+    # Build wheel
+    cd "$BUILD_DIR"
+
+    # Clean any existing dist
+    rm -rf dist/
+
+    # Build with uv
+    uv build --wheel --quiet
+
+    # Find the built wheel and rename with platform tag
+    for wheel in dist/*.whl; do
+        if [[ -f "$wheel" ]]; then
+            # Original: stepflow_orchestrator-X.Y.Z-py3-none-any.whl
+            # Target: stepflow_orchestrator-X.Y.Z-py3-none-<wheel_tag>.whl
+            wheel_basename=$(basename "$wheel")
+            new_name=$(echo "$wheel_basename" | sed "s/-py3-none-any\.whl/-py3-none-${wheel_tag}.whl/")
+
+            # Move to output directory with new name
+            mv "$wheel" "$OUTPUT_DIR/$new_name"
+            echo -e "  ${GREEN}Created: $new_name${NC}"
+        fi
+    done
+
+    BUILT_PLATFORMS+=("$rust_target")
+
+    cd "$PROJECT_ROOT"
+done
+
+echo ""
+echo -e "${GREEN}=========================================${NC}"
+echo -e "${GREEN}Wheel building complete!${NC}"
+echo -e "${GREEN}=========================================${NC}"
+echo ""
+
+if [[ ${#BUILT_PLATFORMS[@]} -gt 0 ]]; then
+    echo -e "${BLUE}Built wheels for ${#BUILT_PLATFORMS[@]} platform(s):${NC}"
+    for platform in "${BUILT_PLATFORMS[@]}"; do
+        echo "  - $platform"
+    done
+fi
+
+if [[ ${#SKIPPED_PLATFORMS[@]} -gt 0 ]]; then
+    echo ""
+    echo -e "${YELLOW}Skipped ${#SKIPPED_PLATFORMS[@]} platform(s) (binaries not found):${NC}"
+    for platform in "${SKIPPED_PLATFORMS[@]}"; do
+        echo "  - $platform"
+    done
+fi
+
+echo ""
+echo -e "${BLUE}Output:${NC}"
+ls -la "$OUTPUT_DIR"/*.whl 2>/dev/null || echo "  (no wheels found)"
+
+if [[ ${#BUILT_PLATFORMS[@]} -eq 0 ]]; then
+    echo ""
+    echo -e "${RED}Error: No wheels were built. Check that binaries exist in $BINARIES_DIR${NC}"
+    exit 1
+fi

--- a/scripts/prepare-release-python.sh
+++ b/scripts/prepare-release-python.sh
@@ -137,14 +137,14 @@ if [[ "$CREATE_PR" == true ]] && ! command_exists gh; then
 fi
 
 # Ensure we're in the project root directory
-if [[ ! -d "sdks/python" ]] || [[ ! -f "sdks/python/stepflow-worker/pyproject.toml" ]]; then
+if [[ ! -d "sdks/python" ]] || [[ ! -f "sdks/python/stepflow-py/pyproject.toml" ]]; then
     echo -e "${RED}Error: Must be run from project root directory${NC}" >&2
-    echo "Expected to find sdks/python/stepflow-worker/pyproject.toml" >&2
+    echo "Expected to find sdks/python/stepflow-py/pyproject.toml" >&2
     exit 1
 fi
 
 # Change to Python SDK directory for operations
-cd sdks/python/stepflow-worker
+cd sdks/python/stepflow-py
 
 # Check git status only if creating PR
 if [[ "$CREATE_PR" == true ]] && [[ -n "$(git status --porcelain)" ]]; then
@@ -187,6 +187,23 @@ else
     sed -i "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" pyproject.toml
 fi
 
+# Calculate new version parts for constraint update
+IFS='.' read -ra NEW_VERSION_PARTS <<< "$NEW_VERSION"
+NEW_MAJOR=${NEW_VERSION_PARTS[0]}
+NEW_MINOR=${NEW_VERSION_PARTS[1]}
+
+# Update stepflow-orchestrator constraint on minor/major bumps
+if [[ "$BUMP_TYPE" == "minor" ]] || [[ "$BUMP_TYPE" == "major" ]]; then
+    echo -e "${BLUE}Updating stepflow-orchestrator dependency constraint...${NC}"
+    NEW_CONSTRAINT="~=${NEW_MAJOR}.${NEW_MINOR}.0"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s/stepflow-orchestrator~=[0-9]*\.[0-9]*\.[0-9]*/stepflow-orchestrator${NEW_CONSTRAINT}/" pyproject.toml
+    else
+        sed -i "s/stepflow-orchestrator~=[0-9]*\.[0-9]*\.[0-9]*/stepflow-orchestrator${NEW_CONSTRAINT}/" pyproject.toml
+    fi
+    echo -e "${GREEN}Updated orchestrator dependency to ${NEW_CONSTRAINT}${NC}"
+fi
+
 # Update uv.lock if it exists
 if [[ -f "uv.lock" ]]; then
     echo -e "${BLUE}Updating uv.lock...${NC}"
@@ -215,14 +232,17 @@ fi
 echo -e "${BLUE}Generating changelog (Python SDK changes only)${NC}"
 if [[ -n "$TAG_MESSAGE" ]]; then
     echo -e "${BLUE}Including custom message: ${GREEN}$TAG_MESSAGE${NC}"
-    git-cliff --config cliff.toml --tag "stepflow-worker-$NEW_VERSION" -u --prepend CHANGELOG.md --with-tag-message "$TAG_MESSAGE"
+    git-cliff --config cliff.toml --tag "stepflow-py-$NEW_VERSION" -u --prepend CHANGELOG.md --with-tag-message "$TAG_MESSAGE"
 else
-    git-cliff --config cliff.toml --tag "stepflow-worker-$NEW_VERSION" -u --prepend CHANGELOG.md
+    git-cliff --config cliff.toml --tag "stepflow-py-$NEW_VERSION" -u --prepend CHANGELOG.md
 fi
 
 echo -e "${GREEN}✅ Release preparation complete!${NC}"
 echo -e "${BLUE}Changes made:${NC}"
 echo "  - Version bumped from $CURRENT_VERSION to $NEW_VERSION in pyproject.toml"
+if [[ "$BUMP_TYPE" == "minor" ]] || [[ "$BUMP_TYPE" == "major" ]]; then
+    echo "  - Updated stepflow-orchestrator dependency constraint to ~=${NEW_MAJOR}.${NEW_MINOR}.0"
+fi
 if [[ -f "uv.lock" ]]; then
     echo "  - Updated uv.lock"
 fi
@@ -242,7 +262,7 @@ echo ""
 echo -e "${BLUE}Creating pull request...${NC}"
 
 # Create release branch
-RELEASE_BRANCH="release/stepflow-worker-v$NEW_VERSION"
+RELEASE_BRANCH="release/stepflow-py-v$NEW_VERSION"
 echo -e "${BLUE}Creating release branch: $RELEASE_BRANCH${NC}"
 
 # Check if release branch already exists
@@ -265,7 +285,7 @@ if [[ -f "uv.lock" ]]; then
 else
     git add pyproject.toml CHANGELOG.md
 fi
-git commit -m "chore: release stepflow-worker v$NEW_VERSION
+git commit -m "chore: release stepflow-py v$NEW_VERSION
 
 - Bump version from $CURRENT_VERSION to $NEW_VERSION
 - Update CHANGELOG.md with release notes"
@@ -275,9 +295,9 @@ echo -e "${BLUE}Pushing release branch...${NC}"
 git push -u origin "$RELEASE_BRANCH" --force
 
 # Create PR
-PR_BODY="## Release stepflow-worker v$NEW_VERSION
+PR_BODY="## Release stepflow-py v$NEW_VERSION
 
-This PR prepares the release of stepflow-worker v$NEW_VERSION.
+This PR prepares the release of stepflow-py v$NEW_VERSION.
 
 ### Changes
 - Version bump from $CURRENT_VERSION to $NEW_VERSION
@@ -289,10 +309,10 @@ This PR prepares the release of stepflow-worker v$NEW_VERSION.
 3. The release will be automatically tagged and published to PyPI"
 
 PR_URL=$(gh pr create \
-    --title "chore: release stepflow-worker v$NEW_VERSION" \
+    --title "chore: release stepflow-py v$NEW_VERSION" \
     --body "$PR_BODY" \
     --label "release" \
-    --label "release:stepflow-worker")
+    --label "release:stepflow-py")
 
 echo -e "${GREEN}✅ Release PR created successfully!${NC}"
 echo -e "${BLUE}PR URL: $PR_URL${NC}"

--- a/sdks/python/stepflow-orchestrator/pyproject.toml
+++ b/sdks/python/stepflow-orchestrator/pyproject.toml
@@ -56,6 +56,8 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/stepflow_orchestrator"]
+# Include binary files in bin/ directory (added at build time for releases)
+artifacts = ["src/stepflow_orchestrator/bin/*"]
 
 [tool.ruff]
 target-version = "py311"

--- a/stepflow-rs/cliff.toml
+++ b/stepflow-rs/cliff.toml
@@ -1,4 +1,5 @@
-# Configuration file for git-cliff for stepflow-rs package
+# Configuration file for git-cliff for the stepflow release
+# Covers stepflow-rs (Rust) and stepflow-orchestrator (Python wrapper)
 # See: https://git-cliff.org/docs/configuration
 
 [changelog]
@@ -12,8 +13,8 @@ All notable changes to this project will be documented in this file.
 # Template for the changelog body
 body = """
 {%- if version -%}
-    {%- set clean_version = version | trim_start_matches(pat="stepflow-rs-") -%}
-    ## <a id="{{ clean_version }}"></a> [Stepflow {{ clean_version }}](https://github.com/stepflow-ai/stepflow/releases/tag/stepflow-rs-{{ clean_version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+    {%- set clean_version = version | trim_start_matches(pat="stepflow-") -%}
+    ## <a id="{{ clean_version }}"></a> [Stepflow {{ clean_version }}](https://github.com/stepflow-ai/stepflow/releases/tag/stepflow-{{ clean_version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
 {%- else -%}
     ## unreleased
 {%- endif -%}
@@ -41,15 +42,18 @@ conventional_commits = true
 filter_unconventional = true
 # Process each line of a commit as an individual commit
 split_commits = false
-# Only include commits that affect the stepflow-rs directory or root files that affect stepflow-rs
+# Only include commits that affect stepflow (stepflow-rs + Python wrapper)
 filter_commits = true
 # Include commits that modify files in these paths
 include_paths = [
     "stepflow-rs/**",
+    "sdks/python/stepflow-orchestrator/**",
+    "scripts/build-stepflow-wheels.sh",
+    "scripts/prepare-release-stepflow.sh",
     "CLAUDE.md",
     "CONTRIBUTING.md",
     "README.md",
-    ".github/workflows/release_rust.yml",
+    ".github/workflows/release_stepflow.yml",
     ".github/workflows/ci.yml"
 ]
 # Regex for preprocessing the commit messages
@@ -74,7 +78,7 @@ commit_parsers = [
 # Protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false
 # Glob pattern for matching git tags
-tag_pattern = "stepflow-rs-[0-9.]*"
+tag_pattern = "stepflow-[0-9.]*"
 # Regex for skipping tags
 # Regex for ignoring tags
 ignore_tags = ""


### PR DESCRIPTION
- Rename stepflow-rs release unit to `stepflow` since this is the core releasable unit (and change tags to `stepflow-<version>`).
- Add `stepflow-orchestrator` platform-specific Python wheels to the `stepflow` release unit
- Add build-stepflow-wheels.sh script for building wheels from pre-built binaries
- Update stepflow-py release to update stepflow-orchestrator constraint on minor/major bumps
- Update cliff.toml to include stepflow-orchestrator paths and new tag pattern
- Configure hatch artifacts for binary inclusion in wheels

Closes #510