### PR TITLE
fix: Use correct path for Python SDK version extraction

### DIFF
--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Extract version from pyproject.toml
         id: version
-        working-directory: sdks/python
+        working-directory: sdks/python/stepflow-py
         run: |
           VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The version is in sdks/python/stepflow-py/pyproject.toml, not the workspace root sdks/python/pyproject.toml.