### PR TITLE
refactor: Consolidate ExecutionContext into RunContext

### DIFF
--- a/stepflow-rs/crates/stepflow-builtins/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/lib.rs
@@ -10,8 +10,13 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-use stepflow_core::{FlowResult, component::ComponentInfo, workflow::ValueRef};
-use stepflow_plugin::ExecutionContext;
+use std::sync::Arc;
+use stepflow_core::{
+    FlowResult,
+    component::ComponentInfo,
+    workflow::{StepId, ValueRef},
+};
+use stepflow_plugin::RunContext;
 
 mod blob;
 mod error;
@@ -34,5 +39,10 @@ pub use plugin::{BuiltinPluginConfig, Builtins};
 pub(crate) trait BuiltinComponent: Send + Sync {
     fn component_info(&self) -> Result<ComponentInfo>;
 
-    async fn execute(&self, context: ExecutionContext, input: ValueRef) -> Result<FlowResult>;
+    async fn execute(
+        &self,
+        run_context: &Arc<RunContext>,
+        step: Option<&StepId>,
+        input: ValueRef,
+    ) -> Result<FlowResult>;
 }

--- a/stepflow-rs/crates/stepflow-builtins/src/messages.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/messages.rs
@@ -12,10 +12,12 @@
 
 use error_stack::ResultExt as _;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use stepflow_core::FlowResult;
 use stepflow_core::workflow::Component;
+use stepflow_core::workflow::StepId;
 use stepflow_core::{component::ComponentInfo, schema::SchemaRef, workflow::ValueRef};
-use stepflow_plugin::ExecutionContext;
+use stepflow_plugin::RunContext;
 
 use crate::openai::{ChatMessage, ChatMessageRole};
 use crate::{BuiltinComponent, Result, error::BuiltinError};
@@ -53,7 +55,12 @@ impl BuiltinComponent for CreateMessagesComponent {
         })
     }
 
