### PR TITLE
fix: Add urllib3 dependency required by generated API client

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -108,9 +108,19 @@ jobs:
           echo "Built packages:"
           ls -la dist/
 
-          # Test that the built wheel can be imported
-          uv pip install dist/*.whl --force-reinstall
-          uv run python -c "import stepflow_py; print(f'stepflow_py version: {stepflow_py.__version__ if hasattr(stepflow_py, \"__version__\") else \"unknown\"}')"
+          # Create isolated venv and install the built wheel
+          echo "Creating isolated test environment..."
+          uv venv /tmp/verify-venv
+          source /tmp/verify-venv/bin/activate
+          uv pip install dist/*.whl
+
+          # Run release verification tests
+          echo "Running verification tests..."
+          python release_verification/verify_stepflow_py.py
+
+          # Clean up
+          deactivate
+          rm -rf /tmp/verify-venv
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release_stepflow.yml
+++ b/.github/workflows/release_stepflow.yml
@@ -229,10 +229,54 @@ jobs:
           path: ./wheels/*.whl
           retention-days: 7
 
+  verify-stepflow-wheels:
+    name: Verify Python Wheels
+    runs-on: ubuntu-22.04
+    needs: [build-stepflow-wheels]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: stepflow-wheels
+          path: ./wheels
+
+      - name: Verify wheel (Linux x86_64)
+        run: |
+          echo "Available wheels:"
+          ls -la ./wheels/
+
+          # Find the manylinux x86_64 wheel
+          WHEEL=$(ls ./wheels/*manylinux*x86_64*.whl 2>/dev/null | head -1)
+          if [ -z "$WHEEL" ]; then
+            echo "ERROR: No manylinux x86_64 wheel found"
+            exit 1
+          fi
+          echo "Testing wheel: $WHEEL"
+
+          # Create isolated venv and install the wheel
+          echo "Creating isolated test environment..."
+          uv venv /tmp/verify-venv
+          source /tmp/verify-venv/bin/activate
+          uv pip install "$WHEEL"
+
+          # Run release verification tests
+          echo "Running verification tests..."
+          python sdks/python/stepflow-orchestrator/release_verification/verify_stepflow_orchestrator.py
+
+          # Clean up
+          deactivate
+          rm -rf /tmp/verify-venv
+
   publish-stepflow-wheels:
     name: Publish Wheels to PyPI
     runs-on: ubuntu-22.04
-    needs: [determine-version, build-stepflow-wheels]
+    needs: [determine-version, build-stepflow-wheels, verify-stepflow-wheels]
     if: needs.determine-version.outputs.skip_tag == 'false'
     environment:
       name: pypi
@@ -438,7 +482,7 @@ jobs:
   summary:
     name: Build Summary
     runs-on: ubuntu-22.04
-    needs: [determine-version, build-binaries, build-docker, build-stepflow-wheels, publish-stepflow-wheels, create-tag-and-release]
+    needs: [determine-version, build-binaries, build-docker, build-stepflow-wheels, verify-stepflow-wheels, publish-stepflow-wheels, create-tag-and-release]
     if: always()
 
     steps:
@@ -465,6 +509,12 @@ jobs:
             echo "| Python wheel builds | ✅ Success |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| Python wheel builds | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ "${{ needs.verify-stepflow-wheels.result }}" = "success" ]; then
+            echo "| Python wheel verification | ✅ Success |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Python wheel verification | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
           fi
 
           if [ "${{ needs.determine-version.outputs.skip_tag }}" = "false" ]; then

--- a/sdks/python/stepflow-orchestrator/release_verification/verify_stepflow_orchestrator.py
+++ b/sdks/python/stepflow-orchestrator/release_verification/verify_stepflow_orchestrator.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Verify that stepflow-orchestrator release works correctly.
+
+This script tests that the stepflow-orchestrator package correctly provides
+the stepflow-server binary and can be used to run workflows.
+
+Usage:
+    python verify_stepflow_orchestrator.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_import() -> bool:
+    """Test that stepflow_orchestrator can be imported."""
+    print("Testing import...")
+    try:
+        import stepflow_orchestrator
+
+        print(f"  ✓ Import successful: {stepflow_orchestrator.__name__}")
+        return True
+    except ImportError as e:
+        print(f"  ✗ Import failed: {e}")
+        return False
+
+
+def test_orchestrator_class() -> bool:
+    """Test that OrchestratorConfig and StepflowOrchestrator classes are available."""
+    print("Testing orchestrator classes...")
+    try:
+        from stepflow_orchestrator import OrchestratorConfig, StepflowOrchestrator
+
+        # Verify OrchestratorConfig can be created
+        config = OrchestratorConfig(port=0)  # port 0 = auto-assign
+        print(f"  ✓ OrchestratorConfig created: port={config.port}")
+
+        # Verify StepflowOrchestrator has expected methods
+        assert hasattr(StepflowOrchestrator, "start")
+        assert hasattr(StepflowOrchestrator, "__aenter__")
+        assert hasattr(StepflowOrchestrator, "__aexit__")
+        print("  ✓ StepflowOrchestrator class has expected methods")
+
+        return True
+    except ImportError as e:
+        print(f"  ✗ Import failed: {e}")
+        return False
+    except Exception as e:
+        print(f"  ✗ Class test failed: {e}")
+        return False
+
+
+def test_binary_available() -> bool:
+    """Test that the bundled binary is available (or STEPFLOW_DEV_BINARY is set)."""
+    print("Testing binary availability...")
+    try:
+        # Check for dev binary first
+        dev_binary = os.environ.get("STEPFLOW_DEV_BINARY")
+        if dev_binary:
+            path = Path(dev_binary)
+            if path.exists():
+                print(f"  ✓ Dev binary found: {path}")
+                return True
+            else:
+                print(f"  ✗ STEPFLOW_DEV_BINARY set but not found: {path}")
+                return False
+
+        # Check for bundled binary
+        from stepflow_orchestrator import StepflowOrchestrator
+
+        # Create instance to access _get_binary_path (internal method)
+        orchestrator = StepflowOrchestrator()
+        try:
+            binary_path = orchestrator._get_binary_path()
+            print(f"  ✓ Bundled binary found: {binary_path}")
+            return True
+        except FileNotFoundError as e:
+            print(f"  ✗ Bundled binary not found: {e}")
+            return False
+
+    except Exception as e:
+        print(f"  ✗ Binary test failed: {e}")
+        return False
+
+
+def test_binary_execution() -> bool:
+    """Test that the binary can be executed (--help)."""
+    print("Testing binary execution...")
+    try:
+        # Get binary path
+        dev_binary = os.environ.get("STEPFLOW_DEV_BINARY")
+        if dev_binary:
+            binary_path = Path(dev_binary)
+        else:
+            from stepflow_orchestrator import StepflowOrchestrator
+
+            orchestrator = StepflowOrchestrator()
+            binary_path = orchestrator._get_binary_path()
+
+        # Run --help (returns exit code 0)
+        result = subprocess.run(
+            [str(binary_path), "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        if result.returncode != 0:
+            print(f"  ✗ Binary execution failed: {result.stderr}")
+            return False
+
+        # Check that help output looks reasonable
+        if "stepflow" in result.stdout.lower() or "usage" in result.stdout.lower():
+            print("  ✓ Binary executes successfully (--help works)")
+            return True
+        else:
+            print(f"  ✗ Unexpected --help output: {result.stdout[:200]}")
+            return False
+
+    except subprocess.TimeoutExpired:
+        print("  ✗ Binary execution timed out")
+        return False
+    except FileNotFoundError:
+        print("  ✗ Binary not found (skipping execution test)")
+        return False
+    except Exception as e:
+        print(f"  ✗ Binary execution test failed: {e}")
+        return False
+
+
+async def test_orchestrator_lifecycle() -> bool:
+    """Test starting and stopping the orchestrator."""
+    print("Testing orchestrator lifecycle...")
+    try:
+        from stepflow_orchestrator import OrchestratorConfig, StepflowOrchestrator
+    except ImportError as e:
+        print(f"  ✗ Import failed: {e}")
+        return False
+
+    # Use port 0 for auto-assignment
+    config = OrchestratorConfig(port=0, log_level="warn")
+
+    try:
+        print("  Starting orchestrator...")
+        async with StepflowOrchestrator.start(config) as orchestrator:
+            port = orchestrator.port
+            url = orchestrator.url
+            is_running = orchestrator.is_running
+
+            print(f"  ✓ Orchestrator started: port={port}, url={url}")
+
+            if not is_running:
+                print("  ✗ Orchestrator reports not running")
+                return False
+            print("  ✓ Orchestrator is_running=True")
+
+        # After context exit, it should be stopped
+        print("  ✓ Orchestrator stopped successfully")
+        return True
+
+    except FileNotFoundError as e:
+        print(f"  ✗ Binary not found: {e}")
+        return False
+    except Exception as e:
+        print(f"  ✗ Lifecycle test failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def main():
+    print("=" * 60)
+    print("Stepflow-orchestrator Release Verification")
+    print("=" * 60)
+    print()
+
+    results = []
+
+    # Run tests
+    results.append(("Import", test_import()))
+    results.append(("Classes", test_orchestrator_class()))
+    results.append(("Binary available", test_binary_available()))
+    results.append(("Binary execution", test_binary_execution()))
+
+    # Full lifecycle test
+    print()
+    results.append(
+        ("Orchestrator lifecycle", asyncio.run(test_orchestrator_lifecycle()))
+    )
+
+    # Summary
+    print()
+    print("=" * 60)
+    print("Summary")
+    print("=" * 60)
+
+    passed = sum(1 for _, r in results if r)
+    total = len(results)
+
+    for name, result in results:
+        status = "✓ PASS" if result else "✗ FAIL"
+        print(f"  {status}: {name}")
+
+    print()
+    print(f"Results: {passed}/{total} tests passed")
+
+    if passed == total:
+        print("\n✓ All tests passed!")
+        return 0
+    else:
+        print("\n✗ Some tests failed!")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sdks/python/stepflow-py/pyproject.toml
+++ b/sdks/python/stepflow-py/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "aiohttp-retry>=2.8.0",
     "python-dateutil>=2.8.2",
     "typing-extensions>=4.7.1",
+    "urllib3>=2.0.0",  # Required by generated API client
 ]
 
 [project.urls]
@@ -130,9 +131,6 @@ opentelemetry-api = "opentelemetry"
 opentelemetry-sdk = "opentelemetry"
 opentelemetry-exporter-otlp-proto-grpc = "opentelemetry"
 python-dateutil = "dateutil"
-
-[tool.deptry.per_rule_ignores]
-DEP001 = ["urllib3"]  # urllib3 is a transitive dependency used by generated API client
 
 # Note: mypy configuration is at the workspace level (sdks/python/pyproject.toml)
 # to ensure consistent settings across all packages

--- a/sdks/python/stepflow-py/release_verification/verify_stepflow_py.py
+++ b/sdks/python/stepflow-py/release_verification/verify_stepflow_py.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Verify that stepflow-py release works correctly.
+
+This script tests both basic import/API functionality and local orchestrator
+execution when stepflow-orchestrator is installed.
+
+Usage:
+    # Test basic stepflow-py functionality
+    python verify_stepflow_py.py
+
+    # Test with local orchestrator (requires stepflow-py[local])
+    python verify_stepflow_py.py --local
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+
+def test_basic_imports() -> bool:
+    """Test that core imports work correctly."""
+    print("Testing basic imports...")
+    try:
+        from stepflow_py import Flow, Step, StepflowClient  # noqa: F401
+        from stepflow_py.api import ApiClient, Configuration  # noqa: F401
+        from stepflow_py.api.models import ExecutionStatus  # noqa: F401
+
+        print("  ✓ Core imports successful")
+        return True
+    except ImportError as e:
+        print(f"  ✗ Import failed: {e}")
+        return False
+
+
+def test_config_imports() -> bool:
+    """Test that config imports work correctly."""
+    print("Testing config imports...")
+    try:
+        from stepflow_py.config import (
+            BuiltinPluginConfig,
+            InMemoryStateStoreConfig,
+            RouteRule,
+            StepflowConfig,
+        )
+
+        # Create a simple config to verify models work
+        config = StepflowConfig(
+            plugins={"builtin": BuiltinPluginConfig()},
+            routes={"/{*component}": [RouteRule(plugin="builtin")]},
+            stateStore=InMemoryStateStoreConfig(type="inMemory"),
+        )
+        print(f"  ✓ Config creation successful: {type(config).__name__}")
+        return True
+    except ImportError as e:
+        print(f"  ✗ Import failed: {e}")
+        return False
+    except Exception as e:
+        print(f"  ✗ Config creation failed: {e}")
+        return False
+
+
+def test_api_models() -> bool:
+    """Test that API models can be imported and used."""
+    print("Testing API models...")
+    try:
+        from stepflow_py.api.models import (
+            ExecutionStatus,
+        )
+
+        # Verify ExecutionStatus enum values
+        assert hasattr(ExecutionStatus, "COMPLETED")
+        assert hasattr(ExecutionStatus, "FAILED")
+        print("  ✓ API models imported successfully")
+        return True
+    except Exception as e:
+        print(f"  ✗ API models test failed: {e}")
+        return False
+
+
+def test_client_class() -> bool:
+    """Test that StepflowClient class is available."""
+    print("Testing client class...")
+    try:
+        from stepflow_py import StepflowClient
+
+        # Verify methods exist
+        assert hasattr(StepflowClient, "connect")
+        assert hasattr(StepflowClient, "local")
+        assert hasattr(StepflowClient, "store_flow")
+        assert hasattr(StepflowClient, "run")
+        print("  ✓ StepflowClient class available with expected methods")
+        return True
+    except Exception as e:
+        print(f"  ✗ Client class test failed: {e}")
+        return False
+
+
+async def test_local_orchestrator() -> bool:
+    """Test local orchestrator functionality (requires stepflow-py[local]).
+
+    This test verifies:
+    1. The orchestrator can be started from the installed package
+    2. The health endpoint responds correctly
+    3. The client can communicate with the orchestrator
+
+    Note: Full flow execution tests are in the integration test suite.
+    """
+    print("Testing local orchestrator...")
+
+    try:
+        from stepflow_py import StepflowClient
+        from stepflow_py.config import (
+            BuiltinPluginConfig,
+            InMemoryStateStoreConfig,
+            RouteRule,
+            StepflowConfig,
+        )
+    except ImportError as e:
+        print(f"  ✗ Import failed: {e}")
+        return False
+
+    # Create config with builtin plugin only
+    config = StepflowConfig(
+        plugins={"builtin": BuiltinPluginConfig()},
+        routes={"/{*component}": [RouteRule(plugin="builtin")]},
+        stateStore=InMemoryStateStoreConfig(type="inMemory"),
+    )
+
+    try:
+        print("  Starting local orchestrator...")
+        async with StepflowClient.local(config, startup_timeout=60.0) as client:
+            print(f"  ✓ Orchestrator started, server at {client.base_url}")
+
+            # Check health
+            is_healthy = await client.is_healthy()
+            if not is_healthy:
+                print("  ✗ Health check failed")
+                return False
+            print("  ✓ Health check passed")
+
+            # Verify we can make API calls (list flows should return empty)
+            print("  ✓ Local orchestrator test passed")
+            return True
+
+    except ImportError as e:
+        if "stepflow_orchestrator" in str(e):
+            print("  ✗ stepflow-orchestrator not installed")
+            print("    Install with: pip install stepflow-py[local]")
+        else:
+            print(f"  ✗ Import error: {e}")
+        return False
+    except Exception as e:
+        print(f"  ✗ Local orchestrator test failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verify stepflow-py release functionality"
+    )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Test local orchestrator (requires stepflow-py[local])",
+    )
+    args = parser.parse_args()
+
+    print("=" * 60)
+    print("Stepflow-py Release Verification")
+    print("=" * 60)
+    print()
+
+    results = []
+
+    # Basic tests (always run)
+    results.append(("Basic imports", test_basic_imports()))
+    results.append(("Config imports", test_config_imports()))
+    results.append(("API models", test_api_models()))
+    results.append(("Client class", test_client_class()))
+
+    # Local orchestrator test (optional)
+    if args.local:
+        print()
+        results.append(("Local orchestrator", asyncio.run(test_local_orchestrator())))
+
+    # Summary
+    print()
+    print("=" * 60)
+    print("Summary")
+    print("=" * 60)
+
+    passed = sum(1 for _, r in results if r)
+    total = len(results)
+
+    for name, result in results:
+        status = "✓ PASS" if result else "✗ FAIL"
+        print(f"  {status}: {name}")
+
+    print()
+    print(f"Results: {passed}/{total} tests passed")
+
+    if passed == total:
+        print("\n✓ All tests passed!")
+        return 0
+    else:
+        print("\n✗ Some tests failed!")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -1946,7 +1946,7 @@ wheels = [
 
 [[package]]
 name = "stepflow-orchestrator"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "stepflow-orchestrator" }
 dependencies = [
     { name = "msgspec" },
@@ -1973,7 +1973,7 @@ dev = [
 
 [[package]]
 name = "stepflow-py"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "stepflow-py" }
 dependencies = [
     { name = "aiohttp" },
@@ -1987,6 +1987,7 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "types-jsonschema" },
     { name = "typing-extensions" },
+    { name = "urllib3" },
 ]
 
 [package.optional-dependencies]
@@ -2038,6 +2039,7 @@ requires-dist = [
     { name = "stepflow-orchestrator", marker = "extra == 'local'", editable = "stepflow-orchestrator" },
     { name = "types-jsonschema", specifier = ">=4.17.0" },
     { name = "typing-extensions", specifier = ">=4.7.1" },
+    { name = "urllib3", specifier = ">=2.0.0" },
     { name = "uvicorn", marker = "extra == 'http'", specifier = ">=0.24.0" },
 ]
 provides-extras = ["http", "langchain", "local"]


### PR DESCRIPTION
chore: Add release verification tests and run before PyPI publishing

- Create verify_stepflow_py.py for stepflow-py release verification
- Create verify_stepflow_orchestrator.py for orchestrator release verification
- Update release_python.yml to test locally built wheel before publishing
- Update release_stepflow.yml to test wheel before publishing

Verification tests catch issues like missing dependencies or broken binaries before they reach users on PyPI.