### PR TITLE
fix: Use Python 3.11 for wheel verification

### DIFF
--- a/.github/workflows/release_stepflow.yml
+++ b/.github/workflows/release_stepflow.yml
@@ -267,7 +267,7 @@ jobs:
 
           # Create isolated venv and install the wheel
           echo "Creating isolated test environment..."
-          uv venv /tmp/verify-venv
+          uv venv --python 3.11 /tmp/verify-venv
           source /tmp/verify-venv/bin/activate
           uv pip install "$WHEEL"
 


### PR DESCRIPTION
## Summary
- The wheel verification step creates a venv using the system Python (3.10.12 on ubuntu-22.04), but `stepflow-orchestrator` requires Python >= 3.11
- Use `uv venv --python 3.11` so uv downloads and uses Python 3.11

## Test plan
- Re-run the release workflow after merging