### PR TITLE
fix: Correct pyproject.toml path in Python release dispatch

### DIFF
--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Extract version from pyproject.toml
         id: version
-        working-directory: sdks/python
+        working-directory: sdks/python/stepflow-py
         run: |
           VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The version extraction was looking at sdks/python/pyproject.toml (the workspace config which has no version) instead of the correct location at sdks/python/stepflow-py/pyproject.toml.