### PR TITLE
feat: Add Langflow core component handling

### DIFF
--- a/integrations/langflow/src/stepflow_langflow_integration/converter/known_components.py
+++ b/integrations/langflow/src/stepflow_langflow_integration/converter/known_components.py
@@ -1,0 +1,118 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Hash-to-module mappings for known Langflow core components.
+
+This module contains mappings of code hashes to component module paths for
+known Langflow core components. When a component's code_hash matches an entry
+here and the module matches, we can use the core executor instead of compiling
+custom code from a blob.
+
+The hashes are derived from the Langflow workflow metadata and can be found in
+the `metadata.code_hash` and `metadata.module` fields of each node.
+"""
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class KnownComponent:
+    """A known core component mapping."""
+
+    code_hash: str
+    module: (
+        str  # Full module path, e.g., "lfx.components.docling.DoclingInlineComponent"
+    )
+    description: str = ""
+
+
+# Mapping of code_hash -> KnownComponent
+# These hashes are version-specific and may need updating when Langflow versions change
+KNOWN_COMPONENTS: dict[str, KnownComponent] = {
+    # ChatInput component (lfx)
+    "f701f686b325": KnownComponent(
+        code_hash="f701f686b325",
+        module="lfx.components.input_output.chat.ChatInput",
+        description="Chat Input component",
+    ),
+    # ChatOutput component (lfx)
+    "9647f4d2f4b4": KnownComponent(
+        code_hash="9647f4d2f4b4",
+        module="lfx.components.input_output.chat_output.ChatOutput",
+        description="Chat Output component",
+    ),
+    # LanguageModelComponent (lfx)
+    "bb5f8714781b": KnownComponent(
+        code_hash="bb5f8714781b",
+        module="lfx.components.models.language_model.LanguageModelComponent",
+        description="Language Model component",
+    ),
+    # Note: PromptComponent (langflow.components.prompts.prompt) is NOT included
+    # because the module doesn't exist in the lfx package - it must be compiled
+    # from custom code.
+    # Add more known components here as needed
+    # Example for DoclingInlineComponent (hash TBD):
+    # "HASH_HERE": KnownComponent(
+    #     code_hash="HASH_HERE",
+    #     module="lfx.components.docling.DoclingInlineComponent",
+    #     description="Docling inline document processing",
+    # ),
+}
+
+
+def lookup_known_component(
+    code_hash: str, module: str | None = None
+) -> KnownComponent | None:
+    """Look up a known component by code hash.
+
+    Args:
+        code_hash: The code_hash from workflow metadata
+        module: Optional module path to verify (safety check)
+
+    Returns:
+        KnownComponent if found and module matches (if provided), None otherwise
+    """
+    known = KNOWN_COMPONENTS.get(code_hash)
+
+    if known is None:
+        return None
+
+    # If module provided, verify it matches
+    if module is not None and known.module != module:
+        # Hash collision or outdated mapping - log warning and return None
+        logger.warning(
+            f"Code hash {code_hash} matches known component {known.module} "
+            f"but workflow specifies {module}. Using custom_code executor."
+        )
+        return None
+
+    return known
+
+
+def module_to_path(module: str) -> str:
+    """Convert module path to URL path segment.
+
+    Example: "lfx.components.docling.DoclingInlineComponent"
+          -> "lfx/components/docling/DoclingInlineComponent"
+
+    Args:
+        module: Full module path with dots
+
+    Returns:
+        URL path segment with slashes
+    """
+    return module.replace(".", "/")

--- a/integrations/langflow/src/stepflow_langflow_integration/converter/stepflow_tweaks.py
+++ b/integrations/langflow/src/stepflow_langflow_integration/converter/stepflow_tweaks.py
@@ -62,13 +62,19 @@ def apply_stepflow_tweaks_to_dict(
 
     for step_dict in modified_dict.get("steps", []):
         step_id = step_dict.get("id", "")
+        component = step_dict.get("component", "")
 
-        # Check if this is a Langflow UDF executor step
-        if (
+        # Check if this is a Langflow executor step (custom_code or core)
+        is_langflow_step = (
             step_id.startswith("langflow_")
             and not step_id.endswith("_blob")
-            and step_dict.get("component") == "/langflow/udf_executor"
-        ):
+            and (
+                component == "/langflow/custom_code"
+                or component.startswith("/langflow/core/")
+            )
+        )
+
+        if is_langflow_step:
             # Extract Langflow node ID
             langflow_node_id = step_id[len("langflow_") :]
 

--- a/integrations/langflow/src/stepflow_langflow_integration/executor/base_executor.py
+++ b/integrations/langflow/src/stepflow_langflow_integration/executor/base_executor.py
@@ -1,0 +1,320 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Base executor class with shared functionality for Langflow component execution."""
+
+import inspect
+import os
+from abc import ABC, abstractmethod
+from typing import Any
+
+from stepflow_py.worker.observability import get_tracer
+
+from ..exceptions import ExecutionError
+from .type_converter import TypeConverter
+
+
+class BaseExecutor(ABC):
+    """Abstract base class for Langflow component executors.
+
+    Provides shared functionality for both core and custom code executors:
+    - Execution method determination
+    - Component input defaults application
+    - Type conversion utilities
+    - Common component execution flow
+
+    Subclasses must implement `_instantiate_component` to define how components
+    are loaded and instantiated.
+    """
+
+    def __init__(self):
+        """Initialize base executor with shared components."""
+        self.type_converter = TypeConverter()
+
+    @abstractmethod
+    async def _instantiate_component(
+        self,
+        component_info: dict[str, Any],
+    ) -> tuple[Any, str]:
+        """Instantiate a component from component info.
+
+        This is the only method that differs between executors:
+        - CoreExecutor: imports module and instantiates class
+        - CustomCodeExecutor: compiles code from blob and instantiates class
+
+        Args:
+            component_info: Information needed to instantiate the component.
+                For CoreExecutor: contains module_name, class_name
+                For CustomCodeExecutor: contains component class and metadata
+
+        Returns:
+            Tuple of (component_instance, component_name) for execution
+        """
+        pass
+
+    async def _execute_component_instance(
+        self,
+        component_instance: Any,
+        component_name: str,
+        execution_method: str,
+        template: dict[str, Any],
+        runtime_inputs: dict[str, Any],
+    ) -> Any:
+        """Execute a component instance with the given parameters.
+
+        This is the shared execution flow used by both executors after
+        the component has been instantiated.
+
+        Args:
+            component_instance: Instantiated component object
+            component_name: Name for logging/tracing
+            execution_method: Method name to call on the component
+            template: Template containing field definitions
+            runtime_inputs: Runtime input values
+
+        Returns:
+            Component execution result (before serialization)
+        """
+        tracer = get_tracer(__name__)
+
+        # Prepare parameters from template and runtime inputs
+        component_parameters = await self._prepare_component_parameters(
+            template, runtime_inputs
+        )
+
+        # Apply component input defaults
+        component_parameters = self._apply_component_input_defaults(
+            component_instance, component_parameters
+        )
+
+        # Set session_id and graph context
+        session_id = component_parameters.get("session_id", "default_session")
+        component_instance._session_id = session_id
+        self._setup_graph_context(component_instance, session_id)
+
+        # Configure component with parameters
+        if hasattr(component_instance, "set_attributes"):
+            component_instance._parameters = component_parameters
+            component_instance.set_attributes(component_parameters)
+
+        # Verify execution method exists
+        if not hasattr(component_instance, execution_method):
+            available = [m for m in dir(component_instance) if not m.startswith("_")]
+            raise ExecutionError(
+                f"Method {execution_method} not found in {component_name}. "
+                f"Available: {available}"
+            )
+
+        method = getattr(component_instance, execution_method)
+
+        # Execute the method with tracing
+        with tracer.start_as_current_span(
+            f"execute_method:{execution_method}",
+            attributes={
+                "component_name": component_name,
+                "execution_method": execution_method,
+            },
+        ):
+            try:
+                if inspect.iscoroutinefunction(method):
+                    return await method()
+                else:
+                    return method()
+            except Exception as e:
+                raise ExecutionError(
+                    f"Error executing {execution_method} on {component_name} "
+                    f"({type(component_instance).__name__}): {e}"
+                ) from e
+
+    async def _prepare_component_parameters(
+        self, template: dict[str, Any], runtime_inputs: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Prepare component parameters from template and runtime inputs.
+
+        This base implementation handles common parameter extraction.
+        Subclasses may override for more complex type conversion.
+
+        Args:
+            template: Template containing field definitions
+            runtime_inputs: Runtime input values
+
+        Returns:
+            Merged parameters dictionary
+        """
+        parameters: dict[str, Any] = {}
+
+        # Extract default values from template
+        for key, field in template.items():
+            if isinstance(field, dict) and "value" in field:
+                # Skip handle inputs with empty values (connected steps provide them)
+                input_types = field.get("input_types", [])
+                value = field["value"]
+
+                if input_types and (value == "" or value is None):
+                    continue
+
+                parameters[key] = value
+            elif isinstance(field, dict):
+                # Field without value - skip
+                pass
+            else:
+                # Direct value
+                parameters[key] = field
+
+        # Override with runtime inputs
+        parameters.update(runtime_inputs)
+
+        # Resolve environment variables for load_from_db fields
+        parameters = self._resolve_env_variables(parameters, template)
+
+        return parameters
+
+    def _determine_execution_method(
+        self, outputs: list[dict[str, Any]], selected_output: str | None
+    ) -> str | None:
+        """Determine which method to call based on outputs configuration.
+
+        Args:
+            outputs: List of output definitions from the component
+            selected_output: The name of the selected output (if any)
+
+        Returns:
+            The method name to call, or None if not found
+        """
+        if not outputs:
+            return None
+
+        # If selected_output is provided, find the matching output method
+        if selected_output:
+            for output in outputs:
+                if output.get("name") == selected_output:
+                    method = output.get("method")
+                    if isinstance(method, str) and method:
+                        return method
+
+        # Default to first output's method
+        method = outputs[0].get("method")
+        if isinstance(method, str) and method:
+            return method
+
+        return None
+
+    def _apply_component_input_defaults(
+        self, component_instance: Any, parameters: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Apply default values from component's input definitions.
+
+        Args:
+            component_instance: Instantiated component with inputs attribute
+            parameters: Current component parameters
+
+        Returns:
+            Parameters with defaults applied for missing values
+        """
+        if not hasattr(component_instance, "inputs"):
+            return parameters
+
+        inputs = component_instance.inputs
+        if not inputs:
+            return parameters
+
+        result = dict(parameters)
+
+        for input_def in inputs:
+            field_name = getattr(input_def, "name", None)
+            if not field_name:
+                continue
+
+            # Only set default if not already in parameters
+            if field_name not in result:
+                default_value = getattr(input_def, "value", None)
+                if default_value is not None and default_value != "":
+                    result[field_name] = default_value
+
+        return result
+
+    def _setup_graph_context(self, component_instance: Any, session_id: str) -> None:
+        """Set up graph context for components that need it.
+
+        Some components (like Agent) access self.graph.session_id and
+        self.graph.vertices. This creates a minimal graph context object.
+
+        Args:
+            component_instance: Component instance to configure
+            session_id: Session ID for the graph context
+        """
+
+        class GraphContext:
+            def __init__(self, session_id: str):
+                self.session_id = session_id
+                self.vertices: list[Any] = []
+                self.flow_id = None
+
+        # Use __dict__ to set graph even if it's a read-only property
+        component_instance.__dict__["graph"] = GraphContext(session_id)
+
+    def _resolve_env_variables(
+        self, parameters: dict[str, Any], template: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Resolve environment variables for parameters marked with load_from_db.
+
+        For fields that have load_from_db=True and an empty/falsy value, this method
+        attempts to load the value from environment variables. The variable name is
+        taken from the template field's "value" key.
+
+        This enables API keys and other secrets to be loaded from the environment
+        rather than being passed explicitly as runtime variables.
+
+        Args:
+            parameters: Current component parameters
+            template: Template containing field definitions with load_from_db flags
+
+        Returns:
+            Parameters with environment variables resolved
+
+        Raises:
+            ExecutionError: If required environment variable is not set
+        """
+        result = dict(parameters)
+
+        for key, value in result.items():
+            # Skip if value is already set (truthy)
+            if value:
+                continue
+
+            # Check if template field is marked for loading from DB/env
+            template_field = template.get(key, {})
+            if not isinstance(template_field, dict):
+                continue
+
+            if not template_field.get("load_from_db", False):
+                continue
+
+            # Get the variable name from the template field's value
+            # This is the name of the environment variable to load
+            var_name = template_field.get("value", key)
+            if not var_name:
+                continue
+
+            # Attempt to load from environment
+            env_value = os.environ.get(var_name)
+            if env_value is None:
+                raise ExecutionError(
+                    f"Environment variable '{var_name}' for parameter '{key}' not set. "
+                    f"Either provide the value as a runtime variable or set the "
+                    f"environment variable."
+                )
+            result[key] = env_value
+
+        return result

--- a/integrations/langflow/src/stepflow_langflow_integration/executor/core_executor.py
+++ b/integrations/langflow/src/stepflow_langflow_integration/executor/core_executor.py
@@ -1,0 +1,150 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Core component executor for known Langflow components.
+
+Executes known Langflow components by importing them directly by module path,
+without needing to compile code from blob storage. This is more efficient for
+components whose code hash matches a known version.
+"""
+
+import importlib
+from typing import Any
+
+from stepflow_py.worker import StepflowContext
+from stepflow_py.worker.observability import get_tracer
+
+from ..exceptions import ExecutionError
+from .base_executor import BaseExecutor
+
+
+class CoreExecutor(BaseExecutor):
+    """Executes known Langflow components by importing them directly.
+
+    This executor imports components by their module path and instantiates them
+    directly, without needing to compile code from blob storage.
+    """
+
+    def __init__(self):
+        """Initialize core executor."""
+        super().__init__()
+
+    async def _instantiate_component(
+        self,
+        component_info: dict[str, Any],
+    ) -> tuple[Any, str]:
+        """Instantiate a component by importing its module.
+
+        Args:
+            component_info: Contains 'module_name' and 'class_name'
+
+        Returns:
+            Tuple of (component_instance, class_name)
+        """
+        module_name = component_info["module_name"]
+        class_name = component_info["class_name"]
+        tracer = get_tracer(__name__)
+
+        with tracer.start_as_current_span(
+            f"instantiate_component:{class_name}",
+            attributes={"class_name": class_name, "module_name": module_name},
+        ):
+            # Import the module and get the class
+            try:
+                module = importlib.import_module(module_name)
+                component_class = getattr(module, class_name)
+            except ImportError as e:
+                raise ExecutionError(
+                    f"Failed to import module {module_name}: {e}"
+                ) from e
+            except AttributeError as e:
+                raise ExecutionError(
+                    f"Class {class_name} not found in module {module_name}: {e}"
+                ) from e
+
+            # Instantiate the component
+            try:
+                component_instance = component_class()
+            except Exception as e:
+                raise ExecutionError(f"Failed to instantiate {class_name}: {e}") from e
+
+            return component_instance, class_name
+
+    async def execute(
+        self,
+        component_path: str,
+        input_data: dict[str, Any],
+        context: StepflowContext,
+    ) -> dict[str, Any]:
+        """Execute a core Langflow component.
+
+        Args:
+            component_path: The component path suffix after /langflow/core/
+                           (e.g., "lfx/components/docling/DoclingInlineComponent")
+            input_data: Component input containing template, outputs, runtime inputs
+            context: Stepflow context (may be needed for some operations)
+
+        Returns:
+            Component execution result
+        """
+        tracer = get_tracer(__name__)
+
+        # Convert path to module path (slashes to dots)
+        # e.g., "lfx/components/docling/DoclingInlineComponent"
+        #    -> "lfx.components.docling.DoclingInlineComponent"
+        module_path = component_path.replace("/", ".")
+
+        # Split into module and class name
+        parts = module_path.rsplit(".", 1)
+        if len(parts) != 2:
+            raise ExecutionError(f"Invalid component path: {component_path}")
+
+        module_name, class_name = parts
+
+        with tracer.start_as_current_span(
+            f"core_execute:{class_name}",
+            attributes={
+                "component_path": component_path,
+                "module_name": module_name,
+                "class_name": class_name,
+            },
+        ):
+            # Extract execution parameters from input
+            template = input_data.get("template", {})
+            outputs = input_data.get("outputs", [])
+            selected_output = input_data.get("selected_output")
+            runtime_inputs = input_data.get("input", {})
+
+            # Determine execution method
+            execution_method = self._determine_execution_method(
+                outputs, selected_output
+            )
+            if not execution_method:
+                raise ExecutionError(f"No execution method found for {class_name}")
+
+            # Instantiate the component
+            component_instance, component_name = await self._instantiate_component(
+                {"module_name": module_name, "class_name": class_name}
+            )
+
+            # Execute using shared base class method
+            result = await self._execute_component_instance(
+                component_instance=component_instance,
+                component_name=component_name,
+                execution_method=execution_method,
+                template=template,
+                runtime_inputs=runtime_inputs,
+            )
+
+            return {"result": self.type_converter.serialize_langflow_object(result)}

--- a/integrations/langflow/src/stepflow_langflow_integration/executor/standalone_server.py
+++ b/integrations/langflow/src/stepflow_langflow_integration/executor/standalone_server.py
@@ -31,22 +31,37 @@ from stepflow_py.worker import StepflowContext, StepflowServer
 from stepflow_langflow_integration.components.component_tool import (
     component_tool_executor,
 )
-from stepflow_langflow_integration.executor.udf_executor import UDFExecutor
+from stepflow_langflow_integration.executor.core_executor import CoreExecutor
+from stepflow_langflow_integration.executor.custom_code_executor import (
+    CustomCodeExecutor,
+)
 
 # Create server instance (following the exact pattern from stepflow_py.worker/main.py)
 server = StepflowServer()
 
-# Create UDF executor
-udf_executor = UDFExecutor()
+# Create executors
+custom_code_executor = CustomCodeExecutor()
+core_executor = CoreExecutor()
 
 
-# Register the main UDF executor component at module level
-@server.component(name="udf_executor")
-async def udf_executor_component(
+# Register the main custom code executor component at module level
+@server.component(name="custom_code")
+async def custom_code_component(
     input_data: dict[str, Any], context: StepflowContext
 ) -> dict[str, Any]:
-    """Execute a Langflow UDF component."""
-    return await udf_executor.execute(input_data, context)
+    """Execute a Langflow custom code component."""
+    return await custom_code_executor.execute(input_data, context)
+
+
+# Register the core component handler with wildcard path
+@server.component(name="core/{*component}")
+async def core_component(
+    input_data: dict[str, Any],
+    context: StepflowContext,
+    component: str,
+) -> dict[str, Any]:
+    """Execute a known core Langflow component by module path."""
+    return await core_executor.execute(component, input_data, context)
 
 
 # Register the component tool wrapper component
@@ -58,7 +73,7 @@ async def component_tool_component(
     return await component_tool_executor(input_data, context)
 
 
-# All Langflow components now route through the UDF executor for real execution
+# All Langflow components now route through the custom code executor for real execution
 # No hardcoded component implementations - everything uses real Langflow code
 
 

--- a/integrations/langflow/tests/unit/test_base_executor.py
+++ b/integrations/langflow/tests/unit/test_base_executor.py
@@ -1,0 +1,224 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Unit tests for the BaseExecutor shared functionality."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from stepflow_langflow_integration.exceptions import ExecutionError
+from stepflow_langflow_integration.executor.base_executor import BaseExecutor
+
+
+class ConcreteTestExecutor(BaseExecutor):
+    """Concrete implementation of BaseExecutor for testing."""
+
+    async def _instantiate_component(
+        self,
+        component_info: dict[str, Any],
+    ) -> tuple[Any, str]:
+        """Test implementation that just returns the info as-is."""
+        return component_info.get("instance"), component_info.get("name", "test")
+
+
+@pytest.fixture
+def executor():
+    """Create a ConcreteTestExecutor instance for testing base functionality."""
+    return ConcreteTestExecutor()
+
+
+class TestBaseExecutorEnvVarResolution:
+    """Tests for _resolve_env_variables in BaseExecutor."""
+
+    def test_resolve_env_var_when_load_from_db(self, executor, monkeypatch):
+        """Test that env vars are resolved for load_from_db fields."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key-123")
+
+        parameters = {"api_key": ""}
+        template = {
+            "api_key": {
+                "value": "OPENAI_API_KEY",
+                "load_from_db": True,
+            },
+        }
+
+        result = executor._resolve_env_variables(parameters, template)
+
+        assert result["api_key"] == "sk-test-key-123"
+
+    def test_no_resolution_when_value_provided(self, executor, monkeypatch):
+        """Test that env vars are NOT resolved when value is already set."""
+        monkeypatch.setenv("OPENAI_API_KEY", "env-value")
+
+        parameters = {"api_key": "already-set-value"}
+        template = {
+            "api_key": {
+                "value": "OPENAI_API_KEY",
+                "load_from_db": True,
+            },
+        }
+
+        result = executor._resolve_env_variables(parameters, template)
+
+        # Should keep the existing value
+        assert result["api_key"] == "already-set-value"
+
+    def test_no_resolution_without_load_from_db(self, executor, monkeypatch):
+        """Test that env vars are NOT resolved without load_from_db flag."""
+        monkeypatch.setenv("SOME_VAR", "env-value")
+
+        parameters = {"param": ""}
+        template = {
+            "param": {
+                "value": "SOME_VAR",
+                # No load_from_db flag
+            },
+        }
+
+        result = executor._resolve_env_variables(parameters, template)
+
+        # Should keep empty value
+        assert result["param"] == ""
+
+    def test_error_when_env_var_missing(self, executor, monkeypatch):
+        """Test that missing env var raises ExecutionError."""
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+
+        parameters = {"api_key": ""}
+        template = {
+            "api_key": {
+                "value": "MISSING_VAR",
+                "load_from_db": True,
+            },
+        }
+
+        with pytest.raises(ExecutionError, match="Environment variable.*not set"):
+            executor._resolve_env_variables(parameters, template)
+
+    def test_multiple_env_vars(self, executor, monkeypatch):
+        """Test resolving multiple env vars."""
+        monkeypatch.setenv("API_KEY_1", "key1")
+        monkeypatch.setenv("API_KEY_2", "key2")
+
+        parameters = {"key1": "", "key2": "", "regular": "value"}
+        template = {
+            "key1": {"value": "API_KEY_1", "load_from_db": True},
+            "key2": {"value": "API_KEY_2", "load_from_db": True},
+            "regular": {"value": "default"},
+        }
+
+        result = executor._resolve_env_variables(parameters, template)
+
+        assert result["key1"] == "key1"
+        assert result["key2"] == "key2"
+        assert result["regular"] == "value"  # Unchanged
+
+    def test_non_dict_template_field_skipped(self, executor):
+        """Test that non-dict template fields are skipped gracefully."""
+        parameters = {"param": ""}
+        template = {
+            "param": "direct_value",  # Not a dict
+        }
+
+        result = executor._resolve_env_variables(parameters, template)
+
+        assert result["param"] == ""  # Unchanged
+
+
+class TestBaseExecutorDetermineExecutionMethod:
+    """Tests for _determine_execution_method in BaseExecutor."""
+
+    def test_with_selected_output_match(self, executor):
+        """Test finding method for matching selected_output."""
+        outputs = [
+            {"name": "text", "method": "text_response"},
+            {"name": "message", "method": "build_message"},
+        ]
+        result = executor._determine_execution_method(outputs, "message")
+        assert result == "build_message"
+
+    def test_fallback_to_first(self, executor):
+        """Test fallback to first output's method."""
+        outputs = [
+            {"name": "default", "method": "default_method"},
+            {"name": "other", "method": "other_method"},
+        ]
+        result = executor._determine_execution_method(outputs, None)
+        assert result == "default_method"
+
+    def test_empty_outputs(self, executor):
+        """Test with empty outputs list."""
+        result = executor._determine_execution_method([], None)
+        assert result is None
+
+    def test_selected_not_found_fallback(self, executor):
+        """Test fallback when selected_output doesn't match."""
+        outputs = [{"name": "text", "method": "text_method"}]
+        result = executor._determine_execution_method(outputs, "nonexistent")
+        assert result == "text_method"
+
+
+class TestBaseExecutorApplyInputDefaults:
+    """Tests for _apply_component_input_defaults in BaseExecutor."""
+
+    def test_no_inputs_attribute(self, executor):
+        """Test with component that has no inputs attribute."""
+        component = MagicMock(spec=[])  # No inputs attribute
+        params = {"key": "value"}
+        result = executor._apply_component_input_defaults(component, params)
+        assert result == {"key": "value"}
+
+    def test_adds_missing_defaults(self, executor):
+        """Test that defaults are added for missing parameters."""
+        input_def = MagicMock()
+        input_def.name = "temperature"
+        input_def.value = 0.7
+
+        component = MagicMock()
+        component.inputs = [input_def]
+
+        params = {"model": "gpt-4"}
+        result = executor._apply_component_input_defaults(component, params)
+        assert result == {"model": "gpt-4", "temperature": 0.7}
+
+    def test_preserves_existing_values(self, executor):
+        """Test that existing params are not overwritten."""
+        input_def = MagicMock()
+        input_def.name = "temperature"
+        input_def.value = 0.7
+
+        component = MagicMock()
+        component.inputs = [input_def]
+
+        params = {"temperature": 0.9}  # Already set
+        result = executor._apply_component_input_defaults(component, params)
+        assert result == {"temperature": 0.9}  # Original preserved
+
+
+class TestBaseExecutorSetupGraphContext:
+    """Tests for _setup_graph_context in BaseExecutor."""
+
+    def test_sets_graph_context(self, executor):
+        """Test that graph context is set correctly."""
+        component = MagicMock()
+        component.__dict__ = {}
+
+        executor._setup_graph_context(component, "test-session-id")
+
+        assert "graph" in component.__dict__
+        assert component.__dict__["graph"].session_id == "test-session-id"
+        assert component.__dict__["graph"].vertices == []
+        assert component.__dict__["graph"].flow_id is None

--- a/integrations/langflow/tests/unit/test_core_executor.py
+++ b/integrations/langflow/tests/unit/test_core_executor.py
@@ -1,0 +1,379 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Unit tests for the CoreExecutor."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from stepflow_langflow_integration.exceptions import ExecutionError
+from stepflow_langflow_integration.executor.core_executor import CoreExecutor
+
+
+@pytest.fixture
+def executor():
+    """Create a CoreExecutor instance."""
+    return CoreExecutor()
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock StepflowContext."""
+    context = MagicMock()
+    context.get_blob = AsyncMock(return_value={})
+    context.put_blob = AsyncMock(return_value="blob_id")
+    return context
+
+
+class TestCoreExecutorExecutionMethodDetermination:
+    """Tests for _determine_execution_method inherited from base."""
+
+    def test_determine_execution_method_with_selected_output(self, executor):
+        """Test determining method when selected_output matches."""
+        outputs = [
+            {"name": "text", "method": "text_response"},
+            {"name": "message", "method": "build_message"},
+        ]
+        result = executor._determine_execution_method(outputs, "message")
+        assert result == "build_message"
+
+    def test_determine_execution_method_fallback_to_first(self, executor):
+        """Test falling back to first output's method."""
+        outputs = [
+            {"name": "default", "method": "default_method"},
+            {"name": "other", "method": "other_method"},
+        ]
+        result = executor._determine_execution_method(outputs, None)
+        assert result == "default_method"
+
+    def test_determine_execution_method_empty_outputs(self, executor):
+        """Test with empty outputs list."""
+        result = executor._determine_execution_method([], None)
+        assert result is None
+
+    def test_determine_execution_method_selected_not_found(self, executor):
+        """Test when selected_output doesn't match any output."""
+        outputs = [{"name": "text", "method": "text_method"}]
+        result = executor._determine_execution_method(outputs, "nonexistent")
+        # Should fall back to first output's method
+        assert result == "text_method"
+
+
+class TestCoreExecutorInputDefaults:
+    """Tests for _apply_component_input_defaults inherited from base."""
+
+    def test_apply_defaults_no_inputs(self, executor):
+        """Test with component that has no inputs attribute."""
+        component = MagicMock(spec=[])  # No inputs attribute
+        params = {"key": "value"}
+        result = executor._apply_component_input_defaults(component, params)
+        assert result == {"key": "value"}
+
+    def test_apply_defaults_empty_inputs(self, executor):
+        """Test with empty inputs list."""
+        component = MagicMock()
+        component.inputs = []
+        params = {"key": "value"}
+        result = executor._apply_component_input_defaults(component, params)
+        assert result == {"key": "value"}
+
+    def test_apply_defaults_adds_missing(self, executor):
+        """Test that defaults are added for missing parameters."""
+        input_def = MagicMock()
+        input_def.name = "temperature"
+        input_def.value = 0.7
+
+        component = MagicMock()
+        component.inputs = [input_def]
+
+        params = {"model": "gpt-4"}
+        result = executor._apply_component_input_defaults(component, params)
+        assert result == {"model": "gpt-4", "temperature": 0.7}
+
+    def test_apply_defaults_preserves_existing(self, executor):
+        """Test that existing params are not overwritten."""
+        input_def = MagicMock()
+        input_def.name = "temperature"
+        input_def.value = 0.7
+
+        component = MagicMock()
+        component.inputs = [input_def]
+
+        params = {"temperature": 0.9}  # Already set
+        result = executor._apply_component_input_defaults(component, params)
+        assert result == {"temperature": 0.9}  # Original value preserved
+
+
+class TestCoreExecutorErrors:
+    """Tests for error handling in CoreExecutor."""
+
+    @pytest.mark.asyncio
+    async def test_execute_invalid_path_no_dot(self, executor, mock_context):
+        """Test error when path has no class name separator."""
+        with pytest.raises(ExecutionError, match="Invalid component path"):
+            await executor.execute("invalid", {}, mock_context)
+
+    @pytest.mark.asyncio
+    async def test_execute_module_not_found(self, executor, mock_context):
+        """Test error when module doesn't exist."""
+        input_data = {
+            "template": {},
+            "outputs": [{"name": "result", "method": "run"}],
+            "input": {},
+        }
+        with pytest.raises(ExecutionError, match="Failed to import module"):
+            await executor.execute(
+                "nonexistent/module/path/ClassName", input_data, mock_context
+            )
+
+    @pytest.mark.asyncio
+    async def test_execute_class_not_found(self, executor, mock_context):
+        """Test error when class doesn't exist in module."""
+        input_data = {
+            "template": {},
+            "outputs": [{"name": "result", "method": "run"}],
+            "input": {},
+        }
+        # os module exists but NonExistentClass doesn't
+        with pytest.raises(ExecutionError, match="Class.*not found in module"):
+            await executor.execute("os/NonExistentClass", input_data, mock_context)
+
+    @pytest.mark.asyncio
+    async def test_execute_no_execution_method(self, executor, mock_context):
+        """Test error when no execution method found."""
+        input_data = {
+            "template": {},
+            "outputs": [],  # Empty outputs
+            "input": {},
+        }
+        # Use a real importable class
+        with pytest.raises(ExecutionError, match="No execution method found"):
+            await executor.execute("dataclasses/dataclass", input_data, mock_context)
+
+
+class TestCoreExecutorWithRealComponent:
+    """Integration tests with real Langflow components.
+
+    Note: Some Langflow components have complex dependencies (database, etc.)
+    These tests focus on verifying the executor can import and instantiate
+    components, rather than full execution which may require more setup.
+    """
+
+    @pytest.mark.asyncio
+    async def test_import_prompt_component(self, executor, mock_context):
+        """Test that PromptComponent can be imported and instantiated."""
+        import importlib
+
+        try:
+            module = importlib.import_module("langflow.components.prompts.prompt")
+            component_class = module.PromptComponent
+
+            # Verify we can instantiate
+            instance = component_class()
+            assert instance is not None
+            assert hasattr(instance, "build_prompt")
+        except ModuleNotFoundError:
+            # langflow.components.prompts may not be available in all environments
+            # Skip test if not available
+            pytest.skip("langflow.components.prompts not available")
+
+    @pytest.mark.asyncio
+    async def test_import_chat_input_component(self, executor, mock_context):
+        """Test that ChatInput component can be imported and instantiated."""
+        import importlib
+
+        module = importlib.import_module("lfx.components.input_output.chat")
+        component_class = module.ChatInput
+
+        # Verify we can instantiate
+        instance = component_class()
+        assert instance is not None
+        assert hasattr(instance, "message_response")
+
+    @pytest.mark.asyncio
+    async def test_execute_with_mocked_method(self, executor, mock_context):
+        """Test execution flow with a mocked component method."""
+        from unittest.mock import MagicMock, patch
+
+        input_data = {
+            "template": {
+                "template": {"value": "Hello {name}!"},
+            },
+            "outputs": [{"name": "prompt", "method": "build_prompt"}],
+            "selected_output": "prompt",
+            "input": {
+                "name": "World",
+            },
+        }
+
+        # Mock the component instantiation and method
+        mock_instance = MagicMock()
+        mock_instance.inputs = []
+        mock_instance.build_prompt = MagicMock(return_value="Hello World!")
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.TestComponent = MagicMock(return_value=mock_instance)
+            mock_import.return_value = mock_module
+
+            result = await executor.execute(
+                "test_module/TestComponent",
+                input_data,
+                mock_context,
+            )
+
+            assert "result" in result
+            # Method was called
+            mock_instance.build_prompt.assert_called_once()
+
+
+class TestCoreExecutorPrepareParameters:
+    """Tests for _prepare_component_parameters."""
+
+    @pytest.mark.asyncio
+    async def test_extract_values_from_template(self, executor):
+        """Test extracting values from template structure."""
+        template = {
+            "param1": {"value": "value1"},
+            "param2": {"value": 42},
+            "param3": "direct_value",
+        }
+        runtime_inputs = {}
+
+        result = await executor._prepare_component_parameters(template, runtime_inputs)
+
+        assert result["param1"] == "value1"
+        assert result["param2"] == 42
+        assert result["param3"] == "direct_value"
+
+    @pytest.mark.asyncio
+    async def test_runtime_inputs_override_template(self, executor):
+        """Test that runtime inputs override template values."""
+        template = {
+            "param1": {"value": "template_value"},
+        }
+        runtime_inputs = {
+            "param1": "runtime_value",
+        }
+
+        result = await executor._prepare_component_parameters(template, runtime_inputs)
+
+        assert result["param1"] == "runtime_value"
+
+    @pytest.mark.asyncio
+    async def test_empty_template_dict_skipped(self, executor):
+        """Test that template fields without value are skipped."""
+        template = {
+            "param1": {"value": "has_value"},
+            "param2": {},  # No value key
+            "param3": {"type": "str"},  # No value key
+        }
+        runtime_inputs = {}
+
+        result = await executor._prepare_component_parameters(template, runtime_inputs)
+
+        assert result == {"param1": "has_value"}
+
+    @pytest.mark.asyncio
+    async def test_handle_inputs_with_empty_values_skipped(self, executor):
+        """Test that handle inputs with empty values are skipped."""
+        template = {
+            "input_value": {
+                "value": "",
+                "input_types": ["Message"],  # This is a handle input
+            },
+            "regular_param": {"value": "keep_this"},
+        }
+        runtime_inputs = {}
+
+        result = await executor._prepare_component_parameters(template, runtime_inputs)
+
+        # Handle input with empty value should be skipped
+        assert "input_value" not in result
+        assert result["regular_param"] == "keep_this"
+
+
+class TestCoreExecutorEnvVarResolution:
+    """Tests for environment variable resolution in CoreExecutor."""
+
+    @pytest.mark.asyncio
+    async def test_env_var_resolution_when_load_from_db(self, executor, monkeypatch):
+        """Test that env vars are loaded for load_from_db fields."""
+        monkeypatch.setenv("MY_API_KEY", "secret-key-value")
+
+        template = {
+            "api_key": {
+                "value": "MY_API_KEY",  # This is the env var name
+                "load_from_db": True,
+            },
+        }
+        runtime_inputs = {"api_key": ""}  # Empty runtime value triggers env lookup
+
+        result = await executor._prepare_component_parameters(template, runtime_inputs)
+
+        assert result["api_key"] == "secret-key-value"
+
+    @pytest.mark.asyncio
+    async def test_env_var_not_needed_when_value_provided(self, executor, monkeypatch):
+        """Test that env vars are NOT loaded when runtime value is provided."""
+        monkeypatch.setenv("MY_API_KEY", "env-value")
+
+        template = {
+            "api_key": {
+                "value": "MY_API_KEY",
+                "load_from_db": True,
+            },
+        }
+        runtime_inputs = {"api_key": "runtime-value"}  # Non-empty runtime value
+
+        result = await executor._prepare_component_parameters(template, runtime_inputs)
+
+        # Runtime value should be used, not env var
+        assert result["api_key"] == "runtime-value"
+
+    @pytest.mark.asyncio
+    async def test_env_var_missing_raises_error(self, executor, monkeypatch):
+        """Test that missing env var raises ExecutionError."""
+        # Ensure the env var is NOT set
+        monkeypatch.delenv("MISSING_API_KEY", raising=False)
+
+        template = {
+            "api_key": {
+                "value": "MISSING_API_KEY",
+                "load_from_db": True,
+            },
+        }
+        runtime_inputs = {"api_key": ""}  # Empty triggers env lookup
+
+        with pytest.raises(ExecutionError, match="Environment variable.*not set"):
+            await executor._prepare_component_parameters(template, runtime_inputs)
+
+    @pytest.mark.asyncio
+    async def test_no_env_resolution_without_load_from_db(self, executor, monkeypatch):
+        """Test that env vars are NOT loaded without load_from_db flag."""
+        monkeypatch.setenv("SOME_VAR", "env-value")
+
+        template = {
+            "param": {
+                "value": "SOME_VAR",
+                # No load_from_db flag
+            },
+        }
+        runtime_inputs = {"param": ""}  # Empty value
+
+        result = await executor._prepare_component_parameters(template, runtime_inputs)
+
+        # Should keep the empty value, not load from env
+        assert result["param"] == ""

--- a/integrations/langflow/tests/unit/test_stepflow_tweaks.py
+++ b/integrations/langflow/tests/unit/test_stepflow_tweaks.py
@@ -117,18 +117,18 @@ class TestStepflowTweaksIntegration:
 
         modified_dict = apply_stepflow_tweaks_to_dict(basic_prompting_flow_dict, tweaks)
 
-        # Find the LanguageModelComponent UDF executor step
+        # Find the LanguageModelComponent executor step (custom_code or core)
         langflow_step = None
         for step in modified_dict["steps"]:
-            if (
-                step["id"] == "langflow_LanguageModelComponent-kBOja"
-                and step["component"] == "/langflow/udf_executor"
+            if step["id"] == "langflow_LanguageModelComponent-kBOja" and (
+                step["component"] == "/langflow/custom_code"
+                or step["component"].startswith("/langflow/core/")
             ):
                 langflow_step = step
                 break
 
         assert langflow_step is not None, (
-            "LanguageModelComponent UDF executor step not found"
+            "LanguageModelComponent executor step not found"
         )
 
         # Verify tweaks were applied

--- a/integrations/langflow/tests/unit/test_translator.py
+++ b/integrations/langflow/tests/unit/test_translator.py
@@ -400,13 +400,13 @@ class CustomComponent(Component):
 
         workflow = converter.convert(workflow_data)
 
-        # Should create blob step + UDF executor step for component with custom code
+        # Should create blob + custom_code steps for component with custom code
         step_components = [step.component for step in workflow.steps]
         assert "/builtin/put_blob" in step_components, (
             "Should create blob step for custom code"
         )
-        assert "/langflow/udf_executor" in step_components, (
-            "Should route custom code to UDF executor"
+        assert "/langflow/custom_code" in step_components, (
+            "Should route custom code to custom code executor"
         )
 
         # Find the blob step and verify it contains the custom code

--- a/integrations/langflow/tests/unit/test_udf_executor.py
+++ b/integrations/langflow/tests/unit/test_udf_executor.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-"""Unit test for UDF execution in isolation (with real Langflow code)."""
+"""Unit test for custom code execution in isolation (with real Langflow code)."""
 
 from typing import Any
 from unittest.mock import AsyncMock
@@ -20,16 +20,18 @@ from unittest.mock import AsyncMock
 import pytest
 
 from stepflow_langflow_integration.exceptions import ExecutionError
-from stepflow_langflow_integration.executor.udf_executor import UDFExecutor
+from stepflow_langflow_integration.executor.custom_code_executor import (
+    CustomCodeExecutor,
+)
 
 
-class TestUDFExecutor:
-    """Test UDFExecutor functionality with real Langflow component code."""
+class TestCustomCodeExecutor:
+    """Test CustomCodeExecutor functionality with real Langflow component code."""
 
     @pytest.fixture
     def executor(self):
-        """Create UDFExecutor instance."""
-        return UDFExecutor()
+        """Create CustomCodeExecutor instance."""
+        return CustomCodeExecutor()
 
     @pytest.fixture
     def mock_context(self):
@@ -174,7 +176,9 @@ class ChatInput(ChatComponent):
         }
 
     @pytest.mark.asyncio
-    async def test_execute_missing_blob_id(self, executor: UDFExecutor, mock_context):
+    async def test_execute_missing_blob_id(
+        self, executor: CustomCodeExecutor, mock_context
+    ):
         """Test execution fails when blob_id is missing."""
         input_data = {"input": {"text": "test"}}
 
@@ -183,7 +187,10 @@ class ChatInput(ChatComponent):
 
     @pytest.mark.asyncio
     async def test_execute_simple_component(
-        self, executor: UDFExecutor, mock_context, simple_component_blob: dict[str, Any]
+        self,
+        executor: CustomCodeExecutor,
+        mock_context,
+        simple_component_blob: dict[str, Any],
     ):
         """Test execution of a simple custom component."""
         # Setup mock context
@@ -217,7 +224,7 @@ class ChatInput(ChatComponent):
     @pytest.mark.asyncio
     async def test_execute_chat_input_component(
         self,
-        executor: UDFExecutor,
+        executor: CustomCodeExecutor,
         mock_context,
         chat_input_component_blob: dict[str, Any],
     ):
@@ -253,7 +260,10 @@ class ChatInput(ChatComponent):
 
     @pytest.mark.asyncio
     async def test_execute_component_with_template_defaults(
-        self, executor: UDFExecutor, mock_context, simple_component_blob: dict[str, Any]
+        self,
+        executor: CustomCodeExecutor,
+        mock_context,
+        simple_component_blob: dict[str, Any],
     ):
         """Test that template default values are used when input is not provided."""
         # Modify blob to have default value
@@ -277,7 +287,10 @@ class ChatInput(ChatComponent):
 
     @pytest.mark.asyncio
     async def test_execute_component_runtime_overrides_template(
-        self, executor: UDFExecutor, mock_context, simple_component_blob: dict[str, Any]
+        self,
+        executor: CustomCodeExecutor,
+        mock_context,
+        simple_component_blob: dict[str, Any],
     ):
         """Test that runtime inputs override template defaults."""
         # Set template default
@@ -301,7 +314,7 @@ class ChatInput(ChatComponent):
 
     @pytest.mark.asyncio
     async def test_execute_component_with_missing_code(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         """Test execution fails when component code is missing."""
         blob_data = {
@@ -319,7 +332,7 @@ class ChatInput(ChatComponent):
 
     @pytest.mark.asyncio
     async def test_execute_component_with_invalid_code(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         """Test execution fails when component code is invalid Python."""
         blob_data = {
@@ -337,7 +350,7 @@ class ChatInput(ChatComponent):
 
     @pytest.mark.asyncio
     async def test_execute_component_class_not_found(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         """Test execution fails when component class is not found in code."""
         blob_data = {
@@ -362,7 +375,7 @@ def some_function():
 
     @pytest.mark.asyncio
     async def test_execute_component_instantiation_fails(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         """Test execution fails when component cannot be instantiated."""
         blob_data = {
@@ -400,7 +413,7 @@ class FailingComponent(Component):
 
     @pytest.mark.asyncio
     async def test_execute_component_method_not_found(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         """Test execution fails when execution method is not found."""
         blob_data = {
@@ -426,7 +439,7 @@ class NoMethodComponent(Component):
 
     @pytest.mark.asyncio
     async def test_execute_component_method_execution_fails(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         """Test execution fails when component method throws exception."""
         blob_data = {
@@ -451,7 +464,9 @@ class FailingMethodComponent(Component):
         with pytest.raises(ExecutionError, match="Failed to execute failing_method"):
             await executor.execute(input_data, mock_context)
 
-    def test_environment_variable_handling_deprecated(self, executor: UDFExecutor):
+    def test_environment_variable_handling_deprecated(
+        self, executor: CustomCodeExecutor
+    ):
         """Test that environment variable handling is now handled via preprocessing.
 
         This test documents that environment variable resolution was moved from
@@ -463,7 +478,7 @@ class FailingMethodComponent(Component):
         # instead of runtime resolution in the UDF executor
         assert True  # This test now just documents the architectural change
 
-    def test_determine_execution_method(self, executor: UDFExecutor):
+    def test_determine_execution_method(self, executor: CustomCodeExecutor):
         """Test execution method determination from outputs metadata."""
         outputs = [
             {"name": "result1", "method": "method1", "types": ["str"]},
@@ -487,14 +502,14 @@ class FailingMethodComponent(Component):
         assert method == "method1"
 
 
-class TestUDFExecutorIntegration:
+class TestCustomCodeExecutorIntegration:
     """Integration tests with mock Langflow imports."""
 
     @pytest.fixture
     def executor_with_mocks(self):
-        """Create UDFExecutor with mocked Langflow imports."""
+        """Create CustomCodeExecutor with mocked Langflow imports."""
         # We'll test this without real Langflow imports to avoid dependency issues
-        return UDFExecutor()
+        return CustomCodeExecutor()
 
     # Registry fixture removed - no longer needed after eliminating test registry
 
@@ -507,7 +522,7 @@ class TestUDFExecutorIntegration:
 
     @pytest.mark.asyncio
     async def test_component_parameter_preparation(
-        self, executor_with_mocks: UDFExecutor
+        self, executor_with_mocks: CustomCodeExecutor
     ):
         """Test component parameter preparation logic.
 
@@ -551,13 +566,13 @@ class TestUDFExecutorIntegration:
         assert params["extra_field"] == "extra_value"
 
 
-class TestUDFExecutorWithRealLangflowComponents:
-    """Test UDFExecutor with real converted Langflow workflow components."""
+class TestCustomCodeExecutorWithRealLangflowComponents:
+    """Test CustomCodeExecutor with real converted Langflow workflow components."""
 
     @pytest.fixture
     def executor(self):
-        """Create UDFExecutor instance."""
-        return UDFExecutor()
+        """Create CustomCodeExecutor instance."""
+        return CustomCodeExecutor()
 
     @pytest.fixture
     def mock_context(self):
@@ -576,7 +591,7 @@ class TestUDFExecutorWithRealLangflowComponents:
 
     @pytest.mark.asyncio
     async def test_execute_converted_workflow_components(
-        self, executor: UDFExecutor, mock_context, converter
+        self, executor: CustomCodeExecutor, mock_context, converter
     ):
         """Test that components from converted workflows execute correctly."""
         # Create simple workflow data to test UDF component creation
@@ -615,32 +630,36 @@ class TestPrompt(Component):
             }
         }
 
-        # Convert to find the UDF components
+        # Convert to find the custom code components
         stepflow_workflow = converter.convert(langflow_data)
 
-        # Find steps that use /langflow/udf_executor
-        udf_steps = [
+        # Find steps that use /langflow/custom_code
+        custom_code_steps = [
             step
             for step in stepflow_workflow.steps
-            if step.component == "/langflow/udf_executor"
+            if step.component == "/langflow/custom_code"
         ]
 
-        assert len(udf_steps) > 0, "No UDF executor steps found in test workflow"
+        assert len(custom_code_steps) > 0, (
+            "No custom code executor steps found in test workflow"
+        )
 
-        # Test the first UDF step
-        first_step = udf_steps[0]
+        # Test the first custom code step
+        first_step = custom_code_steps[0]
 
         # The step input should have blob_id reference
         assert "blob_id" in str(first_step.input), (
             f"No blob_id found in step input: {first_step.input}"
         )
 
-        print(f"✅ Found {len(udf_steps)} UDF components in converted workflow")
-        print(f"✅ First UDF step: {first_step.id} using {first_step.component}")
+        print(f"✅ Found {len(custom_code_steps)} custom code components")
+        print(
+            f"✅ First custom code step: {first_step.id} using {first_step.component}"
+        )
 
     @pytest.mark.asyncio
     async def test_component_metadata_extraction_and_usage(
-        self, executor: UDFExecutor, mock_context
+        self, executor: CustomCodeExecutor, mock_context
     ):
         # Create blob with enhanced metadata (from Phase 1 improvements)
         enhanced_blob = {
@@ -778,7 +797,7 @@ class EnhancedTestComponent(Component):
 
     @pytest.mark.asyncio
     async def test_agent_component(
-        self, executor: UDFExecutor, mock_context, agent_component_blob
+        self, executor: CustomCodeExecutor, mock_context, agent_component_blob
     ):
         """Test that Agent component can be compiled and instantiated.
 
@@ -815,7 +834,7 @@ class EnhancedTestComponent(Component):
 
     @pytest.mark.asyncio
     async def test_agent_component_execution_attempt(
-        self, executor: UDFExecutor, mock_context, agent_component_blob
+        self, executor: CustomCodeExecutor, mock_context, agent_component_blob
     ):
         """Test Agent component execution (will fail without real API key).
 
@@ -855,7 +874,7 @@ class EnhancedTestComponent(Component):
 
     @pytest.mark.asyncio
     async def test_prompt_component(
-        self, executor: UDFExecutor, mock_context, prompt_component_data
+        self, executor: CustomCodeExecutor, mock_context, prompt_component_data
     ):
         """Test executing Prompt component with string-type system_message field.
 
@@ -913,7 +932,7 @@ class EnhancedTestComponent(Component):
 
     @pytest.mark.asyncio
     async def test_language_model_message_to_string_conversion(
-        self, executor: UDFExecutor, mock_context, basic_prompting_flow
+        self, executor: CustomCodeExecutor, mock_context, basic_prompting_flow
     ):
         """Test LanguageModelComponent receives string when Message passed.
 
@@ -977,7 +996,7 @@ class EnhancedTestComponent(Component):
 
     @pytest.mark.asyncio
     async def test_chat_input_lfx_component(
-        self, executor: UDFExecutor, mock_context, chat_input_component_data
+        self, executor: CustomCodeExecutor, mock_context, chat_input_component_data
     ):
         """Test executing ChatInput component (lfx-based) from basic_prompting flow.
 
@@ -1031,7 +1050,7 @@ class EnhancedTestComponent(Component):
 
     @pytest.mark.asyncio
     async def test_chat_input_message_to_string_conversion(
-        self, executor: UDFExecutor, mock_context, chat_input_component_data
+        self, executor: CustomCodeExecutor, mock_context, chat_input_component_data
     ):
         """Test ChatInput component with Message object passed to string field.
 

--- a/sdks/python/stepflow-py/src/stepflow_py/api/models/flow_error.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/api/models/flow_error.py
@@ -96,9 +96,7 @@ class FlowError(BaseModel):
             {
                 "code": obj.get("code"),
                 "message": obj.get("message"),
-                "data": OneOf.from_dict(obj["data"])
-                if obj.get("data") is not None
-                else None,
+                "data": obj.get("data") if obj.get("data") is not None else None,
             }
         )
         return _obj


### PR DESCRIPTION
Add support for executing known Langflow components directly by module path,
avoiding the need to compile code from blob storage for every execution.
    
Key changes:
- Create CoreExecutor for importing known components by module path
- Rename UDFExecutor to CustomCodeExecutor for clarity
- Add known_components.py with hash-to-module mappings
- Refactor BaseExecutor as abstract class with shared execution logic
- Move environment variable resolution to shared BaseExecutor
- Add comprehensive tests for both execution paths
    
Components with known hashes (ChatInput, ChatOutput, LanguageModelComponent)
now route to /langflow/core/{module_path} while unknown components continue
using /langflow/custom_code with blob compilation.

Closes #544