### PR TITLE
feat: Trait-based selective migration for store initialization

### DIFF
--- a/stepflow-rs/crates/stepflow-config/src/storage_config.rs
+++ b/stepflow-rs/crates/stepflow-config/src/storage_config.rs
@@ -207,41 +207,57 @@ impl StorageConfig {
     ///
     /// When multiple stores have identical configurations, they share a single
     /// backend instance (smart deduplication based on full config equality).
+    /// Each store's `initialize_*` method is called to set up only the tables
+    /// needed for its role.
     pub async fn create_stores(&self) -> Result<Stores> {
         let (metadata_config, blobs_config, journal_config) = self.get_configs();
 
-        // Cache for deduplication: configs with the same values share one instance
+        // Deduplicate: create each unique config only once
         let mut cache: HashMap<StoreConfig, ConcreteStore> = HashMap::new();
-
-        // Helper to get or create a store for a given config
-        async fn get_or_create(
-            cache: &mut HashMap<StoreConfig, ConcreteStore>,
-            config: StoreConfig,
-        ) -> Result<ConcreteStore> {
-            if let Some(existing) = cache.get(&config) {
-                return Ok(existing.clone());
+        for config in [&metadata_config, &blobs_config, &journal_config] {
+            if !cache.contains_key(config) {
+                let store = create_concrete(config).await?;
+                cache.insert(config.clone(), store);
             }
-            let store = create_concrete(&config).await?;
-            cache.insert(config, store.clone());
-            Ok(store)
         }
 
-        // Create stores, reusing instances when configs match
-        let metadata_concrete = get_or_create(&mut cache, metadata_config).await?;
-        let blobs_concrete = get_or_create(&mut cache, blobs_config).await?;
-        let journal_concrete = get_or_create(&mut cache, journal_config).await?;
+        // Look up the concrete stores for each role
+        let metadata_concrete = cache[&metadata_config].clone();
+        let blobs_concrete = cache[&blobs_config].clone();
+        let journal_concrete = cache[&journal_config].clone();
 
         // Convert to trait objects, validating each store supports the required trait
+        let metadata_store = metadata_concrete
+            .as_metadata()
+            .attach_printable("metadata store configuration")?;
+        let blob_store = blobs_concrete
+            .as_blob()
+            .attach_printable("blob store configuration")?;
+        let execution_journal = journal_concrete
+            .as_journal()
+            .attach_printable("journal configuration")?;
+
+        // Initialize each store (creates only the tables needed for its role)
+        metadata_store
+            .initialize_metadata_store()
+            .await
+            .change_context(ConfigError::Configuration)
+            .attach_printable("failed to initialize metadata store")?;
+        blob_store
+            .initialize_blob_store()
+            .await
+            .change_context(ConfigError::Configuration)
+            .attach_printable("failed to initialize blob store")?;
+        execution_journal
+            .initialize_journal()
+            .await
+            .change_context(ConfigError::Configuration)
+            .attach_printable("failed to initialize execution journal")?;
+
         Ok(Stores {
-            metadata_store: metadata_concrete
-                .as_metadata()
-                .attach_printable("metadata store configuration")?,
-            blob_store: blobs_concrete
-                .as_blob()
-                .attach_printable("blob store configuration")?,
-            execution_journal: journal_concrete
-                .as_journal()
-                .attach_printable("journal configuration")?,
+            metadata_store,
+            blob_store,
+            execution_journal,
         })
     }
 }

--- a/stepflow-rs/crates/stepflow-state-sql/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-state-sql/src/lib.rs
@@ -15,7 +15,7 @@
 //! Provides persistent storage for blobs and execution state using SQLite.
 //! Future versions will support PostgreSQL and MySQL.
 
-mod migrations;
+pub(crate) mod migrations;
 mod sqlite_state_store;
 
 pub use sqlite_state_store::{SqliteStateStore, SqliteStateStoreConfig};

--- a/stepflow-rs/crates/stepflow-state-sql/src/migrations.rs
+++ b/stepflow-rs/crates/stepflow-state-sql/src/migrations.rs
@@ -14,30 +14,71 @@ use error_stack::{Result, ResultExt as _};
 use sqlx::{Row as _, SqlitePool};
 use stepflow_state::StateError;
 
-/// Run migrations to set up the database schema
-pub async fn run_migrations(pool: &SqlitePool) -> Result<(), StateError> {
-    // Create migration tracking table first
+/// Run blob store migrations (creates the `blobs` table and indexes).
+pub async fn run_blob_migrations(pool: &SqlitePool) -> Result<(), StateError> {
+    create_migrations_table(pool).await?;
+    apply_migration(pool, "001_create_blob_tables", || create_blob_tables(pool)).await?;
+    Ok(())
+}
+
+/// Run metadata store migrations (creates `runs`, `step_results`, `step_info`,
+/// `run_items` tables and their indexes).
+///
+/// Metadata tables have no FK references to the blobs table because blobs may
+/// live in a different backend (e.g., S3, filesystem).
+pub async fn run_metadata_migrations(pool: &SqlitePool) -> Result<(), StateError> {
     create_migrations_table(pool).await?;
 
-    // Apply the unified schema migration
-    apply_migration(pool, "001_create_unified_schema", || {
-        create_unified_schema(pool)
+    apply_migration(pool, "001_create_metadata_tables", || {
+        create_metadata_tables(pool)
     })
     .await?;
 
-    // Apply journal tables migration
-    apply_migration(pool, "002_create_journal_tables", || {
-        create_journal_tables(pool)
-    })
-    .await?;
-
-    // Add step_statuses_json column to run_items
     apply_migration(pool, "003_add_step_statuses_to_run_items", || {
         add_step_statuses_column(pool)
     })
     .await?;
 
-    // Add orchestrator_id column to runs for multi-orchestrator recovery
+    apply_migration(pool, "004_add_orchestrator_id_to_runs", || {
+        add_orchestrator_id_column(pool)
+    })
+    .await?;
+
+    Ok(())
+}
+
+/// Run journal migrations (creates the `journal_entries` table and indexes).
+pub async fn run_journal_migrations(pool: &SqlitePool) -> Result<(), StateError> {
+    create_migrations_table(pool).await?;
+    apply_migration(pool, "002_create_journal_tables", || {
+        create_journal_tables(pool)
+    })
+    .await?;
+    Ok(())
+}
+
+/// Run all migrations (blob + metadata + journal). Convenience for tests and
+/// single-instance deployments where one SQLite database backs all stores.
+pub async fn run_all_migrations(pool: &SqlitePool) -> Result<(), StateError> {
+    create_migrations_table(pool).await?;
+
+    apply_migration(pool, "001_create_blob_tables", || create_blob_tables(pool)).await?;
+
+    apply_migration(pool, "001_create_metadata_tables", || {
+        create_metadata_tables(pool)
+    })
+    .await?;
+
+    apply_migration(pool, "002_create_journal_tables", || {
+        create_journal_tables(pool)
+    })
+    .await?;
+
+    apply_migration(pool, "003_add_step_statuses_to_run_items", || {
+        add_step_statuses_column(pool)
+    })
+    .await?;
+
     apply_migration(pool, "004_add_orchestrator_id_to_runs", || {
         add_orchestrator_id_column(pool)
     })
@@ -125,11 +166,9 @@ where
     Ok(())
 }
 
-/// Create the unified database schema in one migration
-async fn create_unified_schema(pool: &SqlitePool) -> Result<(), StateError> {
-    // Create all tables with their final schema
-    let table_commands = vec![
-        // Unified blobs table for content-addressable storage (both data and flows)
+/// Create the blob tables for content-addressable storage.
+async fn create_blob_tables(pool: &SqlitePool) -> Result<(), StateError> {
+    sqlx::query(
         r#"
             CREATE TABLE IF NOT EXISTS blobs (
                 id TEXT PRIMARY KEY,
@@ -139,7 +178,25 @@ async fn create_unified_schema(pool: &SqlitePool) -> Result<(), StateError> {
                 created_at DATETIME DEFAULT CURRENT_TIMESTAMP
             )
         "#,
-        // Runs table with flow metadata and hierarchy support for sub-flows
+    )
+    .execute(pool)
+    .await
+    .change_context(StateError::Initialization)?;
+
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_blobs_type ON blobs(blob_type)")
+        .execute(pool)
+        .await
+        .change_context(StateError::Initialization)?;
+
+    Ok(())
+}
+
+/// Create the metadata tables for runs, steps, and run items.
+async fn create_metadata_tables(pool: &SqlitePool) -> Result<(), StateError> {
+    let table_commands = vec![
+        // Runs table with flow metadata and hierarchy support for sub-flows.
+        // flow_id is a blob reference but has no FK constraint because blobs
+        // may be stored in a different backend (e.g., S3, filesystem).
         r#"
             CREATE TABLE IF NOT EXISTS runs (
                 id TEXT PRIMARY KEY,
@@ -150,8 +207,7 @@ async fn create_unified_schema(pool: &SqlitePool) -> Result<(), StateError> {
                 root_run_id TEXT NOT NULL,
                 parent_run_id TEXT,
                 created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                completed_at DATETIME,
-                FOREIGN KEY (flow_id) REFERENCES blobs(id)
+                completed_at DATETIME
             )
         "#,
         // Step results table for flow step execution results
@@ -196,7 +252,6 @@ async fn create_unified_schema(pool: &SqlitePool) -> Result<(), StateError> {
         "#,
     ];
 
-    // Execute table creation commands
     for sql in table_commands {
         sqlx::query(sql)
             .execute(pool)
@@ -204,10 +259,7 @@ async fn create_unified_schema(pool: &SqlitePool) -> Result<(), StateError> {
             .change_context(StateError::Initialization)?;
     }
 
-    // Create all indexes for optimal performance
     let index_commands = vec![
-        // Blob indexes
-        "CREATE INDEX IF NOT EXISTS idx_blobs_type ON blobs(blob_type)",
         // Step results indexes
         "CREATE INDEX IF NOT EXISTS idx_step_results_step_id ON step_results(run_id, step_id)",
         // Step info indexes
@@ -224,7 +276,6 @@ async fn create_unified_schema(pool: &SqlitePool) -> Result<(), StateError> {
         "CREATE INDEX IF NOT EXISTS idx_run_items_status ON run_items(run_id, status)",
     ];
 
-    // Execute index creation commands
     for sql in index_commands {
         sqlx::query(sql)
             .execute(pool)

--- a/stepflow-rs/crates/stepflow-state-sql/src/sqlite_state_store.rs
+++ b/stepflow-rs/crates/stepflow-state-sql/src/sqlite_state_store.rs
@@ -75,7 +75,11 @@ pub struct SqliteStateStore {
 }
 
 impl SqliteStateStore {
-    /// Create a new SqliteStateStore with the given configuration
+    /// Create a new SqliteStateStore with the given configuration.
+    ///
+    /// If `auto_migrate` is true, runs all migrations (blob, metadata, journal).
+    /// For selective initialization, set `auto_migrate` to false and call the
+    /// trait-level `initialize_*` methods instead.
     pub async fn new(config: SqliteStateStoreConfig) -> Result<Self, StateError> {
         let pool = SqlitePoolOptions::new()
             .max_connections(config.max_connections)
@@ -98,7 +102,7 @@ impl SqliteStateStore {
             .attach_printable("Failed to set busy timeout")?;
 
         if config.auto_migrate {
-            migrations::run_migrations(&pool).await?;
+            migrations::run_all_migrations(&pool).await?;
         }
 
         Ok(Self {
@@ -107,7 +111,7 @@ impl SqliteStateStore {
         })
     }
 
-    /// Create SqliteStateStore directly from a database URL
+    /// Create SqliteStateStore directly from a database URL.
     pub async fn from_url(database_url: &str) -> Result<Self, StateError> {
         let config = SqliteStateStoreConfig {
             database_url: database_url.to_string(),
@@ -171,6 +175,11 @@ impl SqliteStateStore {
 }
 
 impl BlobStore for SqliteStateStore {
+    fn initialize_blob_store(&self) -> BoxFuture<'_, error_stack::Result<(), StateError>> {
+        let pool = self.pool.clone();
+        async move { migrations::run_blob_migrations(&pool).await }.boxed()
+    }
+
     fn put_blob(
         &self,
         content: &[u8],
@@ -251,6 +260,11 @@ impl BlobStore for SqliteStateStore {
 }
 
 impl MetadataStore for SqliteStateStore {
+    fn initialize_metadata_store(&self) -> BoxFuture<'_, error_stack::Result<(), StateError>> {
+        let pool = self.pool.clone();
+        async move { migrations::run_metadata_migrations(&pool).await }.boxed()
+    }
+
     fn create_run(
         &self,
         params: stepflow_state::CreateRunParams,
@@ -897,6 +911,11 @@ impl MetadataStore for SqliteStateStore {
 }
 
 impl ExecutionJournal for SqliteStateStore {
+    fn initialize_journal(&self) -> BoxFuture<'_, error_stack::Result<(), StateError>> {
+        let pool = self.pool.clone();
+        async move { migrations::run_journal_migrations(&pool).await }.boxed()
+    }
+
     fn write(
         &self,
         root_run_id: Uuid,

--- a/stepflow-rs/crates/stepflow-state-sql/src/tests.rs
+++ b/stepflow-rs/crates/stepflow-state-sql/src/tests.rs
@@ -416,7 +416,7 @@ async fn sqlite_blob_compliance() {
 // Migration Idempotency Tests
 // =========================================================================
 
-/// Migrations must be idempotent: calling run_migrations twice on the same
+/// Migrations must be idempotent: calling run_all_migrations twice on the same
 /// database must succeed. This exercises the `INSERT OR IGNORE` and
 /// concurrent-failure-recheck logic in `apply_migration`.
 #[tokio::test]
@@ -425,7 +425,7 @@ async fn test_migrations_idempotent() {
     let store = SqliteStateStore::in_memory().await.unwrap();
 
     // Second call on the same pool should be a no-op (all migrations already applied)
-    crate::migrations::run_migrations(&store.pool)
+    crate::migrations::run_all_migrations(&store.pool)
         .await
         .unwrap();
 }
@@ -472,8 +472,8 @@ async fn test_migrations_concurrent_pools() {
 
     // Run migrations from both pools concurrently
     let (r1, r2) = tokio::join!(
-        crate::migrations::run_migrations(&pool1),
-        crate::migrations::run_migrations(&pool2),
+        crate::migrations::run_all_migrations(&pool1),
+        crate::migrations::run_all_migrations(&pool2),
     );
 
     r1.expect("pool1 migrations should succeed");
@@ -498,4 +498,116 @@ async fn test_migrations_concurrent_pools() {
         )
         .await
         .unwrap();
+}
+
+// =========================================================================
+// Selective Migration Tests
+// =========================================================================
+
+/// Helper to check if a table exists in the database.
+async fn table_exists(pool: &sqlx::SqlitePool, table_name: &str) -> bool {
+    let row =
+        sqlx::query("SELECT COUNT(*) as count FROM sqlite_master WHERE type='table' AND name=?")
+            .bind(table_name)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    let count: i64 = sqlx::Row::get(&row, "count");
+    count > 0
+}
+
+/// Blob-only migration should only create the blobs table.
+#[tokio::test]
+async fn test_blob_only_migration() {
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+
+    crate::migrations::run_blob_migrations(&pool).await.unwrap();
+
+    assert!(table_exists(&pool, "blobs").await);
+    assert!(!table_exists(&pool, "runs").await);
+    assert!(!table_exists(&pool, "step_results").await);
+    assert!(!table_exists(&pool, "step_info").await);
+    assert!(!table_exists(&pool, "run_items").await);
+    assert!(!table_exists(&pool, "journal_entries").await);
+}
+
+/// Metadata migration should create only metadata tables (no blobs, no journal).
+/// Blobs may live in a different backend (e.g., S3), so no FK or table dependency.
+#[tokio::test]
+async fn test_metadata_only_migration() {
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+
+    crate::migrations::run_metadata_migrations(&pool)
+        .await
+        .unwrap();
+
+    // Blob tables NOT created (blobs are independent)
+    assert!(!table_exists(&pool, "blobs").await);
+    // Metadata tables created
+    assert!(table_exists(&pool, "runs").await);
+    assert!(table_exists(&pool, "step_results").await);
+    assert!(table_exists(&pool, "step_info").await);
+    assert!(table_exists(&pool, "run_items").await);
+    // Journal not created
+    assert!(!table_exists(&pool, "journal_entries").await);
+}
+
+/// Journal-only migration should only create the journal_entries table.
+#[tokio::test]
+async fn test_journal_only_migration() {
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+
+    crate::migrations::run_journal_migrations(&pool)
+        .await
+        .unwrap();
+
+    assert!(!table_exists(&pool, "blobs").await);
+    assert!(!table_exists(&pool, "runs").await);
+    assert!(table_exists(&pool, "journal_entries").await);
+}
+
+/// Running migrations incrementally should add tables for new store types.
+#[tokio::test]
+async fn test_incremental_migrations() {
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+
+    // First: only blob tables
+    crate::migrations::run_blob_migrations(&pool).await.unwrap();
+
+    assert!(table_exists(&pool, "blobs").await);
+    assert!(!table_exists(&pool, "runs").await);
+
+    // Second: add metadata tables
+    crate::migrations::run_metadata_migrations(&pool)
+        .await
+        .unwrap();
+
+    assert!(table_exists(&pool, "blobs").await);
+    assert!(table_exists(&pool, "runs").await);
+    assert!(table_exists(&pool, "step_results").await);
+    assert!(table_exists(&pool, "run_items").await);
 }

--- a/stepflow-rs/crates/stepflow-state/src/blob_store.rs
+++ b/stepflow-rs/crates/stepflow-state/src/blob_store.rs
@@ -63,6 +63,15 @@ pub struct RawBlob {
 /// Implementors provide [`put_blob`](Self::put_blob) and [`get_blob`](Self::get_blob).
 /// Convenience defaults are provided for flow storage and typed retrieval.
 pub trait BlobStore: Send + Sync {
+    /// Initialize the blob store backend (e.g., create tables, set up schema).
+    ///
+    /// Called by the configuration layer after the store is created and before
+    /// it is used. The default implementation is a no-op, suitable for backends
+    /// that require no initialization (e.g., in-memory stores).
+    fn initialize_blob_store(&self) -> BoxFuture<'_, error_stack::Result<(), StateError>> {
+        async { Ok(()) }.boxed()
+    }
+
     /// Store raw content bytes as a blob and return its content-based ID.
     ///
     /// The blob ID is generated as a SHA-256 hash of `content`,

--- a/stepflow-rs/crates/stepflow-state/src/execution_journal.rs
+++ b/stepflow-rs/crates/stepflow-state/src/execution_journal.rs
@@ -34,7 +34,7 @@
 use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
-use futures::future::BoxFuture;
+use futures::future::{BoxFuture, FutureExt as _};
 use serde::{Deserialize, Serialize};
 use stepflow_core::status::ExecutionStatus;
 use stepflow_core::workflow::ValueRef;
@@ -314,6 +314,15 @@ impl JournalEvent {
 /// After `write` returns, the event is guaranteed to survive process crashes
 /// or restarts.
 pub trait ExecutionJournal: Send + Sync {
+    /// Initialize the journal backend (e.g., create tables, set up schema).
+    ///
+    /// Called by the configuration layer after the journal is created and before
+    /// it is used. The default implementation is a no-op, suitable for backends
+    /// that require no initialization (e.g., in-memory or no-op journals).
+    fn initialize_journal(&self) -> BoxFuture<'_, error_stack::Result<(), StateError>> {
+        async { Ok(()) }.boxed()
+    }
+
     /// Write a journal event durably.
     ///
     /// The event is persisted to the journal for the given `root_run_id`.

--- a/stepflow-rs/crates/stepflow-state/src/metadata_store.rs
+++ b/stepflow-rs/crates/stepflow-state/src/metadata_store.rs
@@ -25,7 +25,7 @@
 
 use std::collections::HashSet;
 
-use futures::future::BoxFuture;
+use futures::future::{BoxFuture, FutureExt as _};
 use stepflow_core::status::ExecutionStatus;
 use stepflow_core::{FlowResult, workflow::WorkflowOverrides};
 use uuid::Uuid;
@@ -45,6 +45,15 @@ use super::state_store::CreateRunParams;
 /// Step-level execution details are handled by [`ExecutionJournal`](crate::ExecutionJournal) and
 /// recovered via journal replay during recovery.
 pub trait MetadataStore: Send + Sync {
+    /// Initialize the metadata store backend (e.g., create tables, set up schema).
+    ///
+    /// Called by the configuration layer after the store is created and before
+    /// it is used. The default implementation is a no-op, suitable for backends
+    /// that require no initialization (e.g., in-memory stores).
+    fn initialize_metadata_store(&self) -> BoxFuture<'_, error_stack::Result<(), StateError>> {
+        async { Ok(()) }.boxed()
+    }
+
     // =========================================================================
     // Run Management
     // =========================================================================


### PR DESCRIPTION
## Summary

- Add `initialize_blob_store()`, `initialize_metadata_store()`, and `initialize_journal()` to `BlobStore`, `MetadataStore`, and `ExecutionJournal` traits with default no-op implementations
- `SqliteStateStore` implements each to run only the migrations needed for that store role
- Split monolithic `run_migrations()` into `run_blob_migrations()`, `run_metadata_migrations()`, `run_journal_migrations()`, and `run_all_migrations()`
- Drop FK constraint from `runs.flow_id` since blobs may live in a different backend (e.g., S3)
- `storage_config.rs` calls `initialize_*()` on each trait object after creation, so expanded-form configs only create the tables they need

## Test plan

- [x] Selective migration tests: blob-only, metadata-only, journal-only each create only their tables
- [x] Incremental migration test: adding metadata after blob works correctly
- [x] Idempotency and concurrent pool migration tests pass
- [x] All compliance tests (blob, metadata, journal) pass
- [x] `./scripts/check-rust.sh` passes (fmt, clippy, tests, docs)