### PR TITLE
fix: Use exclusive transactions for SQLite migrations

### DIFF
--- a/stepflow-rs/crates/stepflow-state-sql/src/migrations.rs
+++ b/stepflow-rs/crates/stepflow-state-sql/src/migrations.rs
@@ -53,8 +53,18 @@ pub async fn run_metadata_migrations(pool: &SqlitePool) -> Result<(), StateError
     create_migrations_table(pool).await?;
 
     run_migration(pool, "001_create_metadata_tables", create_metadata_tables).await?;
-    run_migration(pool, "003_add_step_statuses_to_run_items", add_step_statuses_column).await?;
-    run_migration(pool, "004_add_orchestrator_id_to_runs", add_orchestrator_id_column).await?;
+    run_migration(
+        pool,
+        "003_add_step_statuses_to_run_items",
+        add_step_statuses_column,
+    )
+    .await?;
+    run_migration(
+        pool,
+        "004_add_orchestrator_id_to_runs",
+        add_orchestrator_id_column,
+    )
+    .await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Fix flaky `test_migrations_concurrent_pools` by replacing the racy check-then-act migration pattern with `BEGIN IMMEDIATE` transactions that serialize concurrent callers
- An optimistic read-only check avoids taking a write lock when migrations are already applied (the common case)
- Migration functions now operate on a single connection holding the transaction, ensuring check + execute + record are atomic

Fixes #682

## Test plan
- [x] `cargo test -p stepflow-state-sql` — all 16 tests pass
- [x] `test_migrations_concurrent_pools` passes 20 consecutive runs