### PR TITLE
fix: Install uv for all release prepare workflows

### DIFF
--- a/.github/workflows/release_prepare.yml
+++ b/.github/workflows/release_prepare.yml
@@ -48,8 +48,7 @@ jobs:
       - name: Install git-cliff
         uses: kenji-miyake/setup-git-cliff@v1
 
-      - name: Install uv (for Python packages)
-        if: inputs.package == 'stepflow-py' || inputs.package == 'stepflow-langflow'
+      - name: Install uv
         uses: astral-sh/setup-uv@v3
 
       - name: Configure git


### PR DESCRIPTION
## Summary
- The stepflow release script needs `uv` to regenerate the Python API client (`uv run python scripts/generate_api_client.py`), but the prepare release workflow only installed `uv` for Python package releases
- Remove the conditional so `uv` is installed unconditionally for all packages

## Test plan
- Re-run the stepflow release prepare workflow after merging