### PR TITLE
feat: Add --fix argument to check scripts for suggesting fix commands

### DIFF
--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -45,9 +45,7 @@ require_tool "pnpm" "npm install -g pnpm"
 
 run_check "Dependencies" pnpm install --frozen-lockfile || true
 
-if ! run_check "Build" pnpm build; then
-    print_fix "Fix build errors"
-fi
+run_check "Build" pnpm build
 
 # =============================================================================
 # OPTIONAL CHECKS (warn but don't fail)

--- a/scripts/check-langflow.sh
+++ b/scripts/check-langflow.sh
@@ -54,13 +54,9 @@ run_check "Dependencies" uv sync || true
 # LANGFLOW CHECKS
 # =============================================================================
 
-if ! run_check "Formatting" uv run poe fmt-check; then
-    print_fix "uv run poe fmt-fix"
-fi
+run_check "Formatting" --fix "uv run poe fmt-fix" uv run poe fmt-check
 
-if ! run_check "Linting" uv run poe lint-check; then
-    print_fix "uv run poe lint-fix"
-fi
+run_check "Linting" --fix "uv run poe lint-fix" uv run poe lint-check
 
 # Clear mypy cache before type checking to avoid cross-project cache corruption.
 # This is needed because langflow imports stepflow_py via editable install, and
@@ -69,15 +65,11 @@ fi
 # require reinstalling packages after every change to stepflow_py or stepflow_orchestrator.
 rm -rf .mypy_cache
 
-if ! run_check "Type checking" uv run poe type-check; then
-    print_fix "Fix type errors"
-fi
+run_check "Type checking" uv run poe type-check
 
 run_check "Dep check" uv run poe dep-check || true
 
-if ! run_check "Tests" uv run poe test; then
-    print_fix "Fix failing tests"
-fi
+run_check "Tests" uv run poe test
 
 # =============================================================================
 # INTEGRATION TESTS (requires stepflow-server binary)
@@ -103,9 +95,7 @@ fi
 
 if [ -n "$STEPFLOW_BINARY" ]; then
     export STEPFLOW_DEV_BINARY="$STEPFLOW_BINARY"
-    if ! run_check "Integration tests" uv run python -m pytest tests/integration/ -v -m "not slow" -x; then
-        print_fix "Fix integration test failures"
-    fi
+    run_check "Integration tests" uv run python -m pytest tests/integration/ -v -m "not slow" -x
 else
     print_step "Integration tests"
     print_skip "stepflow-server binary build failed"

--- a/scripts/check-licenses.sh
+++ b/scripts/check-licenses.sh
@@ -43,9 +43,7 @@ require_tool "licensure" "cargo install licensure"
 # LICENSE HEADER CHECKS
 # =============================================================================
 
-if ! run_check "License headers" licensure -c -p; then
-    print_fix "licensure -p --in-place"
-fi
+run_check "License headers" --fix "licensure -p --in-place" licensure -c -p
 
 # =============================================================================
 # RESULTS SUMMARY

--- a/scripts/check-python.sh
+++ b/scripts/check-python.sh
@@ -52,33 +52,21 @@ run_check "Dependencies" uv sync --all-extras --group dev || true
 
 run_check "Codegen" uv run poe codegen-fix || true
 
-if ! run_check "Formatting" uv run poe fmt-check; then
-    print_fix "uv run poe fmt-fix"
-fi
+run_check "Formatting" --fix "uv run poe fmt-fix" uv run poe fmt-check
 
-if ! run_check "Linting" uv run poe lint-check; then
-    print_fix "uv run poe lint-fix"
-fi
+run_check "Linting" --fix "uv run poe lint-fix" uv run poe lint-check
 
-if ! run_check "Type checking" uv run poe type-check; then
-    print_fix "Fix type errors"
-fi
+run_check "Type checking" uv run poe type-check
 
-if ! run_check "Dep check" uv run poe dep-check; then
-    print_fix "Fix dependency issues"
-fi
+run_check "Dep check" uv run poe dep-check
 
-if ! run_check "Tests" uv run poe test; then
-    print_fix "Fix failing tests"
-fi
+run_check "Tests" uv run poe test
 
 # =============================================================================
 # ADDITIONAL CHECKS
 # =============================================================================
 
-if ! run_check "Codegen check" uv run poe codegen-check; then
-    print_fix "uv run poe codegen-fix"
-fi
+run_check "Codegen check" --fix "uv run poe codegen-fix" uv run poe codegen-check
 
 # =============================================================================
 # RESULTS SUMMARY

--- a/scripts/check-rust.sh
+++ b/scripts/check-rust.sh
@@ -40,41 +40,27 @@ cd "$PROJECT_ROOT/stepflow-rs"
 # RUST STYLE & QUALITY CHECKS
 # =============================================================================
 
-if ! run_check "Formatting" cargo fmt --check; then
-    print_fix "cargo fmt"
-fi
+run_check "Formatting" --fix "cargo fmt" cargo fmt --check
 
-if ! run_optional_check "Security audit" "cargo-deny" cargo deny check; then
-    print_fix "cargo deny check (review and fix security issues)"
-fi
+run_optional_check "Security audit" "cargo-deny" cargo deny check
 
-if ! run_optional_check "Unused deps" "cargo-machete" cargo machete --with-metadata; then
-    print_fix "cargo machete --fix --with-metadata"
-fi
+run_optional_check "Unused deps" "cargo-machete" --fix "cargo machete --fix --with-metadata" cargo machete --with-metadata
 
 # =============================================================================
 # RUST BUILD & TEST CHECKS
 # =============================================================================
 
-if ! run_check "Tests" cargo test; then
-    print_fix "Fix failing tests"
-fi
+run_check "Tests" cargo test
 
-if ! run_check "Clippy" cargo clippy -- -D warnings; then
-    print_fix "cargo clippy --fix"
-fi
+run_check "Clippy" --fix "cargo clippy --fix  # add --allow-dirty if needed" cargo clippy -- -D warnings
 
 # =============================================================================
 # ADDITIONAL CHECKS (not in CI but useful for local development)
 # =============================================================================
 
-if ! run_check "Compilation" cargo check --all-targets --all-features; then
-    print_fix "Fix compilation errors"
-fi
+run_check "Compilation" cargo check --all-targets --all-features
 
-if ! run_check "Documentation" cargo doc --all --no-deps; then
-    print_fix "Fix documentation errors"
-fi
+run_check "Documentation" cargo doc --all --no-deps
 
 # =============================================================================
 # RESULTS SUMMARY


### PR DESCRIPTION
When a check fails, the scripts can now suggest a command to fix the issue. The fix command is shown immediately after failure and in the summary alongside the check command.

Usage: run_check "Name" --fix "fix command" check command args...