### PR TITLE
fix: Add Cross.toml to install protoc for cross builds

### DIFF
--- a/stepflow-rs/Cross.toml
+++ b/stepflow-rs/Cross.toml
@@ -1,0 +1,11 @@
+# Cross-compilation configuration for the `cross` tool.
+# Install protobuf compiler needed by etcd-client's build script.
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = ["apt-get update && apt-get install -y protobuf-compiler"]
+
+[target.x86_64-unknown-linux-musl]
+pre-build = ["apt-get update && apt-get install -y protobuf-compiler"]
+
+[target.aarch64-unknown-linux-musl]
+pre-build = ["apt-get update && apt-get install -y protobuf-compiler"]


### PR DESCRIPTION
## Summary
- Cross builds (`aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`) run inside Docker containers where host-installed `protoc` is not available
- Add `Cross.toml` with `pre-build` steps to install `protobuf-compiler` for all cross-compilation targets
- Follow-up to #666 which fixed native builds but missed cross builds

## Test plan
- Re-run the stepflow release workflow after merging