### PR TITLE
fix: Disable etcd feature for schema generation in release

### DIFF
--- a/scripts/prepare-release-stepflow.sh
+++ b/scripts/prepare-release-stepflow.sh
@@ -206,7 +206,7 @@ cargo update -w > /dev/null
 
 # Regenerate OpenAPI schema with new version
 echo -e "${BLUE}Regenerating OpenAPI schema...${NC}"
-STEPFLOW_OVERWRITE_SCHEMA=1 cargo test -p stepflow-server test_openapi_schema_generation --quiet || {
+STEPFLOW_OVERWRITE_SCHEMA=1 cargo test -p stepflow-server --no-default-features test_openapi_schema_generation --quiet || {
     echo -e "${RED}Error: Failed to regenerate OpenAPI schema${NC}" >&2
     exit 1
 }


### PR DESCRIPTION
## Summary
- The stepflow release prepare workflow fails compiling `etcd-client` because `protoc` is not installed on CI runners
- The OpenAPI schema generation test doesn't need the `etcd` feature, so pass `--no-default-features` to skip it

## Context
Follow-up to #662 which fixed the `cargo update -w` and `2>/dev/null` issues — removing stderr suppression revealed this underlying `protoc` dependency problem.

## Test plan
- Re-run the stepflow release prepare workflow after merging