### PR TITLE
docs: Add changelog reference to stepflow-orchestrator

### DIFF
--- a/sdks/python/stepflow-orchestrator/README.md
+++ b/sdks/python/stepflow-orchestrator/README.md
@@ -57,3 +57,7 @@ Set `STEPFLOW_DEV_BINARY` to use a local development build:
 ```bash
 export STEPFLOW_DEV_BINARY=/path/to/stepflow-server
 ```
+
+## Changelog
+
+This package bundles the Stepflow server binary. For release notes and changelog, see the main [Stepflow Changelog](https://github.com/stepflow-ai/stepflow/blob/main/stepflow-rs/CHANGELOG.md).

--- a/sdks/python/stepflow-orchestrator/pyproject.toml
+++ b/sdks/python/stepflow-orchestrator/pyproject.toml
@@ -41,6 +41,7 @@ Documentation = "https://stepflow-ai.github.io/stepflow/"
 Repository = "https://github.com/stepflow-ai/stepflow"
 "Bug Tracker" = "https://github.com/stepflow-ai/stepflow/issues"
 "Source Code" = "https://github.com/stepflow-ai/stepflow/tree/main/sdks/python/stepflow-orchestrator"
+Changelog = "https://github.com/stepflow-ai/stepflow/blob/main/stepflow-rs/CHANGELOG.md"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Reference the main Stepflow changelog since stepflow-orchestrator just bundles the Rust binary.

- Add Changelog section to README.md with link to main changelog
- Add Changelog URL to pyproject.toml for PyPI display

Closes #556