### PR TITLE
fix: Run codegen-check before codegen-fix in Python CI

### DIFF
--- a/scripts/check-python.sh
+++ b/scripts/check-python.sh
@@ -53,6 +53,11 @@ run_check "Dependencies" uv sync --all-extras --group dev || true
 # PYTHON SDK CHECKS
 # =============================================================================
 
+# Verify generated types match schemas BEFORE codegen-fix regenerates them.
+# This catches PRs that change schemas without updating generated Python types.
+run_check "Codegen check" --fix "uv run poe codegen-fix" uv run poe codegen-check || true
+
+# Regenerate types so subsequent checks (format, lint, type, test) use latest code.
 run_check "Codegen" uv run poe codegen-fix || true
 
 run_check "Formatting" --fix "uv run poe fmt-fix" uv run poe fmt-check || true
@@ -64,12 +69,6 @@ run_check "Type checking" uv run poe type-check || true
 run_check "Dep check" uv run poe dep-check || true
 
 run_check "Tests" uv run poe test || true
-
-# =============================================================================
-# ADDITIONAL CHECKS
-# =============================================================================
-
-run_check "Codegen check" --fix "uv run poe codegen-fix" uv run poe codegen-check || true
 
 # =============================================================================
 # RESULTS SUMMARY


### PR DESCRIPTION
## Summary
- Moved `codegen-check` to run **before** `codegen-fix` in `check-python.sh`
- Previously, `codegen-fix` regenerated types first, so `codegen-check` always passed by comparing freshly-generated files against a fresh generation
- This allowed PRs that changed schemas without updating Python generated types to silently pass CI, leading to stale generated code on main

Note: the `schemas/**` path trigger for Python CI was already in place in `ci.yml` — the issue was purely the check ordering in the script.

## Test plan
- [x] Verify Python CI still passes on this branch (codegen-check should pass since generated types are up to date)
- [x] To validate the fix catches drift: locally modify a schema file without regenerating Python types, run `./scripts/check-python.sh`, and confirm the `Codegen check` step fails

Closes #609