-    async fn execute(&self, _context: ExecutionContext, input: ValueRef) -> Result<FlowResult> {
+    async fn execute(
+        &self,
+        _run_context: &Arc<RunContext>,
+        _step: Option<&StepId>,
+        input: ValueRef,
+    ) -> Result<FlowResult> {
         let CreateMessagesInput {
             system_instructions,
             user_prompt,
@@ -93,7 +100,7 @@ mod tests {
         let input = serde_json::to_value(input).unwrap();
         let mock = MockContext::new().await;
         let output = component
-            .execute(mock.execution_context(), input.into())
+            .execute(&mock.run_context(), None, input.into())
             .await
             .unwrap();
         let output: CreateMessagesOutput = output.success().unwrap().deserialize().unwrap();

--- a/stepflow-rs/crates/stepflow-builtins/src/openai.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/openai.rs
@@ -13,9 +13,11 @@
 use error_stack::ResultExt as _;
 use openai_api_rs::v1::{api::OpenAIClient, chat_completion};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use stepflow_core::workflow::Component;
+use stepflow_core::workflow::StepId;
 use stepflow_core::{FlowResult, component::ComponentInfo, schema::SchemaRef, workflow::ValueRef};
-use stepflow_plugin::ExecutionContext;
+use stepflow_plugin::RunContext;
 
 use crate::{BuiltinComponent, Result, error::BuiltinError};
 
@@ -101,7 +103,12 @@ impl BuiltinComponent for OpenAIComponent {
         })
     }
 
-    async fn execute(&self, _context: ExecutionContext, input: ValueRef) -> Result<FlowResult> {
+    async fn execute(
+        &self,
+        _run_context: &Arc<RunContext>,
+        _step: Option<&StepId>,
+        input: ValueRef,
+    ) -> Result<FlowResult> {
         let input: OpenAIInput = input
             .deserialize()
             .change_context(BuiltinError::InvalidInput)?;
@@ -172,7 +179,7 @@ mod tests {
         let input = serde_json::to_value(input).unwrap();
         let mock = MockContext::new().await;
         let output = component
-            .execute(mock.execution_context(), input.into())
+            .execute(&mock.run_context(), None, input.into())
             .await
             .unwrap();
 

--- a/stepflow-rs/crates/stepflow-builtins/src/plugin.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/plugin.rs
@@ -15,13 +15,14 @@ use std::sync::Arc;
 use crate::{BuiltinComponent as _, registry};
 use error_stack::ResultExt as _;
 use serde::{Deserialize, Serialize};
+use stepflow_core::workflow::StepId;
 use stepflow_core::{
     FlowResult,
     component::ComponentInfo,
     workflow::{Component, ValueRef},
 };
 use stepflow_plugin::{
-    DynPlugin, ExecutionContext, Plugin, PluginConfig, PluginError, Result, StepflowEnvironment,
+    DynPlugin, Plugin, PluginConfig, PluginError, Result, RunContext, StepflowEnvironment,
 };
 
 /// The struct that implements the `Plugin` trait.
@@ -75,12 +76,13 @@ impl Plugin for Builtins {
     async fn execute(
         &self,
         component: &Component,
-        context: ExecutionContext,
+        run_context: &Arc<RunContext>,
+        step: Option<&StepId>,
         input: ValueRef,
     ) -> Result<FlowResult> {
         let component = registry::get_component(component)?;
         component
-            .execute(context, input)
+            .execute(run_context, step, input)
             .await
             .change_context(PluginError::UdfExecution)
     }

--- a/stepflow-rs/crates/stepflow-components-mcp/src/plugin.rs
+++ b/stepflow-rs/crates/stepflow-components-mcp/src/plugin.rs
@@ -17,13 +17,14 @@ use error_stack::ResultExt as _;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use stepflow_core::workflow::StepId;
 use stepflow_core::{
     FlowError, FlowResult,
     component::ComponentInfo,
     workflow::{Component, ValueRef},
 };
 use stepflow_plugin::{
-    DynPlugin, ExecutionContext, Plugin, PluginConfig, PluginError, Result, StepflowEnvironment,
+    DynPlugin, Plugin, PluginConfig, PluginError, Result, RunContext, StepflowEnvironment,
 };
 use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
@@ -438,7 +439,8 @@ impl Plugin for McpPlugin {
     async fn execute(
         &self,
         component: &Component,
-        _context: ExecutionContext,
+        _run_context: &Arc<RunContext>,
+        _step: Option<&StepId>,
         input: ValueRef,
     ) -> Result<FlowResult> {
         let tool_name = component_path_to_tool_name(component.path())

--- a/stepflow-rs/crates/stepflow-execution/src/flow_executor.rs
+++ b/stepflow-rs/crates/stepflow-execution/src/flow_executor.rs
@@ -560,17 +560,12 @@ impl FlowExecutor {
         // Create RunContext with subflow submitter for this task's run
         // The submitter uses this run as the parent_run_id for any subflows
         let submitter = self.submit_sender.for_run(task.run_id);
-        let run_context = Arc::new(RunContext::for_root(task.run_id).with_submitter(submitter));
+        let run_context = Arc::new(
+            RunContext::new(task.run_id, flow, flow_id, self.env.clone()).with_submitter(submitter),
+        );
 
         // Create step runner with all execution context
-        let runner = StepRunner::new(
-            flow,
-            task.step_index,
-            step_input,
-            self.env.clone(),
-            flow_id,
-            run_context,
-        );
+        let runner = StepRunner::new(task.step_index, step_input, run_context);
 
         // Create an owned future that runs the step and handles errors
         let future = async move {

--- a/stepflow-rs/crates/stepflow-mock/src/mock_plugin.rs
+++ b/stepflow-rs/crates/stepflow-mock/src/mock_plugin.rs
@@ -14,6 +14,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use error_stack::ResultExt as _;
 use serde::{Deserialize, Serialize};
+use stepflow_core::workflow::StepId;
 use stepflow_core::{
     FlowResult,
     component::ComponentInfo,
@@ -21,7 +22,7 @@ use stepflow_core::{
     workflow::{Component, ValueRef},
 };
 use stepflow_plugin::{
-    DynPlugin, ExecutionContext, Plugin, PluginConfig, PluginError, Result, StepflowEnvironment,
+    DynPlugin, Plugin, PluginConfig, PluginError, Result, RunContext, StepflowEnvironment,
 };
 use tokio::sync::Mutex;
 
@@ -221,7 +222,8 @@ impl Plugin for MockPlugin {
     async fn execute(
         &self,
         component: &Component,
-        _context: ExecutionContext,
+        _run_context: &Arc<RunContext>,
+        _step: Option<&StepId>,
         input: ValueRef,
     ) -> Result<FlowResult> {
         let mock_component = self

--- a/stepflow-rs/crates/stepflow-plugin/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/lib.rs
@@ -18,7 +18,7 @@ mod plugin;
 pub mod routing;
 mod subflow;
 
-pub use context::{ExecutionContext, RunContext};
+pub use context::RunContext;
 pub use environment_builder::StepflowEnvironmentBuilder;
 pub use environment_ext::PluginRouterExt;
 pub use error::{PluginError, Result};

--- a/stepflow-rs/crates/stepflow-plugin/src/plugin.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/plugin.rs
@@ -12,12 +12,12 @@
 
 use std::{path::Path, sync::Arc};
 
-use crate::{ExecutionContext, Result, StepflowEnvironment};
+use crate::{Result, RunContext, StepflowEnvironment};
 use serde::{Serialize, de::DeserializeOwned};
 use stepflow_core::{
     FlowResult,
     component::ComponentInfo,
-    workflow::{Component, ValueRef},
+    workflow::{Component, StepId, ValueRef},
 };
 
 #[trait_variant::make(Send)]
@@ -42,10 +42,17 @@ pub trait Plugin: Send + Sync {
     /// Execute the step and return the resulting arguments.
     ///
     /// The arguments should be fully resolved.
+    ///
+    /// # Arguments
+    /// * `component` - The component to execute
+    /// * `run_context` - The run context with flow, environment, and subflow submission
+    /// * `step` - The step being executed (None for workflow-level operations)
+    /// * `input` - The resolved input values
     async fn execute(
         &self,
         component: &Component,
-        context: ExecutionContext,
+        run_context: &Arc<RunContext>,
+        step: Option<&StepId>,
         input: ValueRef,
     ) -> Result<FlowResult>;
 }

--- a/stepflow-rs/crates/stepflow-plugin/src/routing/plugin_router.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/routing/plugin_router.rs
@@ -194,7 +194,8 @@ mod tests {
         async fn execute(
             &self,
             _component: &stepflow_core::workflow::Component,
-            _context: crate::ExecutionContext,
+            _run_context: &std::sync::Arc<crate::RunContext>,
+            _step: Option<&stepflow_core::workflow::StepId>,
             _input: stepflow_core::workflow::ValueRef,
         ) -> crate::Result<stepflow_core::FlowResult> {
             Ok(stepflow_core::FlowResult::Success(

--- a/stepflow-rs/crates/stepflow-protocol/src/handlers/flow_handlers.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/handlers/flow_handlers.rs
@@ -13,7 +13,7 @@
 use futures::future::{BoxFuture, FutureExt as _};
 use std::sync::Arc;
 use stepflow_core::GetRunParams;
-use stepflow_plugin::{RunContext, StepflowEnvironment};
+use stepflow_plugin::RunContext;
 use stepflow_state::StateStoreExt as _;
 use tokio::sync::mpsc;
 
@@ -33,9 +33,9 @@ impl MethodHandler for SubmitRunHandler {
         &self,
         request: &'a MethodRequest<'a>,
         response_tx: mpsc::Sender<String>,
-        env: Arc<StepflowEnvironment>,
-        _run_context: &'a Arc<RunContext>,
+        run_context: &'a Arc<RunContext>,
     ) -> BoxFuture<'a, error_stack::Result<(), TransportError>> {
+        let env = run_context.env().clone();
         handle_method_call(
             request,
             response_tx,
@@ -112,9 +112,9 @@ impl MethodHandler for GetRunHandler {
         &self,
         request: &'a MethodRequest<'a>,
         response_tx: mpsc::Sender<String>,
-        env: Arc<StepflowEnvironment>,
-        _run_context: &'a Arc<RunContext>,
+        run_context: &'a Arc<RunContext>,
     ) -> BoxFuture<'a, error_stack::Result<(), TransportError>> {
+        let env = run_context.env().clone();
         handle_method_call(
             request,
             response_tx,

--- a/stepflow-rs/crates/stepflow-protocol/src/handlers/message_handler.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/handlers/message_handler.rs
@@ -13,7 +13,7 @@
 use futures::future::BoxFuture;
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
-use stepflow_plugin::{RunContext, StepflowEnvironment};
+use stepflow_plugin::RunContext;
 use tokio::sync::mpsc;
 
 use super::blob_handlers::{GetBlobHandler, PutBlobHandler};
@@ -31,8 +31,7 @@ pub trait MethodHandler: Send + Sync {
     /// # Arguments
     /// * `request` - The method request to handle
     /// * `outgoing_tx` - Channel to send messages back to the component server
-    /// * `env` - The shared environment (state store, plugins, etc.)
-    /// * `run_context` - The run context with run_id and root_run_id.
+    /// * `run_context` - The run context with run_id, root_run_id, and environment access.
     ///   Always present since bidirectional requests only occur during component execution.
     ///
     /// # Returns
@@ -41,7 +40,6 @@ pub trait MethodHandler: Send + Sync {
         &self,
         request: &'a MethodRequest<'a>,
         outgoing_tx: mpsc::Sender<String>,
-        env: Arc<StepflowEnvironment>,
         run_context: &'a Arc<RunContext>,
     ) -> BoxFuture<'a, error_stack::Result<(), TransportError>>;
 }

--- a/stepflow-rs/crates/stepflow-protocol/src/http/bidirectional_driver.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/http/bidirectional_driver.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use futures::stream::{FuturesUnordered, StreamExt as _};
-use stepflow_plugin::{RunContext, StepflowEnvironment};
+use stepflow_plugin::RunContext;
 use tokio::task::JoinHandle;
 
 use crate::error::{Result, TransportError};
@@ -41,10 +41,8 @@ use crate::{Message, OwnedJson, RequestId};
 pub struct BidirectionalDriver {
     client_handle: super::HttpClientHandle,
     instance_id: Option<String>,
-    /// Environment for bidirectional request handlers (state store access, etc.)
-    env: Arc<StepflowEnvironment>,
     /// Run context for this bidirectional session.
-    /// Required so handlers know which run tree they're serving.
+    /// Provides run hierarchy, environment access, and handler context.
     run_context: Arc<RunContext>,
 }
 
@@ -62,18 +60,15 @@ impl BidirectionalDriver {
     /// # Arguments
     /// * `client_handle` - HTTP client handle for sending responses
     /// * `instance_id` - Optional instance ID for load balancer routing
-    /// * `env` - Environment for bidirectional request handlers
-    /// * `run_context` - Run context for bidirectional handlers
+    /// * `run_context` - Run context for bidirectional handlers (provides environment access)
     pub fn new(
         client_handle: super::HttpClientHandle,
         instance_id: Option<String>,
-        env: Arc<StepflowEnvironment>,
         run_context: Arc<RunContext>,
     ) -> Self {
         Self {
             client_handle,
             instance_id,
-            env,
             run_context,
         }
     }
@@ -193,7 +188,6 @@ impl BidirectionalDriver {
 
         // Clone values for the spawned task
         let instance_id = self.instance_id.clone();
-        let env = self.env.clone();
         let run_context = self.run_context.clone();
 
         // Spawn concurrent handler
@@ -204,7 +198,6 @@ impl BidirectionalDriver {
                     request_id.clone(),
                     owned_json,
                     instance_id.as_deref(),
-                    env,
                     &run_context,
                 )
                 .await

--- a/stepflow-rs/crates/stepflow-protocol/src/protocol/observability.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/protocol/observability.rs
@@ -65,21 +65,24 @@ pub struct ObservabilityContext {
 }
 
 impl ObservabilityContext {
-    /// Create observability context from current span and execution context.
+    /// Create observability context from current span and run context.
     ///
     /// This extracts trace context from the current fastrace span and combines it
-    /// with execution context (run_id, flow_id, step_id) to create a complete
+    /// with run context (run_id, flow_id) and optional step to create a complete
     /// observability context for component execution.
-    pub fn from_execution_context(execution_context: &stepflow_plugin::ExecutionContext) -> Self {
+    pub fn from_run_context(
+        run_context: &stepflow_plugin::RunContext,
+        step: Option<&stepflow_core::workflow::StepId>,
+    ) -> Self {
         // Extract trace context from current fastrace span
         let (trace_id, span_id) = Self::extract_trace_context();
 
         Self {
             trace_id,
             span_id,
-            run_id: Some(execution_context.run_id().to_string()),
-            flow_id: execution_context.flow_id().cloned(),
-            step_id: execution_context.step_id().map(|s| s.to_owned()),
+            run_id: Some(run_context.run_id.to_string()),
+            flow_id: Some(run_context.flow_id.clone()),
+            step_id: step.map(|s| s.name().to_owned()),
         }
     }
 


### PR DESCRIPTION
Simplify the plugin execution API by merging ExecutionContext into RunContext. The unified RunContext now carries all execution state: run hierarchy (run_id, root_run_id), flow and flow_id, environment, and subflow submission.

Key changes:
- Remove ExecutionContext, use RunContext throughout
- Plugin::execute takes run_context and step separately
- StepRunner constructor simplified to just step_index, input, run_context
- Update all plugins and handlers to use the new API

Closes #505