### PR TITLE
fix: Specify output directory for Python build in release workflow

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Build package
         working-directory: sdks/python/stepflow-py
-        run: uv build
+        run: uv build --out-dir dist/
 
       - name: Verify build
         working-directory: sdks/python/stepflow-py


### PR DESCRIPTION
When running `uv build` from a workspace member directory, the dist is created in the workspace root (sdks/python/dist/) rather than the member directory. Use --out-dir dist/ to ensure the output goes to the expected location.