### PR TITLE
feat: Add Langflow core component handling

### DIFF
--- a/integrations/langflow/src/stepflow_langflow_integration/converter/known_components.py
+++ b/integrations/langflow/src/stepflow_langflow_integration/converter/known_components.py
@@ -1,0 +1,121 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Hash-to-module mappings for known Langflow core components.
+
+This module contains mappings of code hashes to component module paths for
+known Langflow core components. When a component's code_hash matches an entry
+here and the module matches, we can use the core executor instead of compiling
+custom code from a blob.
+
+The hashes are derived from the Langflow workflow metadata and can be found in
+the `metadata.code_hash` and `metadata.module` fields of each node.
+"""
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class KnownComponent:
+    """A known core component mapping."""
+
+    code_hash: str
+    module: (
+        str  # Full module path, e.g., "lfx.components.docling.DoclingInlineComponent"
+    )
+    description: str = ""
+
+
+# Mapping of code_hash -> KnownComponent
+# These hashes are version-specific and may need updating when Langflow versions change
+KNOWN_COMPONENTS: dict[str, KnownComponent] = {
+    # ChatInput component (lfx)
+    "f701f686b325": KnownComponent(
+        code_hash="f701f686b325",
+        module="lfx.components.input_output.chat.ChatInput",
+        description="Chat Input component",
+    ),
+    # ChatOutput component (lfx)
+    "9647f4d2f4b4": KnownComponent(
+        code_hash="9647f4d2f4b4",
+        module="lfx.components.input_output.chat_output.ChatOutput",
+        description="Chat Output component",
+    ),
+    # LanguageModelComponent (lfx)
+    "bb5f8714781b": KnownComponent(
+        code_hash="bb5f8714781b",
+        module="lfx.components.models.language_model.LanguageModelComponent",
+        description="Language Model component",
+    ),
+    # PromptComponent (langflow)
+    "3bf0b511e227": KnownComponent(
+        code_hash="3bf0b511e227",
+        module="langflow.components.prompts.prompt.PromptComponent",
+        description="Prompt template component",
+    ),
+    # Add more known components here as needed
+    # Example for DoclingInlineComponent (hash TBD):
+    # "HASH_HERE": KnownComponent(
+    #     code_hash="HASH_HERE",
+    #     module="lfx.components.docling.DoclingInlineComponent",
+    #     description="Docling inline document processing",
+    # ),
+}
+
+
+def lookup_known_component(
+    code_hash: str, module: str | None = None
+) -> KnownComponent | None:
+    """Look up a known component by code hash.
+
+    Args:
+        code_hash: The code_hash from workflow metadata
+        module: Optional module path to verify (safety check)
+
+    Returns:
+        KnownComponent if found and module matches (if provided), None otherwise
+    """
+    known = KNOWN_COMPONENTS.get(code_hash)
+
+    if known is None:
+        return None
+
+    # If module provided, verify it matches
+    if module is not None and known.module != module:
+        # Hash collision or outdated mapping - log warning and return None
+        logger.warning(
+            f"Code hash {code_hash} matches known component {known.module} "
+            f"but workflow specifies {module}. Using custom_code executor."
+        )
+        return None
+
+    return known
+
+
+def module_to_path(module: str) -> str:
+    """Convert module path to URL path segment.
+
+    Example: "lfx.components.docling.DoclingInlineComponent"
+          -> "lfx/components/docling/DoclingInlineComponent"
+
+    Args:
+        module: Full module path with dots
+
+    Returns:
+        URL path segment with slashes
+    """
+    return module.replace(".", "/")

--- a/integrations/langflow/src/stepflow_langflow_integration/converter/stepflow_tweaks.py
+++ b/integrations/langflow/src/stepflow_langflow_integration/converter/stepflow_tweaks.py
@@ -62,13 +62,19 @@ def apply_stepflow_tweaks_to_dict(
 
     for step_dict in modified_dict.get("steps", []):
         step_id = step_dict.get("id", "")
+        component = step_dict.get("component", "")
 
-        # Check if this is a Langflow UDF executor step
-        if (
+        # Check if this is a Langflow executor step (custom_code or core)
+        is_langflow_step = (
             step_id.startswith("langflow_")
             and not step_id.endswith("_blob")
-            and step_dict.get("component") == "/langflow/udf_executor"
-        ):
+            and (
+                component == "/langflow/custom_code"
+                or component.startswith("/langflow/core/")
+            )
+        )
+
+        if is_langflow_step:
             # Extract Langflow node ID
             langflow_node_id = step_id[len("langflow_") :]
 

--- a/integrations/langflow/src/stepflow_langflow_integration/executor/base_executor.py
+++ b/integrations/langflow/src/stepflow_langflow_integration/executor/base_executor.py
@@ -1,0 +1,119 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Base executor class with shared functionality for Langflow component execution."""
+
+from typing import Any
+
+from .type_converter import TypeConverter
+
+
+class BaseExecutor:
+    """Base class for Langflow component executors.
+
+    Provides shared functionality for both core and custom code executors:
+    - Execution method determination
+    - Component input defaults application
+    - Type conversion utilities
+    """
+
+    def __init__(self):
+        """Initialize base executor with shared components."""
+        self.type_converter = TypeConverter()
+
+    def _determine_execution_method(
+        self, outputs: list[dict[str, Any]], selected_output: str | None
+    ) -> str | None:
+        """Determine which method to call based on outputs configuration.
+
+        Args:
+            outputs: List of output definitions from the component
+            selected_output: The name of the selected output (if any)
+
+        Returns:
+            The method name to call, or None if not found
+        """
+        if not outputs:
+            return None
+
+        # If selected_output is provided, find the matching output method
+        if selected_output:
+            for output in outputs:
+                if output.get("name") == selected_output:
+                    method = output.get("method")
+                    if isinstance(method, str) and method:
+                        return method
+
+        # Default to first output's method
+        method = outputs[0].get("method")
+        if isinstance(method, str) and method:
+            return method
+
+        return None
+
+    def _apply_component_input_defaults(
+        self, component_instance: Any, parameters: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Apply default values from component's input definitions.
+
+        Args:
+            component_instance: Instantiated component with inputs attribute
+            parameters: Current component parameters
+
+        Returns:
+            Parameters with defaults applied for missing values
+        """
+        if not hasattr(component_instance, "inputs"):
+            return parameters
+
+        inputs = component_instance.inputs
+        if not inputs:
+            return parameters
+
+        result = dict(parameters)
+
+        for input_def in inputs:
+            field_name = getattr(input_def, "name", None)
+            if not field_name:
+                continue
+
+            # Only set default if not already in parameters
+            if field_name not in result:
+                default_value = getattr(input_def, "value", None)
+                if default_value is not None and default_value != "":
+                    result[field_name] = default_value
+
+        return result
+
+    def _setup_graph_context(
+        self, component_instance: Any, session_id: str
+    ) -> None:
+        """Set up graph context for components that need it.
+
+        Some components (like Agent) access self.graph.session_id and
+        self.graph.vertices. This creates a minimal graph context object.
+
+        Args:
+            component_instance: Component instance to configure
+            session_id: Session ID for the graph context
+        """
+
+        class GraphContext:
+            def __init__(self, session_id: str):
+                self.session_id = session_id
+                self.vertices: list[Any] = []
+                self.flow_id = None
+
+        # Use __dict__ to set graph even if it's a read-only property
+        component_instance.__dict__["graph"] = GraphContext(session_id)

--- a/integrations/langflow/src/stepflow_langflow_integration/executor/core_executor.py
+++ b/integrations/langflow/src/stepflow_langflow_integration/executor/core_executor.py
@@ -1,0 +1,205 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Core component executor for known Langflow components.
+
+Executes known Langflow components by importing them directly by module path,
+without needing to compile code from blob storage. This is more efficient for
+components whose code hash matches a known version.
+"""
+
+import importlib
+import inspect
+from typing import Any
+
+from stepflow_py.worker import StepflowContext
+from stepflow_py.worker.observability import get_tracer
+
+from ..exceptions import ExecutionError
+from .base_executor import BaseExecutor
+
+
+class CoreExecutor(BaseExecutor):
+    """Executes known Langflow components by importing them directly."""
+
+    def __init__(self):
+        """Initialize core executor."""
+        super().__init__()
+
+    async def execute(
+        self,
+        component_path: str,
+        input_data: dict[str, Any],
+        context: StepflowContext,
+    ) -> dict[str, Any]:
+        """Execute a core Langflow component.
+
+        Args:
+            component_path: The component path suffix after /langflow/core/
+                           (e.g., "lfx/components/docling/DoclingInlineComponent")
+            input_data: Component input containing template, outputs, runtime inputs
+            context: Stepflow context (may be needed for some operations)
+
+        Returns:
+            Component execution result
+        """
+        tracer = get_tracer(__name__)
+
+        # Convert path to module path (slashes to dots)
+        # e.g., "lfx/components/docling/DoclingInlineComponent"
+        #    -> "lfx.components.docling.DoclingInlineComponent"
+        module_path = component_path.replace("/", ".")
+
+        # Split into module and class name
+        parts = module_path.rsplit(".", 1)
+        if len(parts) != 2:
+            raise ExecutionError(f"Invalid component path: {component_path}")
+
+        module_name, class_name = parts
+
+        with tracer.start_as_current_span(
+            f"core_execute:{class_name}",
+            attributes={
+                "component_path": component_path,
+                "module_name": module_name,
+                "class_name": class_name,
+            },
+        ):
+            # Import the component class
+            try:
+                module = importlib.import_module(module_name)
+                component_class = getattr(module, class_name)
+            except ImportError as e:
+                raise ExecutionError(
+                    f"Failed to import module {module_name}: {e}"
+                ) from e
+            except AttributeError as e:
+                raise ExecutionError(
+                    f"Class {class_name} not found in module {module_name}: {e}"
+                ) from e
+
+            # Extract execution parameters from input
+            template = input_data.get("template", {})
+            outputs = input_data.get("outputs", [])
+            selected_output = input_data.get("selected_output")
+            runtime_inputs = input_data.get("input", {})
+
+            # Determine execution method
+            execution_method = self._determine_execution_method(
+                outputs, selected_output
+            )
+            if not execution_method:
+                raise ExecutionError(f"No execution method found for {class_name}")
+
+            # Execute the component
+            result = await self._execute_component(
+                component_class=component_class,
+                template=template,
+                execution_method=execution_method,
+                runtime_inputs=runtime_inputs,
+                class_name=class_name,
+            )
+
+            return {"result": self.type_converter.serialize_langflow_object(result)}
+
+    async def _execute_component(
+        self,
+        component_class: type,
+        template: dict[str, Any],
+        execution_method: str,
+        runtime_inputs: dict[str, Any],
+        class_name: str,
+    ) -> Any:
+        """Execute a component instance."""
+        tracer = get_tracer(__name__)
+
+        # Create component instance
+        with tracer.start_as_current_span(
+            f"instantiate_component:{class_name}",
+            attributes={"class_name": class_name},
+        ):
+            try:
+                component_instance = component_class()
+            except Exception as e:
+                raise ExecutionError(f"Failed to instantiate {class_name}: {e}") from e
+
+        # Prepare parameters
+        component_parameters = await self._prepare_component_parameters(
+            template, runtime_inputs
+        )
+
+        # Apply component input defaults
+        component_parameters = self._apply_component_input_defaults(
+            component_instance, component_parameters
+        )
+
+        # Set session_id and graph context
+        session_id = component_parameters.get("session_id", "default_session")
+        component_instance._session_id = session_id
+        self._setup_graph_context(component_instance, session_id)
+
+        # Configure component
+        if hasattr(component_instance, "set_attributes"):
+            component_instance._parameters = component_parameters
+            component_instance.set_attributes(component_parameters)
+
+        # Execute component method
+        if not hasattr(component_instance, execution_method):
+            available = [m for m in dir(component_instance) if not m.startswith("_")]
+            raise ExecutionError(
+                f"Method {execution_method} not found in {class_name}. "
+                f"Available: {available}"
+            )
+
+        method = getattr(component_instance, execution_method)
+
+        with tracer.start_as_current_span(
+            f"execute_method:{execution_method}",
+            attributes={
+                "class_name": class_name,
+                "execution_method": execution_method,
+            },
+        ):
+            try:
+                if inspect.iscoroutinefunction(method):
+                    result = await method()
+                else:
+                    result = method()
+                return result
+            except Exception as e:
+                raise ExecutionError(
+                    f"Error executing {execution_method} on {class_name}: {e}"
+                ) from e
+
+    async def _prepare_component_parameters(
+        self, template: dict[str, Any], runtime_inputs: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Prepare component parameters from template and runtime inputs."""
+        parameters: dict[str, Any] = {}
+
+        # Extract default values from template
+        for key, field in template.items():
+            if isinstance(field, dict) and "value" in field:
+                parameters[key] = field["value"]
+            elif isinstance(field, dict):
+                # Field without value - skip or use None
+                pass
+            else:
+                # Direct value
+                parameters[key] = field
+
+        # Override with runtime inputs
+        parameters.update(runtime_inputs)
+
+        return parameters

--- a/integrations/langflow/src/stepflow_langflow_integration/executor/standalone_server.py
+++ b/integrations/langflow/src/stepflow_langflow_integration/executor/standalone_server.py
@@ -31,22 +31,37 @@ from stepflow_py.worker import StepflowContext, StepflowServer
 from stepflow_langflow_integration.components.component_tool import (
     component_tool_executor,
 )
-from stepflow_langflow_integration.executor.udf_executor import UDFExecutor
+from stepflow_langflow_integration.executor.core_executor import CoreExecutor
+from stepflow_langflow_integration.executor.custom_code_executor import (
+    CustomCodeExecutor,
+)
 
 # Create server instance (following the exact pattern from stepflow_py.worker/main.py)
 server = StepflowServer()
 
-# Create UDF executor
-udf_executor = UDFExecutor()
+# Create executors
+custom_code_executor = CustomCodeExecutor()
+core_executor = CoreExecutor()
 
 
-# Register the main UDF executor component at module level
-@server.component(name="udf_executor")
-async def udf_executor_component(
+# Register the main custom code executor component at module level
+@server.component(name="custom_code")
+async def custom_code_component(
     input_data: dict[str, Any], context: StepflowContext
 ) -> dict[str, Any]:
-    """Execute a Langflow UDF component."""
-    return await udf_executor.execute(input_data, context)
+    """Execute a Langflow custom code component."""
+    return await custom_code_executor.execute(input_data, context)
+
+
+# Register the core component handler with wildcard path
+@server.component(name="core/{*component}")
+async def core_component(
+    input_data: dict[str, Any],
+    context: StepflowContext,
+    component: str,
+) -> dict[str, Any]:
+    """Execute a known core Langflow component by module path."""
+    return await core_executor.execute(component, input_data, context)
 
 
 # Register the component tool wrapper component
@@ -58,7 +73,7 @@ async def component_tool_component(
     return await component_tool_executor(input_data, context)
 
 
-# All Langflow components now route through the UDF executor for real execution
+# All Langflow components now route through the custom code executor for real execution
 # No hardcoded component implementations - everything uses real Langflow code
 
 

--- a/integrations/langflow/tests/unit/test_core_executor.py
+++ b/integrations/langflow/tests/unit/test_core_executor.py
@@ -1,0 +1,301 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Unit tests for the CoreExecutor."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from stepflow_langflow_integration.exceptions import ExecutionError
+from stepflow_langflow_integration.executor.core_executor import CoreExecutor
+
+
+@pytest.fixture
+def executor():
+    """Create a CoreExecutor instance."""
+    return CoreExecutor()
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock StepflowContext."""
+    context = MagicMock()
+    context.get_blob = AsyncMock(return_value={})
+    context.put_blob = AsyncMock(return_value="blob_id")
+    return context
+
+
+class TestCoreExecutorPathConversion:
+    """Tests for path to module conversion."""
+
+    def test_simple_path_conversion(self, executor):
+        """Test converting simple path to module."""
+        # The conversion happens inside execute(), but we can test
+        # the logic indirectly
+        pass  # Path conversion is internal to execute()
+
+
+class TestCoreExecutorExecutionMethodDetermination:
+    """Tests for _determine_execution_method inherited from base."""
+
+    def test_determine_execution_method_with_selected_output(self, executor):
+        """Test determining method when selected_output matches."""
+        outputs = [
+            {"name": "text", "method": "text_response"},
+            {"name": "message", "method": "build_message"},
+        ]
+        result = executor._determine_execution_method(outputs, "message")
+        assert result == "build_message"
+
+    def test_determine_execution_method_fallback_to_first(self, executor):
+        """Test falling back to first output's method."""
+        outputs = [
+            {"name": "default", "method": "default_method"},
+            {"name": "other", "method": "other_method"},
+        ]
+        result = executor._determine_execution_method(outputs, None)
+        assert result == "default_method"
+
+    def test_determine_execution_method_empty_outputs(self, executor):
+        """Test with empty outputs list."""
+        result = executor._determine_execution_method([], None)
+        assert result is None
+
+    def test_determine_execution_method_selected_not_found(self, executor):
+        """Test when selected_output doesn't match any output."""
+        outputs = [{"name": "text", "method": "text_method"}]
+        result = executor._determine_execution_method(outputs, "nonexistent")
+        # Should fall back to first output's method
+        assert result == "text_method"
+
+
+class TestCoreExecutorInputDefaults:
+    """Tests for _apply_component_input_defaults inherited from base."""
+
+    def test_apply_defaults_no_inputs(self, executor):
+        """Test with component that has no inputs attribute."""
+        component = MagicMock(spec=[])  # No inputs attribute
+        params = {"key": "value"}
+        result = executor._apply_component_input_defaults(component, params)
+        assert result == {"key": "value"}
+
+    def test_apply_defaults_empty_inputs(self, executor):
+        """Test with empty inputs list."""
+        component = MagicMock()
+        component.inputs = []
+        params = {"key": "value"}
+        result = executor._apply_component_input_defaults(component, params)
+        assert result == {"key": "value"}
+
+    def test_apply_defaults_adds_missing(self, executor):
+        """Test that defaults are added for missing parameters."""
+        input_def = MagicMock()
+        input_def.name = "temperature"
+        input_def.value = 0.7
+
+        component = MagicMock()
+        component.inputs = [input_def]
+
+        params = {"model": "gpt-4"}
+        result = executor._apply_component_input_defaults(component, params)
+        assert result == {"model": "gpt-4", "temperature": 0.7}
+
+    def test_apply_defaults_preserves_existing(self, executor):
+        """Test that existing params are not overwritten."""
+        input_def = MagicMock()
+        input_def.name = "temperature"
+        input_def.value = 0.7
+
+        component = MagicMock()
+        component.inputs = [input_def]
+
+        params = {"temperature": 0.9}  # Already set
+        result = executor._apply_component_input_defaults(component, params)
+        assert result == {"temperature": 0.9}  # Original value preserved
+
+
+class TestCoreExecutorErrors:
+    """Tests for error handling in CoreExecutor."""
+
+    @pytest.mark.asyncio
+    async def test_execute_invalid_path_no_dot(self, executor, mock_context):
+        """Test error when path has no class name separator."""
+        with pytest.raises(ExecutionError, match="Invalid component path"):
+            await executor.execute("invalid", {}, mock_context)
+
+    @pytest.mark.asyncio
+    async def test_execute_module_not_found(self, executor, mock_context):
+        """Test error when module doesn't exist."""
+        input_data = {
+            "template": {},
+            "outputs": [{"name": "result", "method": "run"}],
+            "input": {},
+        }
+        with pytest.raises(ExecutionError, match="Failed to import module"):
+            await executor.execute(
+                "nonexistent/module/path/ClassName", input_data, mock_context
+            )
+
+    @pytest.mark.asyncio
+    async def test_execute_class_not_found(self, executor, mock_context):
+        """Test error when class doesn't exist in module."""
+        input_data = {
+            "template": {},
+            "outputs": [{"name": "result", "method": "run"}],
+            "input": {},
+        }
+        # os module exists but NonExistentClass doesn't
+        with pytest.raises(ExecutionError, match="Class.*not found in module"):
+            await executor.execute("os/NonExistentClass", input_data, mock_context)
+
+    @pytest.mark.asyncio
+    async def test_execute_no_execution_method(self, executor, mock_context):
+        """Test error when no execution method found."""
+        input_data = {
+            "template": {},
+            "outputs": [],  # Empty outputs
+            "input": {},
+        }
+        # Use a real importable class
+        with pytest.raises(ExecutionError, match="No execution method found"):
+            await executor.execute(
+                "dataclasses/dataclass", input_data, mock_context
+            )
+
+
+class TestCoreExecutorWithRealComponent:
+    """Integration tests with real Langflow components.
+
+    Note: Some Langflow components have complex dependencies (database, etc.)
+    These tests focus on verifying the executor can import and instantiate
+    components, rather than full execution which may require more setup.
+    """
+
+    @pytest.mark.asyncio
+    async def test_import_prompt_component(self, executor, mock_context):
+        """Test that PromptComponent can be imported and instantiated."""
+        import importlib
+
+        try:
+            module = importlib.import_module("langflow.components.prompts.prompt")
+            component_class = module.PromptComponent
+
+            # Verify we can instantiate
+            instance = component_class()
+            assert instance is not None
+            assert hasattr(instance, "build_prompt")
+        except ModuleNotFoundError:
+            # langflow.components.prompts may not be available in all environments
+            # Skip test if not available
+            pytest.skip("langflow.components.prompts not available")
+
+    @pytest.mark.asyncio
+    async def test_import_chat_input_component(self, executor, mock_context):
+        """Test that ChatInput component can be imported and instantiated."""
+        import importlib
+
+        module = importlib.import_module("lfx.components.input_output.chat")
+        component_class = module.ChatInput
+
+        # Verify we can instantiate
+        instance = component_class()
+        assert instance is not None
+        assert hasattr(instance, "message_response")
+
+    @pytest.mark.asyncio
+    async def test_execute_with_mocked_method(self, executor, mock_context):
+        """Test execution flow with a mocked component method."""
+        from unittest.mock import MagicMock, patch
+
+        input_data = {
+            "template": {
+                "template": {"value": "Hello {name}!"},
+            },
+            "outputs": [{"name": "prompt", "method": "build_prompt"}],
+            "selected_output": "prompt",
+            "input": {
+                "name": "World",
+            },
+        }
+
+        # Mock the component instantiation and method
+        mock_instance = MagicMock()
+        mock_instance.inputs = []
+        mock_instance.build_prompt = MagicMock(return_value="Hello World!")
+
+        with patch(
+            "importlib.import_module"
+        ) as mock_import:
+            mock_module = MagicMock()
+            mock_module.TestComponent = MagicMock(return_value=mock_instance)
+            mock_import.return_value = mock_module
+
+            result = await executor.execute(
+                "test_module/TestComponent",
+                input_data,
+                mock_context,
+            )
+
+            assert "result" in result
+            # Method was called
+            mock_instance.build_prompt.assert_called_once()
+
+
+class TestCoreExecutorPrepareParameters:
+    """Tests for _prepare_component_parameters."""
+
+    @pytest.mark.asyncio
+    async def test_extract_values_from_template(self, executor):
+        """Test extracting values from template structure."""
+        template = {
+            "param1": {"value": "value1"},
+            "param2": {"value": 42},
+            "param3": "direct_value",
+        }
+        runtime_inputs = {}
+
+        result = await executor._prepare_component_parameters(template, runtime_inputs)
+
+        assert result["param1"] == "value1"
+        assert result["param2"] == 42
+        assert result["param3"] == "direct_value"
+
+    @pytest.mark.asyncio
+    async def test_runtime_inputs_override_template(self, executor):
+        """Test that runtime inputs override template values."""
+        template = {
+            "param1": {"value": "template_value"},
+        }
+        runtime_inputs = {
+            "param1": "runtime_value",
+        }
+
+        result = await executor._prepare_component_parameters(template, runtime_inputs)
+
+        assert result["param1"] == "runtime_value"
+
+    @pytest.mark.asyncio
+    async def test_empty_template_dict_skipped(self, executor):
+        """Test that template fields without value are skipped."""
+        template = {
+            "param1": {"value": "has_value"},
+            "param2": {},  # No value key
+            "param3": {"type": "str"},  # No value key
+        }
+        runtime_inputs = {}
+
+        result = await executor._prepare_component_parameters(template, runtime_inputs)
+
+        assert result == {"param1": "has_value"}

--- a/integrations/langflow/tests/unit/test_stepflow_tweaks.py
+++ b/integrations/langflow/tests/unit/test_stepflow_tweaks.py
@@ -117,18 +117,18 @@ class TestStepflowTweaksIntegration:
 
         modified_dict = apply_stepflow_tweaks_to_dict(basic_prompting_flow_dict, tweaks)
 
-        # Find the LanguageModelComponent UDF executor step
+        # Find the LanguageModelComponent executor step (custom_code or core)
         langflow_step = None
         for step in modified_dict["steps"]:
-            if (
-                step["id"] == "langflow_LanguageModelComponent-kBOja"
-                and step["component"] == "/langflow/udf_executor"
+            if step["id"] == "langflow_LanguageModelComponent-kBOja" and (
+                step["component"] == "/langflow/custom_code"
+                or step["component"].startswith("/langflow/core/")
             ):
                 langflow_step = step
                 break
 
         assert langflow_step is not None, (
-            "LanguageModelComponent UDF executor step not found"
+            "LanguageModelComponent executor step not found"
         )
 
         # Verify tweaks were applied

--- a/integrations/langflow/tests/unit/test_translator.py
+++ b/integrations/langflow/tests/unit/test_translator.py
@@ -400,13 +400,13 @@ class CustomComponent(Component):
 
         workflow = converter.convert(workflow_data)
 
-        # Should create blob step + UDF executor step for component with custom code
+        # Should create blob + custom_code steps for component with custom code
         step_components = [step.component for step in workflow.steps]
         assert "/builtin/put_blob" in step_components, (
             "Should create blob step for custom code"
         )
-        assert "/langflow/udf_executor" in step_components, (
-            "Should route custom code to UDF executor"
+        assert "/langflow/custom_code" in step_components, (
+            "Should route custom code to custom code executor"
         )
 
         # Find the blob step and verify it contains the custom code

--- a/integrations/langflow/tests/unit/test_udf_executor.py
+++ b/integrations/langflow/tests/unit/test_udf_executor.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-"""Unit test for UDF execution in isolation (with real Langflow code)."""
+"""Unit test for custom code execution in isolation (with real Langflow code)."""
 
 from typing import Any
 from unittest.mock import AsyncMock
@@ -20,16 +20,18 @@ from unittest.mock import AsyncMock
 import pytest
 
 from stepflow_langflow_integration.exceptions import ExecutionError
-from stepflow_langflow_integration.executor.udf_executor import UDFExecutor
+from stepflow_langflow_integration.executor.custom_code_executor import (
+    CustomCodeExecutor,
+)
 
 
-class TestUDFExecutor:
-    """Test UDFExecutor functionality with real Langflow component code."""
+class TestCustomCodeExecutor:
+    """Test CustomCodeExecutor functionality with real Langflow component code."""
 
     @pytest.fixture
     def executor(self):
-        """Create UDFExecutor instance."""
-        return UDFExecutor()
+        """Create CustomCodeExecutor instance."""
+        return CustomCodeExecutor()
 
     @pytest.fixture
     def mock_context(self):
@@ -174,7 +176,9 @@ class ChatInput(ChatComponent):
         }
 
     @pytest.mark.asyncio
-    async def test_execute_missing_blob_id(self, executor: UDFExecutor, mock_context):
+    async def test_execute_missing_blob_id(
+        self, executor: CustomCodeExecutor, mock_context
+    ):
         """Test execution fails when blob_id is missing."""
         input_data = {"input": {"text": "test"}}
 
@@ -183,7 +187,10 @@ class ChatInput(ChatComponent):
 
     @pytest.mark.asyncio
     async def test_execute_simple_component(
-        self, executor: UDFExecutor, mock_context, simple_component_blob: dict[str, Any]
+        self,
+        executor: CustomCodeExecutor,
+        mock_context,
+        simple_component_blob: dict[str, Any],
     ):
         """Test execution of a simple custom component."""
         # Setup mock context
@@ -217,7 +224,7 @@ class ChatInput(ChatComponent):
     @pytest.mark.asyncio
     async def test_execute_chat_input_component(
         self,
-        executor: UDFExecutor,
+        executor: CustomCodeExecutor,
         mock_context,
         chat_input_component_blob: dict[str, Any],
     ):
@@ -253,7 +260,10 @@ class ChatInput(ChatComponent):
 
     @pytest.mark.asyncio
     async def test_execute_component_with_template_defaults(
-        self, executor: UDFExecutor, mock_context, simple_component_blob: dict[str, Any]
+        self,
+        executor: CustomCodeExecutor,
+        mock_context,
+        simple_component_blob: dict[str, Any],
     ):
         """Test that template default values are used when input is not provided."""
         # Modify blob to have default value
@@ -277,7 +287,10 @@ class ChatInput(ChatComponent):
 
     @pytest.mark.asyncio
     async def test_execute_component_runtime_overrides_template(
-        self, executor: UDFExecutor, mock_context, simple_component_blob: dict[str, Any]
+        self,
+        executor: CustomCodeExecutor,
+        mock_context,
+        simple_component_blob: dict[str, Any],
     ):
         """Test that runtime inputs override template defaults."""
         # Set template default
@@ -301,7 +314,7 @@ class ChatInput(ChatComponent):
 
     @pytest.mark.asyncio
     async def test_execute_component_with_missing_code(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         """Test execution fails when component code is missing."""
         blob_data = {
@@ -319,7 +332,7 @@ class ChatInput(ChatComponent):
 
     @pytest.mark.asyncio
     async def test_execute_component_with_invalid_code(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         """Test execution fails when component code is invalid Python."""
         blob_data = {
@@ -337,7 +350,7 @@ class ChatInput(ChatComponent):
 
     @pytest.mark.asyncio
     async def test_execute_component_class_not_found(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         """Test execution fails when component class is not found in code."""
         blob_data = {
@@ -362,7 +375,7 @@ def some_function():
 
     @pytest.mark.asyncio
     async def test_execute_component_instantiation_fails(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         """Test execution fails when component cannot be instantiated."""
         blob_data = {
@@ -400,7 +413,7 @@ class FailingComponent(Component):
 
     @pytest.mark.asyncio
     async def test_execute_component_method_not_found(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         """Test execution fails when execution method is not found."""
         blob_data = {
@@ -426,7 +439,7 @@ class NoMethodComponent(Component):
 
     @pytest.mark.asyncio
     async def test_execute_component_method_execution_fails(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         """Test execution fails when component method throws exception."""
         blob_data = {
@@ -451,7 +464,9 @@ class FailingMethodComponent(Component):
         with pytest.raises(ExecutionError, match="Failed to execute failing_method"):
             await executor.execute(input_data, mock_context)
 
-    def test_environment_variable_handling_deprecated(self, executor: UDFExecutor):
+    def test_environment_variable_handling_deprecated(
+        self, executor: CustomCodeExecutor
+    ):
         """Test that environment variable handling is now handled via preprocessing.
 
         This test documents that environment variable resolution was moved from
@@ -463,7 +478,7 @@ class FailingMethodComponent(Component):
         # instead of runtime resolution in the UDF executor
         assert True  # This test now just documents the architectural change
 
-    def test_determine_execution_method(self, executor: UDFExecutor):
+    def test_determine_execution_method(self, executor: CustomCodeExecutor):
         """Test execution method determination from outputs metadata."""
         outputs = [
             {"name": "result1", "method": "method1", "types": ["str"]},
@@ -487,14 +502,14 @@ class FailingMethodComponent(Component):
         assert method == "method1"
 
 
-class TestUDFExecutorIntegration:
+class TestCustomCodeExecutorIntegration:
     """Integration tests with mock Langflow imports."""
 
     @pytest.fixture
     def executor_with_mocks(self):
-        """Create UDFExecutor with mocked Langflow imports."""
+        """Create CustomCodeExecutor with mocked Langflow imports."""
         # We'll test this without real Langflow imports to avoid dependency issues
-        return UDFExecutor()
+        return CustomCodeExecutor()
 
     # Registry fixture removed - no longer needed after eliminating test registry
 
@@ -507,7 +522,7 @@ class TestUDFExecutorIntegration:
 
     @pytest.mark.asyncio
     async def test_component_parameter_preparation(
-        self, executor_with_mocks: UDFExecutor
+        self, executor_with_mocks: CustomCodeExecutor
     ):
         """Test component parameter preparation logic.
 
@@ -551,13 +566,13 @@ class TestUDFExecutorIntegration:
         assert params["extra_field"] == "extra_value"
 
 
-class TestUDFExecutorWithRealLangflowComponents:
-    """Test UDFExecutor with real converted Langflow workflow components."""
+class TestCustomCodeExecutorWithRealLangflowComponents:
+    """Test CustomCodeExecutor with real converted Langflow workflow components."""
 
     @pytest.fixture
     def executor(self):
-        """Create UDFExecutor instance."""
-        return UDFExecutor()
+        """Create CustomCodeExecutor instance."""
+        return CustomCodeExecutor()
 
     @pytest.fixture
     def mock_context(self):
@@ -576,7 +591,7 @@ class TestUDFExecutorWithRealLangflowComponents:
 
     @pytest.mark.asyncio
     async def test_execute_converted_workflow_components(
-        self, executor: UDFExecutor, mock_context, converter
+        self, executor: CustomCodeExecutor, mock_context, converter
     ):
         """Test that components from converted workflows execute correctly."""
         # Create simple workflow data to test UDF component creation
@@ -615,32 +630,36 @@ class TestPrompt(Component):
             }
         }
 
-        # Convert to find the UDF components
+        # Convert to find the custom code components
         stepflow_workflow = converter.convert(langflow_data)
 
-        # Find steps that use /langflow/udf_executor
-        udf_steps = [
+        # Find steps that use /langflow/custom_code
+        custom_code_steps = [
             step
             for step in stepflow_workflow.steps
-            if step.component == "/langflow/udf_executor"
+            if step.component == "/langflow/custom_code"
         ]
 
-        assert len(udf_steps) > 0, "No UDF executor steps found in test workflow"
+        assert len(custom_code_steps) > 0, (
+            "No custom code executor steps found in test workflow"
+        )
 
-        # Test the first UDF step
-        first_step = udf_steps[0]
+        # Test the first custom code step
+        first_step = custom_code_steps[0]
 
         # The step input should have blob_id reference
         assert "blob_id" in str(first_step.input), (
             f"No blob_id found in step input: {first_step.input}"
         )
 
-        print(f"✅ Found {len(udf_steps)} UDF components in converted workflow")
-        print(f"✅ First UDF step: {first_step.id} using {first_step.component}")
+        print(f"✅ Found {len(custom_code_steps)} custom code components")
+        print(
+            f"✅ First custom code step: {first_step.id} using {first_step.component}"
+        )
 
     @pytest.mark.asyncio
     async def test_component_metadata_extraction_and_usage(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         # Create blob with enhanced metadata (from Phase 1 improvements)
         enhanced_blob = {
@@ -778,7 +797,7 @@ class EnhancedTestComponent(Component):
 
     @pytest.mark.asyncio
     async def test_agent_component(
-        self, executor: UDFExecutor, mock_context, agent_component_blob
+        self, executor: CustomCodeExecutor, mock_context, agent_component_blob
     ):
         """Test that Agent component can be compiled and instantiated.
 
@@ -815,7 +834,7 @@ class EnhancedTestComponent(Component):
 
     @pytest.mark.asyncio
     async def test_agent_component_execution_attempt(
-        self, executor: UDFExecutor, mock_context, agent_component_blob
+        self, executor: CustomCodeExecutor, mock_context, agent_component_blob
     ):
         """Test Agent component execution (will fail without real API key).
 
@@ -855,7 +874,7 @@ class EnhancedTestComponent(Component):
 
     @pytest.mark.asyncio
     async def test_prompt_component(
-        self, executor: UDFExecutor, mock_context, prompt_component_data
+        self, executor: CustomCodeExecutor, mock_context, prompt_component_data
     ):
         """Test executing Prompt component with string-type system_message field.
 
@@ -913,7 +932,7 @@ class EnhancedTestComponent(Component):
 
     @pytest.mark.asyncio
     async def test_language_model_message_to_string_conversion(
-        self, executor: UDFExecutor, mock_context, basic_prompting_flow
+        self, executor: CustomCodeExecutor, mock_context, basic_prompting_flow
     ):
         """Test LanguageModelComponent receives string when Message passed.
 
@@ -977,7 +996,7 @@ class EnhancedTestComponent(Component):
 
     @pytest.mark.asyncio
     async def test_chat_input_lfx_component(
-        self, executor: UDFExecutor, mock_context, chat_input_component_data
+        self, executor: CustomCodeExecutor, mock_context, chat_input_component_data
     ):
         """Test executing ChatInput component (lfx-based) from basic_prompting flow.
 
@@ -1031,7 +1050,7 @@ class EnhancedTestComponent(Component):
 
     @pytest.mark.asyncio
     async def test_chat_input_message_to_string_conversion(
-        self, executor: UDFExecutor, mock_context, chat_input_component_data
+        self, executor: CustomCodeExecutor, mock_context, chat_input_component_data
     ):
         """Test ChatInput component with Message object passed to string field.
 

--- a/integrations/langflow/uv.lock
+++ b/integrations/langflow/uv.lock
@@ -10098,7 +10098,7 @@ dev = [
 
 [[package]]
 name = "stepflow-orchestrator"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "../../sdks/python/stepflow-orchestrator" }
 dependencies = [
     { name = "msgspec" },
@@ -10117,7 +10117,7 @@ dev = [
 
 [[package]]
 name = "stepflow-py"
-version = "0.8.0"
+version = "0.9.1"
 source = { editable = "../../sdks/python/stepflow-py" }
 dependencies = [
     { name = "aiohttp" },
@@ -10131,6 +10131,7 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "types-jsonschema" },
     { name = "typing-extensions" },
+    { name = "urllib3" },
 ]
 
 [package.metadata]
@@ -10150,6 +10151,7 @@ requires-dist = [
     { name = "stepflow-orchestrator", marker = "extra == 'local'", editable = "../../sdks/python/stepflow-orchestrator" },
     { name = "types-jsonschema", specifier = ">=4.17.0" },
     { name = "typing-extensions", specifier = ">=4.7.1" },
+    { name = "urllib3", specifier = ">=2.0.0" },
     { name = "uvicorn", marker = "extra == 'http'", specifier = ">=0.24.0" },
 ]
 provides-extras = ["http", "langchain", "local"]

--- a/sdks/python/stepflow-py/src/stepflow_py/worker/path_trie.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/path_trie.py
@@ -1,0 +1,240 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Path trie for efficient component path matching.
+
+This module provides a trie (prefix tree) data structure optimized for
+matching URL-like paths with support for:
+- Exact segment matching
+- Single segment parameters: {name}
+- Wildcard (catch-all) parameters: {*name}
+
+The trie provides O(n) lookup where n is the number of path segments,
+compared to O(m*n) for iterating through m registered patterns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass
+class TrieNode(Generic[T]):
+    """A node in the path trie.
+
+    Each node represents a path segment position and can have:
+    - children: Exact match children keyed by segment value
+    - param_child: A single-segment parameter child ({name})
+    - wildcard_child: A catch-all parameter child ({*name})
+    - value: The stored value if this node terminates a pattern
+    - param_name: The parameter name if this is a param/wildcard node
+    """
+
+    children: dict[str, TrieNode[T]] = field(default_factory=dict)
+    param_child: TrieNode[T] | None = None
+    wildcard_child: TrieNode[T] | None = None
+    value: T | None = None
+    param_name: str | None = None
+    is_wildcard: bool = False
+
+
+class PathTrie(Generic[T]):
+    """A trie for matching URL-like paths with parameters.
+
+    Supports three types of path segments:
+    - Literal: Exact string match (e.g., "users", "api")
+    - Parameter: Single segment capture (e.g., "{id}", "{name}")
+    - Wildcard: Capture remaining path (e.g., "{*path}", "{*component}")
+
+    Example:
+        >>> trie = PathTrie[str]()
+        >>> trie.insert("/users/{id}/profile", "user_profile")
+        >>> trie.insert("/api/{*path}", "api_handler")
+        >>> trie.insert("/health", "health_check")
+        >>>
+        >>> trie.match("/users/123/profile")
+        ("user_profile", {"id": "123"})
+        >>> trie.match("/api/v1/users/list")
+        ("api_handler", {"path": "v1/users/list"})
+        >>> trie.match("/health")
+        ("health_check", {})
+    """
+
+    def __init__(self):
+        """Initialize an empty path trie."""
+        self._root = TrieNode[T]()
+        self._patterns: dict[str, T] = {}
+
+    def insert(self, pattern: str, value: T) -> None:
+        """Insert a path pattern with its associated value.
+
+        Args:
+            pattern: Path pattern (e.g., "/users/{id}/profile")
+            value: Value to associate with this pattern
+
+        Raises:
+            ValueError: If pattern is invalid or conflicts with existing pattern
+        """
+        # Store the original pattern for listing
+        self._patterns[pattern] = value
+
+        # Parse and insert into trie
+        segments = self._parse_pattern(pattern)
+        node = self._root
+
+        for segment in segments:
+            if segment.startswith("{*") and segment.endswith("}"):
+                # Wildcard parameter - captures rest of path
+                param_name = segment[2:-1]
+                if node.wildcard_child is None:
+                    node.wildcard_child = TrieNode[T](
+                        param_name=param_name, is_wildcard=True
+                    )
+                node = node.wildcard_child
+                # Wildcards must be last segment
+                break
+            elif segment.startswith("{") and segment.endswith("}"):
+                # Single segment parameter
+                param_name = segment[1:-1]
+                if node.param_child is None:
+                    node.param_child = TrieNode[T](param_name=param_name)
+                node = node.param_child
+            else:
+                # Literal segment
+                if segment not in node.children:
+                    node.children[segment] = TrieNode[T]()
+                node = node.children[segment]
+
+        node.value = value
+
+    def match(self, path: str) -> tuple[T, dict[str, str]] | None:
+        """Match a path against registered patterns.
+
+        Matching priority (highest to lowest):
+        1. Exact literal match
+        2. Single-segment parameter match
+        3. Wildcard (catch-all) match
+
+        Args:
+            path: The path to match (e.g., "/users/123/profile")
+
+        Returns:
+            Tuple of (value, captured_params) if matched, None otherwise
+        """
+        segments = self._parse_path(path)
+        return self._match_recursive(self._root, segments, 0, {})
+
+    def _match_recursive(
+        self,
+        node: TrieNode[T],
+        segments: list[str],
+        index: int,
+        params: dict[str, str],
+    ) -> tuple[T, dict[str, str]] | None:
+        """Recursively match path segments against trie nodes.
+
+        Args:
+            node: Current trie node
+            segments: List of path segments to match
+            index: Current segment index
+            params: Accumulated captured parameters
+
+        Returns:
+            Tuple of (value, params) if matched, None otherwise
+        """
+        # Base case: consumed all segments
+        if index >= len(segments):
+            if node.value is not None:
+                return node.value, params
+            return None
+
+        current_segment = segments[index]
+
+        # Priority 1: Try exact literal match first
+        if current_segment in node.children:
+            result = self._match_recursive(
+                node.children[current_segment], segments, index + 1, params.copy()
+            )
+            if result is not None:
+                return result
+
+        # Priority 2: Try single-segment parameter match
+        if node.param_child is not None:
+            new_params = params.copy()
+            if node.param_child.param_name:
+                new_params[node.param_child.param_name] = current_segment
+            result = self._match_recursive(
+                node.param_child, segments, index + 1, new_params
+            )
+            if result is not None:
+                return result
+
+        # Priority 3: Try wildcard match (captures remaining segments)
+        if node.wildcard_child is not None:
+            # Wildcard captures everything from current segment onwards
+            remaining_path = "/".join(segments[index:])
+            new_params = params.copy()
+            if node.wildcard_child.param_name:
+                new_params[node.wildcard_child.param_name] = remaining_path
+            if node.wildcard_child.value is not None:
+                return node.wildcard_child.value, new_params
+
+        return None
+
+    def get_patterns(self) -> dict[str, T]:
+        """Get all registered patterns and their values.
+
+        Returns:
+            Dictionary mapping patterns to values
+        """
+        return dict(self._patterns)
+
+    def _parse_pattern(self, pattern: str) -> list[str]:
+        """Parse a pattern into segments.
+
+        Args:
+            pattern: Path pattern (e.g., "/users/{id}/profile")
+
+        Returns:
+            List of segments (e.g., ["users", "{id}", "profile"])
+        """
+        # Remove leading slash and split
+        if pattern.startswith("/"):
+            pattern = pattern[1:]
+        return [s for s in pattern.split("/") if s]
+
+    def _parse_path(self, path: str) -> list[str]:
+        """Parse a path into segments.
+
+        Args:
+            path: Path string (e.g., "/users/123/profile")
+
+        Returns:
+            List of segments (e.g., ["users", "123", "profile"])
+        """
+        # Remove leading slash and split
+        if path.startswith("/"):
+            path = path[1:]
+        return [s for s in path.split("/") if s]
+
+    def __contains__(self, pattern: str) -> bool:
+        """Check if a pattern is registered."""
+        return pattern in self._patterns
+
+    def __len__(self) -> int:
+        """Return the number of registered patterns."""
+        return len(self._patterns)

--- a/sdks/python/stepflow-py/tests/test_path_trie.py
+++ b/sdks/python/stepflow-py/tests/test_path_trie.py
@@ -1,0 +1,389 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Unit tests for PathTrie data structure."""
+
+
+from stepflow_py.worker.path_trie import PathTrie
+
+
+class TestPathTrieBasics:
+    """Basic PathTrie functionality tests."""
+
+    def test_empty_trie(self):
+        """Test empty trie returns no matches."""
+        trie = PathTrie[str]()
+        assert trie.match("/any/path") is None
+        assert len(trie) == 0
+
+    def test_exact_match(self):
+        """Test exact literal path matching."""
+        trie = PathTrie[str]()
+        trie.insert("/health", "health_handler")
+        trie.insert("/api/v1/status", "status_handler")
+
+        result = trie.match("/health")
+        assert result is not None
+        value, params = result
+        assert value == "health_handler"
+        assert params == {}
+
+        result = trie.match("/api/v1/status")
+        assert result is not None
+        value, params = result
+        assert value == "status_handler"
+        assert params == {}
+
+    def test_no_match(self):
+        """Test paths that don't match any pattern."""
+        trie = PathTrie[str]()
+        trie.insert("/health", "health_handler")
+
+        assert trie.match("/other") is None
+        assert trie.match("/health/extra") is None
+        assert trie.match("/") is None
+
+    def test_contains(self):
+        """Test __contains__ method."""
+        trie = PathTrie[str]()
+        trie.insert("/health", "handler")
+
+        assert "/health" in trie
+        assert "/other" not in trie
+
+    def test_len(self):
+        """Test __len__ method."""
+        trie = PathTrie[str]()
+        assert len(trie) == 0
+
+        trie.insert("/a", "a")
+        assert len(trie) == 1
+
+        trie.insert("/b", "b")
+        assert len(trie) == 2
+
+
+class TestSingleSegmentParameters:
+    """Tests for single-segment parameter matching ({name})."""
+
+    def test_single_param(self):
+        """Test single parameter capture."""
+        trie = PathTrie[str]()
+        trie.insert("/users/{id}", "user_handler")
+
+        result = trie.match("/users/123")
+        assert result is not None
+        value, params = result
+        assert value == "user_handler"
+        assert params == {"id": "123"}
+
+    def test_param_in_middle(self):
+        """Test parameter in middle of path."""
+        trie = PathTrie[str]()
+        trie.insert("/users/{id}/profile", "profile_handler")
+
+        result = trie.match("/users/abc/profile")
+        assert result is not None
+        value, params = result
+        assert value == "profile_handler"
+        assert params == {"id": "abc"}
+
+        # Should not match extra segments
+        assert trie.match("/users/abc/profile/extra") is None
+
+    def test_multiple_params(self):
+        """Test multiple parameter capture."""
+        trie = PathTrie[str]()
+        trie.insert("/orgs/{org}/repos/{repo}", "repo_handler")
+
+        result = trie.match("/orgs/acme/repos/my-project")
+        assert result is not None
+        value, params = result
+        assert value == "repo_handler"
+        assert params == {"org": "acme", "repo": "my-project"}
+
+    def test_param_with_special_chars(self):
+        """Test parameter values can contain special characters."""
+        trie = PathTrie[str]()
+        trie.insert("/files/{name}", "file_handler")
+
+        result = trie.match("/files/my-file_v2.txt")
+        assert result is not None
+        value, params = result
+        assert value == "file_handler"
+        assert params == {"name": "my-file_v2.txt"}
+
+    def test_param_does_not_match_slash(self):
+        """Test single param doesn't match paths with slashes."""
+        trie = PathTrie[str]()
+        trie.insert("/files/{name}", "file_handler")
+
+        # Should not match - {name} only captures single segment
+        assert trie.match("/files/path/to/file") is None
+
+
+class TestWildcardParameters:
+    """Tests for wildcard parameter matching ({*name})."""
+
+    def test_wildcard_basic(self):
+        """Test basic wildcard capture."""
+        trie = PathTrie[str]()
+        trie.insert("/api/{*path}", "api_handler")
+
+        result = trie.match("/api/users")
+        assert result is not None
+        value, params = result
+        assert value == "api_handler"
+        assert params == {"path": "users"}
+
+    def test_wildcard_nested(self):
+        """Test wildcard captures nested paths."""
+        trie = PathTrie[str]()
+        trie.insert("/api/{*path}", "api_handler")
+
+        result = trie.match("/api/users/123/profile")
+        assert result is not None
+        value, params = result
+        assert value == "api_handler"
+        assert params == {"path": "users/123/profile"}
+
+    def test_wildcard_with_prefix(self):
+        """Test wildcard with literal prefix."""
+        trie = PathTrie[str]()
+        trie.insert("/langflow/core/{*component}", "core_handler")
+
+        result = trie.match("/langflow/core/lfx/components/chat/ChatInput")
+        assert result is not None
+        value, params = result
+        assert value == "core_handler"
+        assert params == {"component": "lfx/components/chat/ChatInput"}
+
+    def test_wildcard_requires_content(self):
+        """Test wildcard requires at least one segment."""
+        trie = PathTrie[str]()
+        trie.insert("/api/{*path}", "api_handler")
+
+        # Should not match - wildcard needs content
+        assert trie.match("/api") is None
+        assert trie.match("/api/") is None
+
+    def test_mixed_param_and_wildcard(self):
+        """Test combining single params and wildcards."""
+        trie = PathTrie[str]()
+        trie.insert("/api/{version}/{*path}", "versioned_api")
+
+        result = trie.match("/api/v2/users/list")
+        assert result is not None
+        value, params = result
+        assert value == "versioned_api"
+        assert params == {"version": "v2", "path": "users/list"}
+
+
+class TestMatchingPriority:
+    """Tests for match priority (exact > param > wildcard)."""
+
+    def test_exact_beats_param(self):
+        """Test exact match takes precedence over parameter."""
+        trie = PathTrie[str]()
+        trie.insert("/users/{id}", "param_handler")
+        trie.insert("/users/me", "exact_handler")
+
+        # Exact match should win
+        result = trie.match("/users/me")
+        assert result is not None
+        value, params = result
+        assert value == "exact_handler"
+        assert params == {}
+
+        # Parameter should match other values
+        result = trie.match("/users/123")
+        assert result is not None
+        value, params = result
+        assert value == "param_handler"
+        assert params == {"id": "123"}
+
+    def test_exact_beats_wildcard(self):
+        """Test exact match takes precedence over wildcard."""
+        trie = PathTrie[str]()
+        trie.insert("/api/{*path}", "wildcard_handler")
+        trie.insert("/api/health", "health_handler")
+
+        # Exact match should win
+        result = trie.match("/api/health")
+        assert result is not None
+        value, params = result
+        assert value == "health_handler"
+        assert params == {}
+
+        # Wildcard should match other paths
+        result = trie.match("/api/users/list")
+        assert result is not None
+        value, params = result
+        assert value == "wildcard_handler"
+        assert params == {"path": "users/list"}
+
+    def test_param_beats_wildcard(self):
+        """Test single param takes precedence over wildcard at same position."""
+        trie = PathTrie[str]()
+        trie.insert("/api/{*path}", "wildcard_handler")
+        trie.insert("/api/{resource}/list", "resource_list_handler")
+
+        # Param path should match when it fits exactly
+        result = trie.match("/api/users/list")
+        assert result is not None
+        value, params = result
+        assert value == "resource_list_handler"
+        assert params == {"resource": "users"}
+
+        # Wildcard should match when param path doesn't fit
+        result = trie.match("/api/users/123/profile")
+        assert result is not None
+        value, params = result
+        assert value == "wildcard_handler"
+        assert params == {"path": "users/123/profile"}
+
+    def test_insertion_order_independent(self):
+        """Test that match priority is independent of insertion order."""
+        # Insert in reverse priority order
+        trie1 = PathTrie[str]()
+        trie1.insert("/api/{*path}", "wildcard")
+        trie1.insert("/api/{id}", "param")
+        trie1.insert("/api/health", "exact")
+
+        # Insert in priority order
+        trie2 = PathTrie[str]()
+        trie2.insert("/api/health", "exact")
+        trie2.insert("/api/{id}", "param")
+        trie2.insert("/api/{*path}", "wildcard")
+
+        # Both should have same behavior
+        for trie in [trie1, trie2]:
+            result = trie.match("/api/health")
+            assert result is not None
+            assert result[0] == "exact"
+
+            result = trie.match("/api/123")
+            assert result is not None
+            assert result[0] == "param"
+
+            result = trie.match("/api/a/b/c")
+            assert result is not None
+            assert result[0] == "wildcard"
+
+
+class TestGetPatterns:
+    """Tests for get_patterns method."""
+
+    def test_get_patterns_empty(self):
+        """Test get_patterns on empty trie."""
+        trie = PathTrie[str]()
+        assert trie.get_patterns() == {}
+
+    def test_get_patterns_returns_all(self):
+        """Test get_patterns returns all registered patterns."""
+        trie = PathTrie[str]()
+        trie.insert("/a", "a_handler")
+        trie.insert("/b/{id}", "b_handler")
+        trie.insert("/c/{*path}", "c_handler")
+
+        patterns = trie.get_patterns()
+        assert patterns == {
+            "/a": "a_handler",
+            "/b/{id}": "b_handler",
+            "/c/{*path}": "c_handler",
+        }
+
+    def test_get_patterns_returns_copy(self):
+        """Test get_patterns returns a copy, not the internal dict."""
+        trie = PathTrie[str]()
+        trie.insert("/a", "handler")
+
+        patterns = trie.get_patterns()
+        patterns["/b"] = "new_handler"
+
+        # Original trie should be unaffected
+        assert "/b" not in trie
+
+
+class TestEdgeCases:
+    """Edge case tests."""
+
+    def test_root_path(self):
+        """Test matching root path."""
+        trie = PathTrie[str]()
+        trie.insert("/", "root_handler")
+
+        result = trie.match("/")
+        # Note: empty path segments are filtered, so "/" matches empty list
+        # This means we need a value at root node
+        # Current implementation: "/" -> [] segments
+        # We'd need to handle this case specially if needed
+
+    def test_trailing_slash(self):
+        """Test paths with trailing slashes."""
+        trie = PathTrie[str]()
+        trie.insert("/users", "users_handler")
+
+        # Both with and without trailing slash should match
+        # (trailing empty segments are filtered)
+        result = trie.match("/users")
+        assert result is not None
+        assert result[0] == "users_handler"
+
+        result = trie.match("/users/")
+        assert result is not None
+        assert result[0] == "users_handler"
+
+    def test_double_slash(self):
+        """Test paths with double slashes."""
+        trie = PathTrie[str]()
+        trie.insert("/users/{id}", "user_handler")
+
+        # Double slashes create empty segments which are filtered
+        result = trie.match("/users//123")
+        # This becomes ["users", "123"] after filtering empty segments
+        assert result is not None
+        assert result[1] == {"id": "123"}
+
+    def test_unicode_segments(self):
+        """Test unicode path segments."""
+        trie = PathTrie[str]()
+        trie.insert("/文件/{name}", "file_handler")
+
+        result = trie.match("/文件/テスト")
+        assert result is not None
+        value, params = result
+        assert value == "file_handler"
+        assert params == {"name": "テスト"}
+
+    def test_generic_type(self):
+        """Test trie works with different value types."""
+        # With integers
+        int_trie = PathTrie[int]()
+        int_trie.insert("/count", 42)
+        result = int_trie.match("/count")
+        assert result is not None
+        assert result[0] == 42
+
+        # With custom objects
+        class Handler:
+            def __init__(self, name: str):
+                self.name = name
+
+        obj_trie = PathTrie[Handler]()
+        handler = Handler("test")
+        obj_trie.insert("/test", handler)
+        result = obj_trie.match("/test")
+        assert result is not None
+        assert result[0] is handler

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -1973,7 +1973,7 @@ dev = [
 
 [[package]]
 name = "stepflow-py"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "stepflow-py" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Implement hash-based routing for known Langflow components, allowing them to be executed directly via module import instead of compiling code from blob storage.

- Rename /langflow/udf_executor to /langflow/custom_code
- Add /langflow/core/{*component} handler for known core components
- Implement hash-based component routing in node_processor
- Create known_components.py with hash-to-module mappings
- Create core_executor.py for direct module execution
- Extract shared executor methods to BaseExecutor class

Closes #544

feat: Add wildcard paths to stepflow-py

- Extend stepflow-py with wildcard path parameters ({name} and {*name})
- Add PathTrie data structure for O(n) path parameter matching
- Replace linear iteration with trie-based lookup in StepflowServer