### PR TITLE
feat: Make runs API async by default with optional wait

### DIFF
--- a/integrations/langflow/tests/integration/test_example_flows.py
+++ b/integrations/langflow/tests/integration/test_example_flows.py
@@ -255,7 +255,10 @@ class TestExecutor:
         timeout: float = 60.0,
     ) -> dict:
         """Execute workflow with optional overrides using StepflowClient."""
-        # Submit the run
+        from stepflow_py.api.models import ExecutionStatus
+        from stepflow_py.api.models.flow_result_failed import FlowResultFailed
+        from stepflow_py.api.models.flow_result_success import FlowResultSuccess
+
         response = await self.client.run(
             flow_id=flow_id,
             input_data=input_data,
@@ -264,29 +267,27 @@ class TestExecutor:
             timeout=timeout,
         )
 
-        result = response.model_dump(by_alias=True, exclude_unset=True)
-
-        # Check if execution succeeded
-        if result.get("status") != "completed":
-            status = result.get("status")
+        if response.status != ExecutionStatus.COMPLETED:
+            dump = response.model_dump(by_alias=True, exclude_unset=True)
             raise AssertionError(
-                f"Workflow execution failed with status {status}. "
-                f"Full response: {result}"
+                f"Workflow execution failed with status {response.status}. "
+                f"Full response: {dump}"
             )
 
-        # Get the flow result and check its structure
-        flow_result = result.get("result")
-        if not flow_result:
-            raise AssertionError("No result field in response")
+        if not response.results:
+            raise AssertionError("No results in response")
 
-        # Handle both direct result and wrapped result formats
-        if isinstance(flow_result, dict) and flow_result.get("outcome") == "success":
-            return flow_result
-        elif isinstance(flow_result, dict) and "outcome" in flow_result:
-            raise AssertionError(f"Workflow execution failed: {flow_result}")
+        flow_result = response.results[0].result
+        if flow_result is None:
+            raise AssertionError("No result in first item")
+
+        actual = flow_result.actual_instance
+        if isinstance(actual, FlowResultSuccess):
+            return {"outcome": "success", "result": actual.result}
+        elif isinstance(actual, FlowResultFailed):
+            raise AssertionError(f"Workflow execution failed: {actual.error}")
         else:
-            # For cases where flow_result is the actual result data
-            return {"outcome": "success", "result": flow_result}
+            raise AssertionError(f"Unexpected result type: {type(actual)}")
 
 
 @pytest.fixture(scope="module")

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -451,7 +451,7 @@
           "Run"
         ],
         "summary": "Create and execute a flow by hash",
-        "description": "Supports both single and batch execution:\n- Single input: Executes one run and returns the result directly\n- Multiple inputs: Executes batch and waits for all results",
+        "description": "Supports both single and batch execution:\n- Single input: Executes one run\n- Multiple inputs: Executes multiple runs (batch mode)\n\nBy default, returns immediately with 202 Accepted and status Running.\nSet `wait: true` in the request body to block until the run completes\nand return 200 OK with the result.",
         "operationId": "create_run",
         "requestBody": {
           "content": {
@@ -465,7 +465,17 @@
         },
         "responses": {
           "200": {
-            "description": "Flow run created successfully",
+            "description": "Flow run completed (wait=true)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateRunResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Flow run accepted for execution",
             "content": {
               "application/json": {
                 "schema": {
@@ -492,6 +502,7 @@
           "Run"
         ],
         "summary": "Get execution details by ID",
+        "description": "Returns the current run status and details. Use `wait=true` to long-poll\nuntil the run reaches a terminal state (completed, failed, or cancelled).",
         "operationId": "get_run",
         "parameters": [
           {
@@ -502,6 +513,32 @@
             "schema": {
               "type": "string",
               "format": "uuid"
+            }
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "description": "If true, wait for the run to reach a terminal state before responding.",
+            "required": false,
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "timeoutSecs",
+            "in": "query",
+            "description": "Maximum seconds to wait when wait=true (default 300). If the timeout elapses,\nreturns the current run status rather than an error.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "minimum": 0
             }
           }
         ],
@@ -852,45 +889,45 @@
             ],
             "description": "Maximum concurrency for batch execution (only used when input is an array)",
             "minimum": 0
+          },
+          "wait": {
+            "type": "boolean",
+            "description": "If true, block until the run completes and return the result (200 OK).\nIf false (default), return immediately with status Running (202 Accepted)."
+          },
+          "timeoutSecs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Maximum seconds to wait when wait=true (default 300). If the timeout elapses,\nreturns the current run status rather than an error.",
+            "minimum": 0
           }
         }
       },
       "CreateRunResponse": {
-        "type": "object",
-        "description": "Response for create run operations",
-        "required": [
-          "runId",
-          "itemCount",
-          "status"
-        ],
-        "properties": {
-          "runId": {
-            "type": "string",
-            "format": "uuid",
-            "description": "The run ID (for single runs) or batch ID (for batch runs)"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RunSummary",
+            "description": "Run summary fields (run_id, flow_id, status, items, timestamps, etc.)"
           },
-          "itemCount": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Number of items in this run (1 for single runs, > 1 for batch runs)",
-            "minimum": 0
-          },
-          "result": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/FlowResult",
-                "description": "The result of the flow execution (if completed, for single runs only)"
+          {
+            "type": "object",
+            "properties": {
+              "results": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/ItemResult"
+                },
+                "description": "Item results, only populated when `wait=true` and the run has completed.\nEach entry contains the item's index, status, and result."
               }
-            ]
-          },
-          "status": {
-            "$ref": "#/components/schemas/ExecutionStatus",
-            "description": "The run status"
+            }
           }
-        }
+        ],
+        "description": "Response for create run operations.\n\nShares the same base fields as `RunDetails` (GET /runs/{id}) via `RunSummary`,\nwith optional item results when `wait=true`."
       },
       "Diagnostic": {
         "type": "object",

--- a/schemas/protocol.json
+++ b/schemas/protocol.json
@@ -586,6 +586,15 @@
             }
           ]
         },
