### PR TITLE
feat: Only use SSE when bidirectional communication is needed

### DIFF
--- a/sdks/python/stepflow-py/src/stepflow_py/worker/http_server.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/http_server.py
@@ -208,11 +208,60 @@ class _HttpServerContext:
                     observability=observability,
                     blob_api_url=self.server.blob_api_url,
                 )
-                # Streaming: tokens are reset inside the generator
-                # (a finally here would fire before the generator runs).
+
+                # On-demand SSE: start execution in background and race
+                # between completion and the first bidirectional request.
+                async def execute_and_shutdown_queue():
+                    try:
+                        result = await self.server.handle_message(request, context)
+                        assert result is not None
+                        return result
+                    finally:
+                        await outgoing_queue.put(None)
+
+                execution_task = asyncio.create_task(execute_and_shutdown_queue())
+                first_msg_task = asyncio.create_task(outgoing_queue.get())
+
+                done, _ = await asyncio.wait(
+                    {execution_task, first_msg_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+                if execution_task in done:
+                    # Component finished without bidirectional calls.
+                    first_msg_task.cancel()
+                    try:
+                        result = execution_task.result()
+                        return JSONResponse(
+                            content=msgspec.to_builtins(result),
+                            media_type="application/json",
+                        )
+                    finally:
+                        blob_store.reset(blob_tokens)
+
+                # first_msg_task completed first
+                first_message = first_msg_task.result()
+                if first_message is None:
+                    # Queue shutdown — execution finished without
+                    # bidirectional calls (tight race).
+                    try:
+                        result = await execution_task
+                        return JSONResponse(
+                            content=msgspec.to_builtins(result),
+                            media_type="application/json",
+                        )
+                    finally:
+                        blob_store.reset(blob_tokens)
+
+                # Bidirectional request detected — upgrade to SSE.
+                # Blob tokens are reset inside the generator.
                 return StreamingResponse(
-                    self.execute_with_streaming_context(
-                        request, context, outgoing_queue, blob_tokens
+                    self._stream_remaining_sse(
+                        execution_task,
+                        first_message,
+                        outgoing_queue,
+                        request.id,
+                        blob_tokens,
                     ),
                     media_type="text/event-stream",
                     headers={"Stepflow-Instance-Id": self.instance_id},
@@ -243,26 +292,26 @@ class _HttpServerContext:
                 error_message=f"Internal error: {str(e)}",
             )
 
-    async def execute_with_streaming_context(
+    async def _stream_remaining_sse(
         self,
-        request: MethodRequest,
-        context: StepflowContext,
+        execution_task: asyncio.Task[Any],
+        first_message: Any,
         outgoing_queue: asyncio.Queue[MethodRequest | None],
+        request_id: RequestId,
         blob_tokens: Any = None,
     ) -> AsyncGenerator[str]:
-        """Execute request with streaming context via SSE."""
+        """Stream SSE events after the first bidirectional message triggered SSE.
 
-        async def execute_and_shutdown_queue():
-            try:
-                result = await self.server.handle_message(request, context)
-                assert result is not None
-                return result
-            finally:
-                await outgoing_queue.put(None)
-
-        execution_task = asyncio.create_task(execute_and_shutdown_queue())
-
+        Called when on-demand SSE detected a real bidirectional request.
+        Yields the first message, then continues draining the queue until
+        execution completes.
+        """
         try:
+            # Yield the first bidirectional message that triggered SSE
+            sse_data = msgspec.json.encode(first_message).decode("utf-8")
+            yield f"data: {sse_data}\n\n"
+
+            # Continue streaming remaining messages
             while True:
                 message = await outgoing_queue.get()
                 if message is None:
@@ -270,6 +319,7 @@ class _HttpServerContext:
                 sse_data = msgspec.json.encode(message).decode("utf-8")
                 yield f"data: {sse_data}\n\n"
 
+            # Execution is done, yield final result
             assert execution_task.done()
             result = await execution_task
             sse_data = msgspec.json.encode(result).decode("utf-8")
@@ -278,7 +328,7 @@ class _HttpServerContext:
             if not execution_task.done():
                 execution_task.cancel()
             yield self.create_sse_error_event(
-                request_id=request.id,
+                request_id=request_id,
                 error_code=-32603,
                 error_message=f"Request execution failed: {str(e)}",
             )

--- a/sdks/python/stepflow-py/tests/test_http_server.py
+++ b/sdks/python/stepflow-py/tests/test_http_server.py
@@ -305,6 +305,26 @@ def core_server():
             blob_id=blob_id,
         )
 
+    # Component that uses context properties only (no bidirectional/blob calls)
+    class ContextPropsInput(msgspec.Struct):
+        message: str
+
+    class ContextPropsOutput(msgspec.Struct):
+        message: str
+        run_id: str | None
+        attempt: int
+
+    @server.component
+    async def context_props_component(
+        input: ContextPropsInput, context: StepflowContext
+    ) -> ContextPropsOutput:
+        """A component that accepts context but only reads properties."""
+        return ContextPropsOutput(
+            message=input.message,
+            run_id=context.run_id,
+            attempt=context.attempt,
+        )
+
     # Define message types for bidirectional SSE test
     class BidirectionalInput(msgspec.Struct):
         value: int
@@ -531,6 +551,7 @@ async def test_components_list(test_server):
     expected_components = [
         "/simple_component",
         "/context_component",
+        "/context_props_component",
         "/bidirectional_component",
         "/udf",
     ]
@@ -659,45 +680,63 @@ async def test_http_blob_api(test_server):
     """Test context component with HTTP blob API.
 
     This test verifies that components using StepflowContext can store blobs
-    via the HTTP Blob API during execution. The blob operations happen over
-    HTTP (not SSE), so we only receive the final result via SSE.
+    via the HTTP Blob API during execution. Since blob operations use HTTP
+    (not SSE bidirectional calls), on-demand SSE returns a direct JSON response.
     """
-
-    async with test_server.stream_request(
+    response = await test_server.send_request(
         Method.components_execute,
         component="/context_component",
         input_data={"data": "test blob data"},
-    ) as response:
-        # Should return streaming response
-        assert response.status_code == 200
-        assert "text/event-stream" in response.headers.get("content-type", "")
+    )
 
-        # Create SSE event helper
-        sse_events = test_server.sse_events(response)
+    # On-demand SSE: no bidirectional calls were made, so response is JSON
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
 
-        # With HTTP blob API, the component makes HTTP calls directly,
-        # so we only receive the final response via SSE (no intermediate blobs/put)
-        final_response = await sse_events.next()
-        assert final_response is not None, "Should receive final component response"
-        assert final_response["jsonrpc"] == "2.0"
-        assert final_response["id"] == "components_execute-test"
-        assert "result" in final_response
-        assert (
-            final_response["result"]["output"]["result"]
-            == "Processed with context: test blob data"
-        )
-        # Blob ID should be a SHA-256 hash (64 hex chars)
-        blob_id = final_response["result"]["output"]["blob_id"]
-        assert len(blob_id) == 64, "Blob ID should be SHA-256 hash"
-        assert all(c in "0123456789abcdef" for c in blob_id), "Blob ID should be hex"
+    result = response.json()
+    assert result["jsonrpc"] == "2.0"
+    assert result["id"] == "components_execute-test"
+    assert "result" in result
+    assert (
+        result["result"]["output"]["result"] == "Processed with context: test blob data"
+    )
+    # Blob ID should be a SHA-256 hash (64 hex chars)
+    blob_id = result["result"]["output"]["blob_id"]
+    assert len(blob_id) == 64, "Blob ID should be SHA-256 hash"
+    assert all(c in "0123456789abcdef" for c in blob_id), "Blob ID should be hex"
 
-        # Verify the blob was stored in our mock storage
-        assert blob_id in _test_blob_storage
-        assert _test_blob_storage[blob_id]["data"] == "test blob data"
+    # Verify the blob was stored in our mock storage
+    assert blob_id in _test_blob_storage
+    assert _test_blob_storage[blob_id]["data"] == "test blob data"
 
-        # Verify the stream is closed (no more events)
-        next_event = await sse_events.next()
-        assert next_event is None, "Should not receive any more events"
+
+@pytest.mark.asyncio
+async def test_context_component_json_response(test_server):
+    """Test that a context component without bidirectional calls returns JSON.
+
+    On-demand SSE: components that accept StepflowContext but only read
+    properties (run_id, attempt, etc.) should get a direct JSON response
+    instead of an SSE stream.
+    """
+    response = await test_server.send_request(
+        Method.components_execute,
+        component="/context_props_component",
+        input_data={"message": "hello"},
+    )
+
+    # Should return direct JSON, not SSE
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
+
+    result = response.json()
+    assert result["jsonrpc"] == "2.0"
+    assert result["id"] == "components_execute-test"
+    assert "result" in result
+
+    output = result["result"]["output"]
+    assert output["message"] == "hello"
+    assert output["run_id"] == "test-run-id"
+    assert output["attempt"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Defer SSE session creation in the Python SDK until a component actually sends a bidirectional request (`runs/submit`, `runs/get`), rather than eagerly creating one whenever a component accepts `StepflowContext`
- Components that only use context properties (`run_id`, `attempt`) or HTTP blob operations (`put_blob`) now return direct JSON responses, avoiding unnecessary SSE overhead
- No Rust changes needed — the orchestrator already handles both JSON and SSE responses based on `Content-Type`

## Test plan
- [x] `test_http_blob_api` updated to verify JSON response (was SSE)
- [x] New `test_context_component_json_response` verifies context-only components return JSON
- [x] `test_bidirectional_sse` still passes — real bidirectional calls trigger SSE on demand
- [x] All 166 Python SDK tests pass
- [x] Integration tests pass

Closes #636