### PR TITLE
fix: Pass repo-token to setup-protoc to avoid rate limits

### DIFF
--- a/.github/actions/recovery-tests/action.yml
+++ b/.github/actions/recovery-tests/action.yml
@@ -37,6 +37,8 @@ runs:
     # Install protoc for etcd-client compilation (needed by stepflow-server)
     - name: Install protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ github.token }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5

--- a/.github/actions/rust-checks/action.yml
+++ b/.github/actions/rust-checks/action.yml
@@ -62,6 +62,8 @@ runs:
     # Install protoc for etcd-client compilation (needed by --all-features)
     - name: Install protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ github.token }}
 
     # Install Graphviz for visualize command tests
     - name: Install Graphviz

--- a/.github/workflows/release_stepflow.yml
+++ b/.github/workflows/release_stepflow.yml
@@ -88,6 +88,8 @@ jobs:
       # Install protoc for etcd-client compilation (needed by stepflow-server)
       - name: Install protoc
         uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cross-compilation tools
         if: matrix.cross


### PR DESCRIPTION
## Summary
- `arduino/setup-protoc@v3` downloads protoc from GitHub releases using unauthenticated API requests, which hit rate limits easily
- Pass `repo-token` to all three usages so requests are authenticated with higher rate limits

## Context
Release workflow run [failed](https://github.com/stepflow-ai/stepflow/actions/runs/22332730043) with: `Error: API rate limit exceeded for 64.236.176.194`

## Test plan
- Re-run the release workflow after merging