+        "timeoutSecs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64",
+          "description": "Maximum seconds to wait when wait=true (default 300). If the timeout elapses,\nreturns the current run status rather than an error.",
+          "minimum": 0
+        },
         "observability": {
           "oneOf": [
             {
@@ -629,6 +638,15 @@
         "resultOrder": {
           "$ref": "#/$defs/ResultOrder",
           "description": "Order of results (byIndex or byCompletion)."
+        },
+        "timeoutSecs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64",
+          "description": "Maximum seconds to wait when wait=true (default 300). If the timeout elapses,\nreturns the current run status rather than an error.",
+          "minimum": 0
         },
         "observability": {
           "oneOf": [

--- a/sdks/python/stepflow-py/src/stepflow_py/api/api/run_api.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/api/api/run_api.py
@@ -306,7 +306,7 @@ class RunApi:
     ) -> CreateRunResponse:
         """Create and execute a flow by hash
 
-        Supports both single and batch execution: - Single input: Executes one run and returns the result directly - Multiple inputs: Executes batch and waits for all results
+        Supports both single and batch execution: - Single input: Executes one run - Multiple inputs: Executes multiple runs (batch mode)  By default, returns immediately with 202 Accepted and status Running. Set `wait: true` in the request body to block until the run completes and return 200 OK with the result.
 
         :param create_run_request: (required)
         :type create_run_request: CreateRunRequest
@@ -342,6 +342,7 @@ class RunApi:
 
         _response_types_map: dict[str, str | None] = {
             "200": "CreateRunResponse",
+            "202": "CreateRunResponse",
             "400": None,
             "404": None,
             "500": None,
@@ -371,7 +372,7 @@ class RunApi:
     ) -> ApiResponse[CreateRunResponse]:
         """Create and execute a flow by hash
 
-        Supports both single and batch execution: - Single input: Executes one run and returns the result directly - Multiple inputs: Executes batch and waits for all results
+        Supports both single and batch execution: - Single input: Executes one run - Multiple inputs: Executes multiple runs (batch mode)  By default, returns immediately with 202 Accepted and status Running. Set `wait: true` in the request body to block until the run completes and return 200 OK with the result.
 
         :param create_run_request: (required)
         :type create_run_request: CreateRunRequest
@@ -407,6 +408,7 @@ class RunApi:
 
         _response_types_map: dict[str, str | None] = {
             "200": "CreateRunResponse",
+            "202": "CreateRunResponse",
             "400": None,
             "404": None,
             "500": None,
@@ -436,7 +438,7 @@ class RunApi:
     ) -> RESTResponseType:
         """Create and execute a flow by hash
 
-        Supports both single and batch execution: - Single input: Executes one run and returns the result directly - Multiple inputs: Executes batch and waits for all results
+        Supports both single and batch execution: - Single input: Executes one run - Multiple inputs: Executes multiple runs (batch mode)  By default, returns immediately with 202 Accepted and status Running. Set `wait: true` in the request body to block until the run completes and return 200 OK with the result.
 
         :param create_run_request: (required)
         :type create_run_request: CreateRunRequest
@@ -472,6 +474,7 @@ class RunApi:
 
         _response_types_map: dict[str, str | None] = {
             "200": "CreateRunResponse",
+            "202": "CreateRunResponse",
             "400": None,
             "404": None,
             "500": None,
@@ -786,6 +789,18 @@ class RunApi:
     async def get_run(
         self,
         run_id: Annotated[StrictStr, Field(description="Run ID (UUID)")],
+        wait: Annotated[
+            StrictBool | None,
+            Field(
+                description="If true, wait for the run to reach a terminal state before responding."
+            ),
+        ] = None,
+        timeout_secs: Annotated[
+            Annotated[int, Field(strict=True, ge=0)] | None,
+            Field(
+                description="Maximum seconds to wait when wait=true (default 300). If the timeout elapses, returns the current run status rather than an error."
+            ),
+        ] = None,
         _request_timeout: None
         | Annotated[StrictFloat, Field(gt=0)]
         | tuple[
@@ -798,9 +813,14 @@ class RunApi:
     ) -> RunDetails:
         """Get execution details by ID
 
+        Returns the current run status and details. Use `wait=true` to long-poll until the run reaches a terminal state (completed, failed, or cancelled).
 
         :param run_id: Run ID (UUID) (required)
         :type run_id: str
+        :param wait: If true, wait for the run to reach a terminal state before responding.
+        :type wait: bool
+        :param timeout_secs: Maximum seconds to wait when wait=true (default 300). If the timeout elapses, returns the current run status rather than an error.
+        :type timeout_secs: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -825,6 +845,8 @@ class RunApi:
 
         _param = self._get_run_serialize(
             run_id=run_id,
+            wait=wait,
+            timeout_secs=timeout_secs,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -850,6 +872,18 @@ class RunApi:
     async def get_run_with_http_info(
         self,
         run_id: Annotated[StrictStr, Field(description="Run ID (UUID)")],
+        wait: Annotated[
+            StrictBool | None,
+            Field(
+                description="If true, wait for the run to reach a terminal state before responding."
+            ),
+        ] = None,
+        timeout_secs: Annotated[
+            Annotated[int, Field(strict=True, ge=0)] | None,
+            Field(
+                description="Maximum seconds to wait when wait=true (default 300). If the timeout elapses, returns the current run status rather than an error."
+            ),
+        ] = None,
         _request_timeout: None
         | Annotated[StrictFloat, Field(gt=0)]
         | tuple[
@@ -862,9 +896,14 @@ class RunApi:
     ) -> ApiResponse[RunDetails]:
         """Get execution details by ID
 
+        Returns the current run status and details. Use `wait=true` to long-poll until the run reaches a terminal state (completed, failed, or cancelled).
 
         :param run_id: Run ID (UUID) (required)
         :type run_id: str
+        :param wait: If true, wait for the run to reach a terminal state before responding.
+        :type wait: bool
+        :param timeout_secs: Maximum seconds to wait when wait=true (default 300). If the timeout elapses, returns the current run status rather than an error.
+        :type timeout_secs: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -889,6 +928,8 @@ class RunApi:
 
         _param = self._get_run_serialize(
             run_id=run_id,
+            wait=wait,
+            timeout_secs=timeout_secs,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -914,6 +955,18 @@ class RunApi:
     async def get_run_without_preload_content(
         self,
         run_id: Annotated[StrictStr, Field(description="Run ID (UUID)")],
+        wait: Annotated[
+            StrictBool | None,
+            Field(
+                description="If true, wait for the run to reach a terminal state before responding."
+            ),
+        ] = None,
+        timeout_secs: Annotated[
+            Annotated[int, Field(strict=True, ge=0)] | None,
+            Field(
+                description="Maximum seconds to wait when wait=true (default 300). If the timeout elapses, returns the current run status rather than an error."
+            ),
+        ] = None,
         _request_timeout: None
         | Annotated[StrictFloat, Field(gt=0)]
         | tuple[
@@ -926,9 +979,14 @@ class RunApi:
     ) -> RESTResponseType:
         """Get execution details by ID
 
+        Returns the current run status and details. Use `wait=true` to long-poll until the run reaches a terminal state (completed, failed, or cancelled).
 
         :param run_id: Run ID (UUID) (required)
         :type run_id: str
+        :param wait: If true, wait for the run to reach a terminal state before responding.
+        :type wait: bool
+        :param timeout_secs: Maximum seconds to wait when wait=true (default 300). If the timeout elapses, returns the current run status rather than an error.
+        :type timeout_secs: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -953,6 +1011,8 @@ class RunApi:
 
         _param = self._get_run_serialize(
             run_id=run_id,
+            wait=wait,
+            timeout_secs=timeout_secs,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -973,6 +1033,8 @@ class RunApi:
     def _get_run_serialize(
         self,
         run_id,
+        wait,
+        timeout_secs,
         _request_auth,
         _content_type,
         _headers,
@@ -995,6 +1057,12 @@ class RunApi:
         if run_id is not None:
             _path_params["run_id"] = run_id
         # process the query parameters
+        if wait is not None:
+            _query_params.append(("wait", wait))
+
+        if timeout_secs is not None:
+            _query_params.append(("timeoutSecs", timeout_secs))
+
         # process the header parameters
         # process the form parameters
         # process the body parameter

--- a/sdks/python/stepflow-py/src/stepflow_py/api/models/create_run_request.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/api/models/create_run_request.py
@@ -23,7 +23,7 @@ import pprint
 import re  # noqa: F401
 from typing import Annotated, Any, ClassVar, Self
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 
 from stepflow_py.api.models.workflow_overrides import WorkflowOverrides
 
@@ -53,12 +53,23 @@ class CreateRunRequest(BaseModel):
         description="Maximum concurrency for batch execution (only used when input is an array)",
         alias="maxConcurrency",
     )
+    wait: StrictBool | None = Field(
+        default=None,
+        description="If true, block until the run completes and return the result (200 OK). If false (default), return immediately with status Running (202 Accepted).",
+    )
+    timeout_secs: Annotated[int, Field(strict=True, ge=0)] | None = Field(
+        default=None,
+        description="Maximum seconds to wait when wait=true (default 300). If the timeout elapses, returns the current run status rather than an error.",
+        alias="timeoutSecs",
+    )
     __properties: ClassVar[list[str]] = [
         "flowId",
         "input",
         "overrides",
         "variables",
         "maxConcurrency",
+        "wait",
+        "timeoutSecs",
     ]
 
     model_config = ConfigDict(
@@ -106,6 +117,11 @@ class CreateRunRequest(BaseModel):
         if self.max_concurrency is None and "max_concurrency" in self.model_fields_set:
             _dict["maxConcurrency"] = None
 
+        # set to None if timeout_secs (nullable) is None
+        # and model_fields_set contains the field
+        if self.timeout_secs is None and "timeout_secs" in self.model_fields_set:
+            _dict["timeoutSecs"] = None
+
         return _dict
 
     @classmethod
@@ -126,6 +142,8 @@ class CreateRunRequest(BaseModel):
                 else None,
                 "variables": obj.get("variables"),
                 "maxConcurrency": obj.get("maxConcurrency"),
+                "wait": obj.get("wait"),
+                "timeoutSecs": obj.get("timeoutSecs"),
             }
         )
         return _obj

--- a/sdks/python/stepflow-py/src/stepflow_py/api/models/create_run_response.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/api/models/create_run_response.py
@@ -21,33 +21,64 @@ from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from typing import Annotated, Any, ClassVar, Self
+from datetime import datetime
+from typing import Any, ClassVar, Self
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 
 from stepflow_py.api.models.execution_status import ExecutionStatus
-from stepflow_py.api.models.flow_result import FlowResult
+from stepflow_py.api.models.item_result import ItemResult
+from stepflow_py.api.models.item_statistics import ItemStatistics
 
 
 class CreateRunResponse(BaseModel):
     """
-    Response for create run operations
+    Response for create run operations.  Shares the same base fields as `RunDetails` (GET /runs/{id}) via `RunSummary`, with optional item results when `wait=true`.
     """  # noqa: E501
 
-    run_id: StrictStr = Field(
-        description="The run ID (for single runs) or batch ID (for batch runs)",
-        alias="runId",
+    run_id: StrictStr = Field(alias="runId")
+    flow_id: StrictStr = Field(
+        description="A SHA-256 hash of the blob content, represented as a hexadecimal string.",
+        alias="flowId",
     )
-    item_count: Annotated[int, Field(strict=True, ge=0)] = Field(
-        description="Number of items in this run (1 for single runs, > 1 for batch runs)",
-        alias="itemCount",
+    flow_name: StrictStr | None = Field(default=None, alias="flowName")
+    status: ExecutionStatus
+    items: ItemStatistics | None = Field(
+        default=None, description="Statistics about items in this run."
     )
-    result: FlowResult | None = Field(
+    created_at: datetime = Field(alias="createdAt")
+    completed_at: datetime | None = Field(default=None, alias="completedAt")
+    root_run_id: StrictStr = Field(
+        description="Root run ID for this execution tree.  For top-level runs, this equals `run_id`. For sub-flows, this is the original run that started the tree.",
+        alias="rootRunId",
+    )
+    parent_run_id: StrictStr | None = Field(
         default=None,
-        description="The result of the flow execution (if completed, for single runs only)",
+        description="Parent run ID if this is a sub-flow.  None for top-level runs, Some(parent_id) for sub-flows.",
+        alias="parentRunId",
     )
-    status: ExecutionStatus = Field(description="The run status")
-    __properties: ClassVar[list[str]] = ["runId", "itemCount", "result", "status"]
+    orchestrator_id: StrictStr | None = Field(
+        default=None,
+        description="The orchestrator currently managing this run.  None means the run is orphaned (no orchestrator owns it). Set when the run is created and updated during recovery.",
+        alias="orchestratorId",
+    )
+    results: list[ItemResult] | None = Field(
+        default=None,
+        description="Item results, only populated when `wait=true` and the run has completed. Each entry contains the item's index, status, and result.",
+    )
+    __properties: ClassVar[list[str]] = [
+        "runId",
+        "flowId",
+        "flowName",
+        "status",
+        "items",
+        "createdAt",
+        "completedAt",
+        "rootRunId",
+        "parentRunId",
+        "orchestratorId",
+        "results",
+    ]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -86,13 +117,20 @@ class CreateRunResponse(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
-        # override the default output from pydantic by calling `to_dict()` of result
-        if self.result:
-            _dict["result"] = self.result.to_dict()
-        # set to None if result (nullable) is None
+        # override the default output from pydantic by calling `to_dict()` of items
+        if self.items:
+            _dict["items"] = self.items.to_dict()
+        # override the default output from pydantic by calling `to_dict()` of each item in results (list)
+        _items = []
+        if self.results:
+            for _item_results in self.results:
+                if _item_results:
+                    _items.append(_item_results.to_dict())
+            _dict["results"] = _items
+        # set to None if results (nullable) is None
         # and model_fields_set contains the field
-        if self.result is None and "result" in self.model_fields_set:
-            _dict["result"] = None
+        if self.results is None and "results" in self.model_fields_set:
+            _dict["results"] = None
 
         return _dict
 
@@ -108,11 +146,20 @@ class CreateRunResponse(BaseModel):
         _obj = cls.model_validate(
             {
                 "runId": obj.get("runId"),
-                "itemCount": obj.get("itemCount"),
-                "result": FlowResult.from_dict(obj["result"])
-                if obj.get("result") is not None
-                else None,
+                "flowId": obj.get("flowId"),
+                "flowName": obj.get("flowName"),
                 "status": obj.get("status"),
+                "items": ItemStatistics.from_dict(obj["items"])
+                if obj.get("items") is not None
+                else None,
+                "createdAt": obj.get("createdAt"),
+                "completedAt": obj.get("completedAt"),
+                "rootRunId": obj.get("rootRunId"),
+                "parentRunId": obj.get("parentRunId"),
+                "orchestratorId": obj.get("orchestratorId"),
+                "results": [ItemResult.from_dict(_item) for _item in obj["results"]]
+                if obj.get("results") is not None
+                else None,
             }
         )
         return _obj

--- a/sdks/python/stepflow-py/src/stepflow_py/client.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/client.py
@@ -30,6 +30,7 @@ from stepflow_py.api.models.workflow_overrides import WorkflowOverrides
 
 if TYPE_CHECKING:
     from stepflow_py.api.models.create_run_response import CreateRunResponse
+    from stepflow_py.api.models.run_details import RunDetails
     from stepflow_py.api.models.store_flow_response import StoreFlowResponse
     from stepflow_py.config import StepflowConfig
 
@@ -223,8 +224,64 @@ class StepflowClient:
         overrides: dict[str, Any] | None = None,
         max_concurrency: int | None = None,
         timeout: float = 300.0,
+        wait_timeout: int | None = None,
     ) -> CreateRunResponse:
-        """Execute a flow and return the result.
+        """Execute a flow and wait for the result.
+
+        Submits the run with wait=true so the server blocks until completion
+        and returns the result directly.
+
+        Args:
+            flow_id: Flow ID from store_flow()
+            input_data: Single input dict or list for batch execution
+            variables: Runtime variables for $variable references
+            overrides: Step overrides (per step_id)
+            max_concurrency: Max parallel executions for batch mode
+            timeout: HTTP request timeout in seconds (client-side)
+            wait_timeout: Server-side wait timeout in seconds (default 300).
+                If the workflow takes longer, the server returns the current
+                status rather than an error. Set this higher than ``timeout``
+                is not useful since the HTTP connection will close first.
+
+        Returns:
+            CreateRunResponse with status and results
+        """
+        # Normalize input to list (API always expects array)
+        inputs = [input_data] if isinstance(input_data, dict) else input_data
+
+        # Build request kwargs, only including non-None values
+        # This ensures exclude_unset=True works correctly (unset != set to None)
+        request_kwargs: dict[str, Any] = {
+            "flowId": flow_id,
+            "input": inputs,
+            "wait": True,
+        }
+        if variables is not None:
+            request_kwargs["variables"] = variables
+        if overrides is not None:
+            request_kwargs["overrides"] = WorkflowOverrides.from_dict(overrides)
+        if max_concurrency is not None:
+            request_kwargs["maxConcurrency"] = max_concurrency
+        if wait_timeout is not None:
+            request_kwargs["timeoutSecs"] = wait_timeout
+
+        request = CreateRunRequest(**request_kwargs)
+        return await self._run_api.create_run(request, _request_timeout=timeout)
+
+    async def submit(
+        self,
+        flow_id: str,
+        input_data: dict[str, Any] | list[dict[str, Any]],
+        variables: dict[str, Any] | None = None,
+        overrides: dict[str, Any] | None = None,
+        max_concurrency: int | None = None,
+        timeout: float = 30.0,
+    ) -> CreateRunResponse:
+        """Submit a flow for execution without waiting for the result.
+
+        Returns immediately with status Running (202 Accepted).
+        Use ``get_run(run_id, wait=True)`` to long-poll for completion, or
+        ``get_run_items()`` to fetch results after completion.
 
         Args:
             flow_id: Flow ID from store_flow()
@@ -235,13 +292,11 @@ class StepflowClient:
             timeout: Request timeout in seconds
 
         Returns:
-            CreateRunResponse with status and result
+            CreateRunResponse with run_id and status (typically Running)
         """
         # Normalize input to list (API always expects array)
         inputs = [input_data] if isinstance(input_data, dict) else input_data
 
-        # Build request kwargs, only including non-None values
-        # This ensures exclude_unset=True works correctly (unset != set to None)
         request_kwargs: dict[str, Any] = {
             "flowId": flow_id,
             "input": inputs,
@@ -255,6 +310,32 @@ class StepflowClient:
 
         request = CreateRunRequest(**request_kwargs)
         return await self._run_api.create_run(request, _request_timeout=timeout)
+
+    async def get_run(
+        self,
+        run_id: str,
+        *,
+        wait: bool = False,
+        wait_timeout: int | None = None,
+        timeout: float = 30.0,
+    ) -> RunDetails:
+        """Get run details by ID.
+
+        Args:
+            run_id: Run ID (UUID string)
+            wait: If True, long-poll until the run reaches a terminal state
+            wait_timeout: Server-side wait timeout in seconds (default 300)
+            timeout: HTTP request timeout in seconds (client-side)
+
+        Returns:
+            RunDetails with status, item statistics, and item details
+        """
+        return await self._run_api.get_run(
+            run_id,
+            wait=wait if wait else None,
+            timeout_secs=wait_timeout,
+            _request_timeout=timeout,
+        )
 
     async def get_run_items(
         self, run_id: str, timeout: float = 30.0

--- a/sdks/python/stepflow-py/src/stepflow_py/worker/generated_protocol.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/generated_protocol.py
@@ -392,6 +392,16 @@ class GetRunProtocolParams(Struct, kw_only=True):
         ]
         | None
     ) = None
+    timeoutSecs: (
+        Annotated[
+            int | None,
+            Meta(
+                description='Maximum seconds to wait when wait=true (default 300). If the timeout elapses,\nreturns the current run status rather than an error.',
+                ge=0,
+            ),
+        ]
+        | None
+    ) = None
     observability: ObservabilityContext | None = None
 
 
@@ -429,6 +439,16 @@ class SubmitRunProtocolParams(Struct, kw_only=True):
         | None
     ) = None
     overrides: WorkflowOverrides | None = None
+    timeoutSecs: (
+        Annotated[
+            int | None,
+            Meta(
+                description='Maximum seconds to wait when wait=true (default 300). If the timeout elapses,\nreturns the current run status rather than an error.',
+                ge=0,
+            ),
+        ]
+        | None
+    ) = None
     observability: ObservabilityContext | None = None
 
 

--- a/sdks/python/stepflow-py/tests/integration/test_batch_execution.py
+++ b/sdks/python/stepflow-py/tests/integration/test_batch_execution.py
@@ -117,17 +117,27 @@ async def store_and_run_batch(
 
 
 def get_result_items(response: CreateRunResponse) -> list[dict]:
-    """Extract items from the result, handling the nested structure.
+    """Extract item results from the response.
 
-    For batch execution, the result contains an 'items' array with individual
-    flow results for each input item.
+    With the async API, results are returned directly on the response as a list
+    of ItemResult objects (when wait=true). Each is converted to a dict with
+    'outcome', 'result', etc.
     """
-    if response.result is None:
+    if response.results is None:
         return []
-    result_dict = response.result.model_dump(by_alias=True, exclude_unset=True)
-    if isinstance(result_dict, dict):
-        return result_dict.get("items", [])
-    return []
+    items = []
+    for item_result in response.results:
+        item_dict: dict = {}
+        if item_result.result is not None:
+            # FlowResult is a oneOf (Success/Failed) - dump to dict for uniform access
+            result_dict = item_result.result.model_dump(
+                by_alias=True, exclude_unset=True
+            )
+            item_dict.update(result_dict)
+        else:
+            item_dict["outcome"] = item_result.status.value
+        items.append(item_dict)
+    return items
 
 
 @pytest.mark.asyncio
@@ -141,7 +151,7 @@ async def test_batch_execution_basic(stepflow_client, simple_workflow, batch_inp
     assert response.status == ExecutionStatus.COMPLETED, (
         f"Batch execution failed with status {response.status}"
     )
-    assert response.item_count == 5, f"Expected 5 items, got {response.item_count}"
+    assert response.items.total == 5, f"Expected 5 items, got {response.items.total}"
 
     # For batch execution, result contains items array
     items = get_result_items(response)
@@ -166,7 +176,7 @@ async def test_batch_execution_with_max_concurrent(
     assert response.status == ExecutionStatus.COMPLETED, (
         f"Batch execution failed with status {response.status}"
     )
-    assert response.item_count == 5
+    assert response.items.total == 5
 
     items = get_result_items(response)
     assert len(items) == 5, f"Expected 5 results, got {len(items)}"
@@ -183,7 +193,7 @@ async def test_batch_execution_results(stepflow_client, simple_workflow, batch_i
     response = await store_and_run_batch(stepflow_client, simple_workflow, batch_inputs)
 
     assert response.status == ExecutionStatus.COMPLETED
-    assert response.item_count == 5
+    assert response.items.total == 5
 
     items = get_result_items(response)
     assert len(items) == 5, f"Expected 5 results, got {len(items)}"
@@ -225,7 +235,7 @@ async def test_batch_execution_with_failures(stepflow_client, simple_workflow):
     assert response.status in [ExecutionStatus.COMPLETED, ExecutionStatus.FAILED], (
         f"Unexpected status: {response.status}"
     )
-    assert response.item_count == 5
+    assert response.items.total == 5
 
     items = get_result_items(response)
     assert len(items) == 5, f"Expected 5 results, got {len(items)}"
@@ -262,7 +272,7 @@ async def test_batch_execution_empty_inputs(stepflow_client, simple_workflow):
     )
 
     assert response.status == ExecutionStatus.COMPLETED
-    assert response.item_count == 0
+    assert response.items.total == 0
 
     items = get_result_items(response)
     assert len(items) == 0, f"Expected 0 results, got {len(items)}"
@@ -287,7 +297,7 @@ async def test_single_input_execution(stepflow_client, simple_workflow):
     assert response.status == ExecutionStatus.COMPLETED, (
         f"Execution failed with status {response.status}"
     )
-    assert response.item_count == 1
+    assert response.items.total == 1
 
     items = get_result_items(response)
     assert len(items) == 1, f"Expected 1 result, got {len(items)}"

--- a/stepflow-rs/Cargo.lock
+++ b/stepflow-rs/Cargo.lock
@@ -4685,7 +4685,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "url",
- "uuid",
  "walkdir",
  "which 7.0.3",
 ]

--- a/stepflow-rs/crates/stepflow-cli/Cargo.toml
+++ b/stepflow-rs/crates/stepflow-cli/Cargo.toml
@@ -38,7 +38,6 @@ tokio.workspace = true
 log.workspace = true
 stepflow-observability.workspace = true
 url.workspace = true
-uuid.workspace = true
 strum.workspace = true
 which.workspace = true
 

--- a/stepflow-rs/crates/stepflow-cli/src/submit.rs
+++ b/stepflow-rs/crates/stepflow-cli/src/submit.rs
@@ -142,6 +142,8 @@ pub async fn submit(
         overrides: overrides.clone(),
         variables: std::collections::HashMap::new(), // TODO: Add variables support to CLI submit
         max_concurrency,
+        wait: true,
+        timeout_secs: None,
     };
 
     let execute_url = service_url
@@ -173,74 +175,15 @@ pub async fn submit(
         MainError::Configuration
     })?;
 
-    // For single-item runs, the result is returned directly
-    // For multi-item runs, we need to fetch results from the items endpoint
-    if execute_result.item_count == 1 {
-        // Single item - result is in the response
-        match execute_result.result {
-            Some(result) => Ok(vec![result]),
-            None => {
-                log::error!("No result in response");
-                Err(MainError::Configuration.into())
-            }
-        }
-    } else {
-        // Multi-item - fetch results from items endpoint
-        fetch_batch_results(&client, &service_url, execute_result.run_id).await
-    }
-}
-
-/// Fetch results for a multi-item run from the items endpoint.
-async fn fetch_batch_results(
-    client: &reqwest::Client,
-    service_url: &Url,
-    run_id: uuid::Uuid,
-) -> Result<Vec<FlowResult>> {
-    // Use the items endpoint to get all results
-    let items_url = service_url
-        .join(&format!("/api/v1/runs/{}/items", run_id))
-        .map_err(|_| MainError::Configuration)?;
-
-    let response = client.get(items_url).send().await.map_err(|e| {
-        log::error!("Failed to get run items: {}", e);
-        MainError::Configuration
-    })?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let error_text = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "Unknown error".to_string());
-        display_server_error(status, &error_text, "getting run items");
+    // With wait=true, results are always populated in the response
+    let items = execute_result.results.unwrap_or_default();
+    if items.is_empty() {
+        log::error!("No results in response");
         return Err(MainError::Configuration.into());
     }
 
-    #[derive(serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct ItemsResponse {
-        items: Vec<ItemInfo>,
-    }
-
-    #[derive(serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct ItemInfo {
-        result: Option<FlowResult>,
-    }
-
-    let items_result: ItemsResponse = response.json().await.map_err(|e| {
-        log::error!("Failed to parse items response: {}", e);
-        MainError::Configuration
-    })?;
-
-    // Collect results (filtering out None values)
-    let results: Vec<FlowResult> = items_result
-        .items
-        .into_iter()
-        .filter_map(|r| r.result)
-        .collect();
-
-    Ok(results)
+    // Extract FlowResult from each ItemResult
+    Ok(items.into_iter().filter_map(|item| item.result).collect())
 }
 
 #[cfg(test)]

--- a/stepflow-rs/crates/stepflow-core/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-core/src/lib.rs
@@ -30,5 +30,5 @@ pub use blob::{BlobData, BlobId, BlobMetadata, BlobType};
 pub use blob_ref::BlobRef;
 pub use environment::StepflowEnvironment;
 pub use error_stack::{ErrorStack, ErrorStackEntry};
-pub use run_params::{GetRunParams, ResultOrder, SubmitRunParams};
+pub use run_params::{DEFAULT_WAIT_TIMEOUT_SECS, GetRunParams, ResultOrder, SubmitRunParams};
 pub use values::ValueExpr;

--- a/stepflow-rs/crates/stepflow-core/src/run_params.rs
+++ b/stepflow-rs/crates/stepflow-core/src/run_params.rs
@@ -14,6 +14,12 @@ use crate::workflow::{ValueRef, WorkflowOverrides};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Default timeout in seconds for wait operations (5 minutes).
+///
+/// Used by the HTTP API and JSON-RPC protocol when `wait=true` and no
+/// explicit `timeout_secs` is provided.
+pub const DEFAULT_WAIT_TIMEOUT_SECS: u64 = 300;
+
 /// Optional parameters for submitting a run.
 ///
 /// Pass to `submit_run()` along with the required flow, flow_id, and inputs.

--- a/stepflow-rs/crates/stepflow-protocol/src/handlers/flow_handlers.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/handlers/flow_handlers.rs
@@ -12,7 +12,7 @@
 
 use futures::future::{BoxFuture, FutureExt as _};
 use std::sync::Arc;
-use stepflow_core::GetRunParams;
+use stepflow_core::{DEFAULT_WAIT_TIMEOUT_SECS, GetRunParams};
 use stepflow_plugin::RunContext;
 use stepflow_state::BlobStoreExt as _;
 use tokio::sync::mpsc;
@@ -74,12 +74,19 @@ impl MethodHandler for SubmitRunHandler {
 
                 // If wait=true, wait for completion and fetch results
                 let run_status = if request.wait {
-                    stepflow_execution::wait_for_completion(&env, run_status.run_id)
-                        .await
-                        .map_err(|e| {
-                            log::error!("Failed to wait for run completion: {e}");
-                            Error::internal("Failed to wait for run completion")
-                        })?;
+                    let timeout_duration = std::time::Duration::from_secs(
+                        request.timeout_secs.unwrap_or(DEFAULT_WAIT_TIMEOUT_SECS),
+                    );
+                    // Ignore timeout — return current status either way
+                    if let Ok(Err(e)) = tokio::time::timeout(
+                        timeout_duration,
+                        stepflow_execution::wait_for_completion(&env, run_status.run_id),
+                    )
+                    .await
+                    {
+                        log::error!("Failed while waiting for run completion: {e}");
+                        return Err(Error::internal("Failed to wait for run completion"));
+                    }
 
                     // Fetch final status with results
 
@@ -124,14 +131,21 @@ impl MethodHandler for GetRunHandler {
                     Error::invalid_value("run_id", "valid UUID")
                 })?;
 
-                // If wait=true, wait for completion first
+                // If wait=true, wait for completion first (with timeout)
                 if request.wait {
-                    stepflow_execution::wait_for_completion(&env, run_id)
-                        .await
-                        .map_err(|e| {
-                            log::error!("Failed to wait for run completion: {e}");
-                            Error::internal("Failed to wait for run completion")
-                        })?;
+                    let timeout_duration = std::time::Duration::from_secs(
+                        request.timeout_secs.unwrap_or(DEFAULT_WAIT_TIMEOUT_SECS),
+                    );
+                    // Ignore timeout — return current status either way
+                    if let Ok(Err(e)) = tokio::time::timeout(
+                        timeout_duration,
+                        stepflow_execution::wait_for_completion(&env, run_id),
+                    )
+                    .await
+                    {
+                        log::error!("Failed while waiting for run completion: {e}");
+                        return Err(Error::internal("Failed to wait for run completion"));
+                    }
                 }
 
                 let params = GetRunParams {

--- a/stepflow-rs/crates/stepflow-protocol/src/protocol/flows.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/protocol/flows.rs
@@ -37,6 +37,10 @@ pub struct SubmitRunProtocolParams {
     /// Optional workflow overrides to apply.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub overrides: Option<WorkflowOverrides>,
+    /// Maximum seconds to wait when wait=true (default 300). If the timeout elapses,
+    /// returns the current run status rather than an error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
     /// Observability context for tracing.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub observability: Option<ObservabilityContext>,
@@ -62,6 +66,10 @@ pub struct GetRunProtocolParams {
     /// Order of results (byIndex or byCompletion).
     #[serde(default)]
     pub result_order: ResultOrder,
+    /// Maximum seconds to wait when wait=true (default 300). If the timeout elapses,
+    /// returns the current run status rather than an error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
     /// Observability context for tracing.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub observability: Option<ObservabilityContext>,

--- a/stepflow-rs/crates/stepflow-server/src/api/runs.rs
+++ b/stepflow-rs/crates/stepflow-server/src/api/runs.rs
@@ -12,6 +12,7 @@
 
 use axum::{
     extract::{Path, Query, State},
+    http::StatusCode,
     response::Json,
 };
 use indexmap::IndexMap;
@@ -20,10 +21,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use stepflow_core::status::{ExecutionStatus, StepStatus};
 use stepflow_core::{
-    BlobId, FlowResult,
+    BlobId, DEFAULT_WAIT_TIMEOUT_SECS, FlowResult,
     workflow::{Flow, ValueRef, WorkflowOverrides},
 };
-use stepflow_dtos::{ItemResult, ResultOrder, RunDetails, RunFilters, RunSummary};
+use stepflow_dtos::{ItemResult, ResultOrder, RunDetails, RunFilters, RunStatus, RunSummary};
 use stepflow_plugin::StepflowEnvironment;
 use stepflow_state::{BlobStoreExt as _, MetadataStoreExt as _};
 use utoipa::ToSchema;
@@ -55,21 +56,50 @@ pub struct CreateRunRequest {
     /// Maximum concurrency for batch execution (only used when input is an array)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_concurrency: Option<usize>,
+    /// If true, block until the run completes and return the result (200 OK).
+    /// If false (default), return immediately with status Running (202 Accepted).
+    #[serde(default)]
+    pub wait: bool,
+    /// Maximum seconds to wait when wait=true (default 300). If the timeout elapses,
+    /// returns the current run status rather than an error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
 }
 
-/// Response for create run operations
+/// Response for create run operations.
+///
+/// Shares the same base fields as `RunDetails` (GET /runs/{id}) via `RunSummary`,
+/// with optional item results when `wait=true`.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateRunResponse {
-    /// The run ID (for single runs) or batch ID (for batch runs)
-    pub run_id: Uuid,
-    /// Number of items in this run (1 for single runs, > 1 for batch runs)
-    pub item_count: u32,
-    /// The result of the flow execution (if completed, for single runs only)
+    /// Run summary fields (run_id, flow_id, status, items, timestamps, etc.)
+    #[serde(flatten)]
+    pub summary: RunSummary,
+    /// Item results, only populated when `wait=true` and the run has completed.
+    /// Each entry contains the item's index, status, and result.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub result: Option<FlowResult>,
-    /// The run status
-    pub status: ExecutionStatus,
+    pub results: Option<Vec<ItemResult>>,
+}
+
+impl From<RunStatus> for CreateRunResponse {
+    fn from(status: RunStatus) -> Self {
+        Self {
+            summary: RunSummary {
+                run_id: status.run_id,
+                flow_id: status.flow_id,
+                flow_name: status.flow_name,
+                status: status.status,
+                items: status.items,
+                created_at: status.created_at,
+                completed_at: status.completed_at,
+                root_run_id: status.root_run_id,
+                parent_run_id: status.parent_run_id,
+                orchestrator_id: None,
+            },
+            results: status.results,
+        }
+    }
 }
 
 /// Response for listing runs
@@ -168,14 +198,19 @@ pub struct RunFlowResponse {
 /// Create and execute a flow by hash
 ///
 /// Supports both single and batch execution:
-/// - Single input: Executes one run and returns the result directly
-/// - Multiple inputs: Executes batch and waits for all results
+/// - Single input: Executes one run
+/// - Multiple inputs: Executes multiple runs (batch mode)
+///
+/// By default, returns immediately with 202 Accepted and status Running.
+/// Set `wait: true` in the request body to block until the run completes
+/// and return 200 OK with the result.
 #[utoipa::path(
     post,
     path = "/runs",
     request_body = CreateRunRequest,
     responses(
-        (status = 200, description = "Flow run created successfully", body = CreateRunResponse),
+        (status = 200, description = "Flow run completed (wait=true)", body = CreateRunResponse),
+        (status = 202, description = "Flow run accepted for execution", body = CreateRunResponse),
         (status = 400, description = "Invalid request"),
         (status = 404, description = "Flow not found"),
         (status = 500, description = "Internal server error")
@@ -185,7 +220,7 @@ pub struct RunFlowResponse {
 pub async fn create_run(
     State(executor): State<Arc<StepflowEnvironment>>,
     Json(req): Json<CreateRunRequest>,
-) -> Result<Json<CreateRunResponse>, ErrorResponse> {
+) -> Result<(StatusCode, Json<CreateRunResponse>), ErrorResponse> {
     let blob_store = executor.blob_store();
 
     // Get the flow from the blob store
@@ -194,7 +229,8 @@ pub async fn create_run(
         .await?
         .ok_or_else(|| error_stack::report!(ServerError::WorkflowNotFound(req.flow_id.clone())))?;
 
-    let item_count = req.input.len() as u32;
+    let wait = req.wait;
+    let timeout_secs = req.timeout_secs;
 
     // Execute the run
     let variables = if req.variables.is_empty() {
@@ -211,43 +247,62 @@ pub async fn create_run(
     let run_status =
         stepflow_execution::submit_run(&executor, flow, req.flow_id, req.input, params).await?;
 
-    // Wait for completion and get final results
-    stepflow_execution::wait_for_completion(&executor, run_status.run_id).await?;
-    let run_status = stepflow_execution::get_run(
-        &executor,
-        run_status.run_id,
-        stepflow_core::GetRunParams {
-            include_results: true,
-            ..Default::default()
-        },
-    )
-    .await?;
+    if wait {
+        // Wait for completion with timeout, then return results
+        let timeout_duration =
+            std::time::Duration::from_secs(timeout_secs.unwrap_or(DEFAULT_WAIT_TIMEOUT_SECS));
+        if let Ok(Err(e)) = tokio::time::timeout(
+            timeout_duration,
+            stepflow_execution::wait_for_completion(&executor, run_status.run_id),
+        )
+        .await
+        {
+            return Err(e.into());
+        }
 
-    // For single-item runs, extract the result directly into the response
-    let result = if item_count == 1 {
-        run_status
-            .results
-            .as_ref()
-            .and_then(|r| r.first())
-            .and_then(|item| item.result.clone())
+        let run_status = stepflow_execution::get_run(
+            &executor,
+            run_status.run_id,
+            stepflow_core::GetRunParams {
+                include_results: true,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        Ok((StatusCode::OK, Json(CreateRunResponse::from(run_status))))
     } else {
-        None // Batch results should be fetched via items endpoint
-    };
+        // Return immediately with 202 Accepted
+        Ok((
+            StatusCode::ACCEPTED,
+            Json(CreateRunResponse::from(run_status)),
+        ))
+    }
+}
 
-    Ok(Json(CreateRunResponse {
-        run_id: run_status.run_id,
-        item_count,
-        result,
-        status: run_status.status,
-    }))
+/// Query parameters for getting a run by ID
+#[derive(Debug, Clone, Default, Deserialize, ToSchema, utoipa::IntoParams)]
+#[serde(rename_all = "camelCase")]
+pub struct GetRunQuery {
+    /// If true, wait for the run to reach a terminal state before responding.
+    #[serde(default)]
+    pub wait: Option<bool>,
+    /// Maximum seconds to wait when wait=true (default 300). If the timeout elapses,
+    /// returns the current run status rather than an error.
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
 }
 
 /// Get execution details by ID
+///
+/// Returns the current run status and details. Use `wait=true` to long-poll
+/// until the run reaches a terminal state (completed, failed, or cancelled).
 #[utoipa::path(
     get,
     path = "/runs/{run_id}",
     params(
-        ("run_id" = Uuid, Path, description = "Run ID (UUID)")
+        ("run_id" = Uuid, Path, description = "Run ID (UUID)"),
+        GetRunQuery
     ),
     responses(
         (status = 200, description = "Run details retrieved successfully", body = RunDetails),
@@ -260,7 +315,23 @@ pub async fn create_run(
 pub async fn get_run(
     State(executor): State<Arc<StepflowEnvironment>>,
     Path(run_id): Path<Uuid>,
+    Query(query): Query<GetRunQuery>,
 ) -> Result<Json<RunDetails>, ErrorResponse> {
+    // If wait=true, block until the run reaches a terminal state (with timeout)
+    if query.wait.unwrap_or(false) {
+        let timeout_duration =
+            std::time::Duration::from_secs(query.timeout_secs.unwrap_or(DEFAULT_WAIT_TIMEOUT_SECS));
+        // Ignore timeout — return current status either way, but propagate actual errors
+        if let Ok(Err(e)) = tokio::time::timeout(
+            timeout_duration,
+            stepflow_execution::wait_for_completion(&executor, run_id),
+        )
+        .await
+        {
+            return Err(e.into());
+        }
+    }
+
     let metadata_store = executor.metadata_store();
 
     // Get execution details

--- a/stepflow-rs/crates/stepflow-server/tests/integration_tests.rs
+++ b/stepflow-rs/crates/stepflow-server/tests/integration_tests.rs
@@ -252,7 +252,7 @@ async fn test_create_run_without_overrides() {
     let store_result: serde_json::Value = serde_json::from_slice(&store_body).unwrap();
     let flow_id = store_result["flowId"].as_str().unwrap();
 
-    // Execute run without overrides
+    // Execute run without overrides (wait=true for synchronous result)
     let create_run_request = Request::builder()
         .uri("/api/v1/runs")
         .method("POST")
@@ -263,7 +263,7 @@ async fn test_create_run_without_overrides() {
                 "input": [{
                     "test_input": "Hello from run execution"
                 }],
-                "debug": false
+                "wait": true
             }))
             .unwrap(),
         ))
@@ -284,7 +284,107 @@ async fn test_create_run_without_overrides() {
 
     assert!(execute_response["runId"].is_string());
     assert_eq!(execute_response["status"], "completed");
-    assert!(execute_response["result"].is_object());
+    // Response now includes RunSummary fields
+    assert!(execute_response["flowId"].is_string());
+    assert!(execute_response["items"].is_object());
+    assert!(execute_response["createdAt"].is_string());
+    // Results are populated with wait=true
+    assert!(execute_response["results"].is_array());
+    assert_eq!(execute_response["results"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_create_run_async_default() {
+    init_test_logging();
+
+    let (mut app, _executor) = create_basic_test_server().await;
+    let workflow = create_test_workflow();
+
+    // Store the flow
+    let store_request = Request::builder()
+        .uri("/api/v1/flows")
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_string(&json!({
+                "flow": workflow
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+
+    let store_response = ServiceExt::<Request<Body>>::ready(&mut app)
+        .await
+        .unwrap()
+        .call(store_request)
+        .await
+        .unwrap();
+    let store_body = to_bytes(store_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let store_result: serde_json::Value = serde_json::from_slice(&store_body).unwrap();
+    let flow_id = store_result["flowId"].as_str().unwrap();
+
+    // Execute run without wait (default async behavior)
+    let create_run_request = Request::builder()
+        .uri("/api/v1/runs")
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_string(&json!({
+                "flowId": flow_id,
+                "input": [{
+                    "test_input": "Hello from async run"
+                }]
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+
+    let response = ServiceExt::<Request<Body>>::ready(&mut app)
+        .await
+        .unwrap()
+        .call(create_run_request)
+        .await
+        .unwrap();
+
+    // Should return 202 Accepted (async)
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let execute_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert!(execute_response["runId"].is_string());
+    // Results should be null (not populated in async mode)
+    assert!(execute_response["results"].is_null());
+    // RunSummary fields should be present
+    assert!(execute_response["flowId"].is_string());
+    assert_eq!(execute_response["status"], "running");
+    let run_id = execute_response["runId"].as_str().unwrap();
+
+    // Now use GET /runs/{run_id}?wait=true to wait for completion
+    let wait_request = Request::builder()
+        .uri(format!("/api/v1/runs/{run_id}?wait=true"))
+        .body(Body::empty())
+        .unwrap();
+
+    let response = ServiceExt::<Request<Body>>::ready(&mut app)
+        .await
+        .unwrap()
+        .call(wait_request)
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let details_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(details_response["runId"], run_id);
+    assert_eq!(details_response["status"], "completed");
 }
 
 #[tokio::test]
@@ -321,7 +421,7 @@ async fn test_create_run_with_overrides() {
     let store_result: serde_json::Value = serde_json::from_slice(&store_body).unwrap();
     let flow_id = store_result["flowId"].as_str().unwrap();
 
-    // Execute run with overrides
+    // Execute run with overrides (wait=true for synchronous result)
     let create_run_request = Request::builder()
         .uri("/api/v1/runs")
         .method("POST")
@@ -350,7 +450,7 @@ async fn test_create_run_with_overrides() {
                         }
                     }
                 },
-                "debug": false
+                "wait": true
             }))
             .unwrap(),
         ))
@@ -371,7 +471,7 @@ async fn test_create_run_with_overrides() {
 
     assert!(execute_response["runId"].is_string());
     assert_eq!(execute_response["status"], "completed");
-    assert!(execute_response["result"].is_object());
+    assert!(execute_response["results"].is_array());
 
     // The overrides should have been applied during execution
     // We can't easily verify the exact changes without inspecting internal state,
@@ -413,6 +513,7 @@ async fn test_create_run_with_invalid_overrides() {
     let flow_id = store_result["flowId"].as_str().unwrap();
 
     // Execute run with overrides that reference a non-existent step
+    // (validation errors are returned synchronously regardless of wait)
     let create_run_request = Request::builder()
         .uri("/api/v1/runs")
         .method("POST")
@@ -431,8 +532,7 @@ async fn test_create_run_with_invalid_overrides() {
                             }
                         }
                     }
-                },
-                "debug": false
+                }
             }))
             .unwrap(),
         ))
@@ -491,7 +591,7 @@ async fn test_create_run_empty_overrides() {
     let store_result: serde_json::Value = serde_json::from_slice(&store_body).unwrap();
     let flow_id = store_result["flowId"].as_str().unwrap();
 
-    // Execute run with empty overrides object
+    // Execute run with empty overrides object (wait=true for synchronous result)
     let create_run_request = Request::builder()
         .uri("/api/v1/runs")
         .method("POST")
@@ -503,7 +603,7 @@ async fn test_create_run_empty_overrides() {
                     "test_input": "Hello"
                 }],
                 "overrides": {},
-                "debug": false
+                "wait": true
             }))
             .unwrap(),
         ))
@@ -524,7 +624,7 @@ async fn test_create_run_empty_overrides() {
 
     assert!(execute_response["runId"].is_string());
     assert_eq!(execute_response["status"], "completed");
-    assert!(execute_response["result"].is_object());
+    assert!(execute_response["results"].is_array());
 }
 
 #[tokio::test]
@@ -630,7 +730,7 @@ async fn test_hash_based_execution() {
     let store_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let flow_id = store_response["flowId"].as_str().unwrap();
 
-    // Execute flow using hash (non-debug mode)
+    // Execute flow using hash (wait=true for synchronous result)
     let execute_request = Request::builder()
         .uri("/api/v1/runs")
         .method("POST")
@@ -639,7 +739,7 @@ async fn test_hash_based_execution() {
             serde_json::to_string(&json!({
                 "flowId": flow_id,
                 "input": [{"message": "test input"}],
-                "debug": false
+                "wait": true
             }))
             .unwrap(),
         ))
@@ -656,8 +756,10 @@ async fn test_hash_based_execution() {
     assert!(execute_response["runId"].is_string());
     assert_eq!(execute_response["status"], "completed");
     // Workflow completes successfully with null output as defined in workflow
-    assert_eq!(execute_response["result"]["outcome"], "success");
-    assert!(execute_response["result"]["result"].is_null());
+    let results = execute_response["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["result"]["outcome"], "success");
+    assert!(results[0]["result"]["result"].is_null());
 }
 
 #[tokio::test]
@@ -695,7 +797,7 @@ async fn test_run_details() {
             serde_json::to_string(&json!({
                 "flowId": flow_id,
                 "input": [{"message": "test input"}],
-                "debug": false
+                "wait": true
             }))
             .unwrap(),
         ))
@@ -941,7 +1043,7 @@ async fn test_status_updates_during_regular_execution() {
     let store_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let flow_id = store_response["flowId"].as_str().unwrap();
 
-    // Execute workflow in regular mode
+    // Execute workflow (wait=true for synchronous result)
     let execute_request = Request::builder()
         .uri("/api/v1/runs")
         .method("POST")
@@ -950,7 +1052,7 @@ async fn test_status_updates_during_regular_execution() {
             serde_json::to_string(&json!({
                 "flowId": flow_id,
                 "input": [{}],
-                "debug": false
+                "wait": true
             }))
             .unwrap(),
         ))
@@ -965,7 +1067,8 @@ async fn test_status_updates_during_regular_execution() {
 
     // Verify execution completed successfully
     assert_eq!(execute_response["status"], "completed");
-    assert_eq!(execute_response["result"]["outcome"], "success");
+    let results = execute_response["results"].as_array().unwrap();
+    assert_eq!(results[0]["result"]["outcome"], "success");
 
     // Check step statuses after completion
     let steps_request = Request::builder()
@@ -1045,7 +1148,7 @@ async fn test_status_transitions_with_error_handling() {
     let store_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let flow_id = store_response["flowId"].as_str().unwrap();
 
-    // Execute workflow (should fail)
+    // Execute workflow (should fail; wait=true for synchronous result)
     let execute_request = Request::builder()
         .uri("/api/v1/runs")
         .method("POST")
@@ -1054,7 +1157,7 @@ async fn test_status_transitions_with_error_handling() {
             serde_json::to_string(&json!({
                 "flowId": flow_id,
                 "input": [{}],
-                "debug": false
+                "wait": true
             }))
             .unwrap(),
         ))
@@ -1069,7 +1172,8 @@ async fn test_status_transitions_with_error_handling() {
 
     // Verify execution failed
     assert_eq!(execute_response["status"], "failed");
-    assert_eq!(execute_response["result"]["outcome"], "failed");
+    let results = execute_response["results"].as_array().unwrap();
+    assert_eq!(results[0]["result"]["outcome"], "failed");
 
     // Check step status shows failure
     let steps_request = Request::builder()


### PR DESCRIPTION
## Summary

- **POST /runs** now returns **202 Accepted** by default (async). Set `wait: true` in the request body to block until completion and get **200 OK** with results.
- **GET /runs/{run_id}** gains `wait` and `timeoutSecs` query parameters for long-polling until a terminal state.
- **JSON-RPC protocol** adds `timeout_secs` to `runs/submit` and `runs/get` for consistent timeout behavior.
- CLI and Python SDK updated to use `wait: true` for backward-compatible blocking behavior.
- New `StepflowClient.submit()` method for async fire-and-forget submissions.

## Test plan

- [x] All existing Rust integration tests updated with `wait: true` and pass
- [x] New `test_create_run_async_default` test verifies 202 path and GET wait=true
- [x] `./scripts/check-all.sh` passes (Rust, Python, Docs, Licenses, Langflow, Integration)
- [x] OpenAPI and protocol schemas regenerated and verified
- [x] Python API client regenerated from updated schemas