### PR TITLE
refactor: Add blob_store module with contextvars

### DIFF
--- a/sdks/python/stepflow-py/src/stepflow_py/config/_generated_config.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/config/_generated_config.py
@@ -201,6 +201,18 @@ class SqliteStateStoreConfig(Struct, kw_only=True):
     autoMigrate: bool | None = None
 
 
+class FilesystemBlobStoreConfig(Struct, kw_only=True):
+    directory: (
+        Annotated[
+            str | None,
+            Meta(
+                description='Directory path for storing blobs. If not specified, a temporary directory is used.'
+            ),
+        ]
+        | None
+    ) = None
+
+
 class EtcdLeaseManagerConfig(Struct, kw_only=True):
     endpoints: Annotated[
         List[str],
@@ -277,8 +289,12 @@ class StoreConfig2(SqliteStateStoreConfig, kw_only=True):
     type: Literal['sqlite']
 
 
+class StoreConfig3(FilesystemBlobStoreConfig, kw_only=True):
+    type: Literal['filesystem']
+
+
 StoreConfig = Annotated[
-    StoreConfig1 | StoreConfig2,
+    StoreConfig1 | StoreConfig2 | StoreConfig3,
     Meta(
         description='Configuration for a single storage backend.\n\nEach variant documents which store types it supports:\n- **metadata**: Flow and run metadata storage\n- **blobs**: Content-addressable blob storage\n- **journal**: Execution journal for recovery'
     ),

--- a/sdks/python/stepflow-py/src/stepflow_py/worker/__init__.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/__init__.py
@@ -22,7 +22,7 @@ from stepflow_py.api.models import (
     Step,
 )
 
-from . import blob_store
+from . import blob_store, execution_context
 from .context import StepflowContext
 from .expressions import ValueExpr
 from .flow_builder import Component, FlowBuilder, StepHandle
@@ -34,8 +34,9 @@ __all__ = [
     "StepflowServer",
     "StepflowContext",
     "FlowBuilder",
-    # Blob store module (module-level API backed by contextvars)
+    # Module-level APIs backed by contextvars
     "blob_store",
+    "execution_context",
     # Value API for cleaner workflow definitions
     "Value",
     "Valuable",

--- a/sdks/python/stepflow-py/src/stepflow_py/worker/execution_context.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/execution_context.py
@@ -1,0 +1,79 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Execution context for the current component invocation.
+
+Provides a single ``ContextVar`` holding an immutable
+:class:`ExecutionContext` snapshot.  The framework sets this before each
+component call and resets it afterward so that any code—components,
+libraries, the blob store—can read the current run / step metadata
+without threading a context parameter.
+
+Usage::
+
+    from stepflow_py.worker import execution_context
+
+    ctx = execution_context.get()
+    print(ctx.run_id, ctx.step_id)
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ExecutionContext:
+    """Immutable snapshot of the current execution context."""
+
+    run_id: str | None = None
+    step_id: str | None = None
+    flow_id: str | None = None
+    attempt: int = 1
+
+
+_DEFAULT = ExecutionContext()
+
+_current: ContextVar[ExecutionContext | None] = ContextVar(
+    "stepflow_execution_context", default=None
+)
+
+
+def get() -> ExecutionContext:
+    """Return the current execution context."""
+    return _current.get() or _DEFAULT
+
+
+def set_context(
+    *,
+    run_id: str | None = None,
+    step_id: str | None = None,
+    flow_id: str | None = None,
+    attempt: int = 1,
+) -> Token[ExecutionContext | None]:
+    """Set the execution context for the current async scope.
+
+    Returns a token that can be passed to :func:`reset_context` to restore
+    the previous context.
+    """
+    ctx = ExecutionContext(
+        run_id=run_id, step_id=step_id, flow_id=flow_id, attempt=attempt
+    )
+    return _current.set(ctx)
+
+
+def reset_context(token: Token[ExecutionContext | None]) -> None:
+    """Restore the previous execution context."""
+    _current.reset(token)

--- a/sdks/python/stepflow-py/src/stepflow_py/worker/http_server.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/http_server.py
@@ -159,14 +159,15 @@ class _HttpServerContext:
     async def handle_request(self, request: MethodRequest):
         """Handle a JSON-RPC method request."""
         try:
-            # Set blob_store contextvars so any code (including components
-            # that don't receive StepflowContext) can use blob_store directly.
+            # Configure blob_store for this request scope so any code
+            # (including components without StepflowContext) can use it.
             from stepflow_py.worker import blob_store
 
             http_client = await self.get_http_client()
-            blob_store._http_client.set(http_client)
-            if self.server.blob_api_url:
-                blob_store._blob_api_url.set(self.server.blob_api_url)
+            blob_tokens = blob_store.configure(
+                blob_api_url=self.server.blob_api_url,
+                http_client=http_client,
+            )
 
             needs_context = self.server.requires_context(request)
 
@@ -186,9 +187,6 @@ class _HttpServerContext:
                     run_id = observability.run_id
                     flow_id = observability.flow_id
 
-                # Get shared HTTP client for blob operations
-                http_client = await self.get_http_client()
-
                 context = StepflowContext(
                     outgoing_queue=outgoing_queue,
                     message_decoder=self.message_decoder,
@@ -201,19 +199,25 @@ class _HttpServerContext:
                     observability=observability,
                     blob_api_url=self.server.blob_api_url,
                 )
+                # Streaming: tokens are reset inside the generator
+                # (a finally here would fire before the generator runs).
                 return StreamingResponse(
                     self.execute_with_streaming_context(
-                        request, context, outgoing_queue
+                        request, context, outgoing_queue, blob_tokens
                     ),
                     media_type="text/event-stream",
                     headers={"Stepflow-Instance-Id": self.instance_id},
                 )
             else:
-                result = await self.server.handle_message(request)
-                assert result is not None
-                return JSONResponse(
-                    content=msgspec.to_builtins(result), media_type="application/json"
-                )
+                try:
+                    result = await self.server.handle_message(request)
+                    assert result is not None
+                    return JSONResponse(
+                        content=msgspec.to_builtins(result),
+                        media_type="application/json",
+                    )
+                finally:
+                    blob_store.reset(blob_tokens)
         except StepflowError as e:
             return self.create_error_response(
                 request_id=request.id,
@@ -235,6 +239,7 @@ class _HttpServerContext:
         request: MethodRequest,
         context: StepflowContext,
         outgoing_queue: asyncio.Queue[MethodRequest | None],
+        blob_tokens: Any = None,
     ) -> AsyncGenerator[str]:
         """Execute request with streaming context via SSE."""
 
@@ -268,6 +273,11 @@ class _HttpServerContext:
                 error_code=-32603,
                 error_message=f"Request execution failed: {str(e)}",
             )
+        finally:
+            if blob_tokens is not None:
+                from stepflow_py.worker import blob_store
+
+                blob_store.reset(blob_tokens)
 
 
 def _create_app(ctx: _HttpServerContext) -> FastAPI:


### PR DESCRIPTION
## Summary

- **New `blob_store.py` module**: Module-level `put_blob()` and `get_blob()` functions backed by Python `contextvars`, allowing any code to use blob operations via `import blob_store` without requiring a `StepflowContext` parameter
- **`StepflowContext` delegates to `blob_store`**: `ctx.put_blob()` and `ctx.get_blob()` now thin-wrap the module-level functions, maintaining backward compatibility
- **Contextvars set by framework**: HTTP server sets `_http_client` and `_blob_api_url` per-request; server sets execution metadata (`current_run_id`, `current_step_id`, `current_flow_id`, `current_attempt`) per component execution

This is Phase 0 of the blob-based large I/O plan — a pure refactor with no behavior changes, preparing the SDK for framework-level blob handling in future phases.

## Test plan
- [x] All existing tests pass (`check-all.sh` green)
- [x] `StepflowContext.put_blob()` / `get_blob()` still work (delegates to blob_store)
- [x] Langflow integration tests pass (pre-compilation blob fetch still works)
- [x] No breaking changes to public API