### PR TITLE
ci: Fix rust-cache and unify toolchain action

### DIFF
--- a/.github/actions/langflow-checks/action.yml
+++ b/.github/actions/langflow-checks/action.yml
@@ -28,15 +28,16 @@ runs:
       run: uv python install ${{ inputs.python-version }}
       working-directory: integrations/langflow
 
+    # Use dtolnay/rust-toolchain (not setup-rust-toolchain) because we
+    # configure Swatinem/rust-cache separately with workspaces.
     - name: Setup Rust toolchain (for stepflow binary)
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Configure Rust cache
       uses: Swatinem/rust-cache@v2
       with:
-        workspaces: stepflow-rs
+        workspaces: |
+          ./stepflow-rs
 
     - name: Build Stepflow binary (needed for integration tests)
       shell: bash

--- a/.github/actions/recovery-tests/action.yml
+++ b/.github/actions/recovery-tests/action.yml
@@ -23,16 +23,16 @@ description: 'Build stepflow-server and run Docker Compose recovery integration 
 runs:
   using: 'composite'
   steps:
+    # Use dtolnay/rust-toolchain (not setup-rust-toolchain) because we
+    # configure Swatinem/rust-cache separately with workspaces.
     - name: Setup Rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Configure Rust cache
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: |
-          stepflow-rs
+          ./stepflow-rs
 
     # Install protoc for etcd-client compilation (needed by stepflow-server)
     - name: Install protoc

--- a/.github/actions/rust-checks/action.yml
+++ b/.github/actions/rust-checks/action.yml
@@ -39,18 +39,20 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # Use dtolnay/rust-toolchain (not setup-rust-toolchain) because we
+    # configure Swatinem/rust-cache separately with workspaces.
     - name: Setup Rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ inputs.rust-toolchain }}
-        components: 'clippy'
+        components: clippy
 
     # Configure Rust dependency caching for faster builds
     - name: Configure Rust cache
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: |
-          stepflow-rs
+          ./stepflow-rs
 
     # Install cargo-deny for dependency security audit
     # Intsall cargo-machete for unused dependency detection
@@ -93,3 +95,5 @@ runs:
     - name: Run Rust build and test checks
       shell: bash
       run: ./scripts/check-rust.sh -v
+      env:
+        RUSTFLAGS: -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,23 +58,42 @@ jobs:
         with:
           filters: |
             rust:
+              - '.github/actions/rust-checks/**'
+              - 'scripts/check-rust.sh'
+              - 'scripts/_lib.sh'
               - 'stepflow-rs/**'
               - 'schemas/**'
             python:
+              - '.github/actions/python-checks/**'
+              - 'scripts/check-python.sh'
+              - 'scripts/_lib.sh'
               - 'sdks/python/**'
               - 'schemas/**'
             docs:
+              - '.github/actions/docs-checks/**'
+              - 'scripts/check-docs.sh'
+              - 'scripts/_lib.sh'
               - 'docs/**'
               - 'README.md'
               - '*.md'
             langflow:
+              - '.github/actions/langflow-checks/**'
+              - 'scripts/check-langflow.sh'
+              - 'scripts/_lib.sh'
               - 'integrations/langflow/**'
               - 'stepflow-rs/**'
               - 'sdks/python/**'
             recovery:
+              - '.github/actions/recovery-tests/**'
+              - 'scripts/check-recovery.sh'
+              - 'scripts/_lib.sh'
               - 'tests/recovery/**'
             openapi:
+              - '.github/actions/openapi-checks/**'
+              - 'scripts/check-openapi.sh'
+              - 'scripts/_lib.sh'
               - 'schemas/openapi.json'
+              - '.redocly.yml'
 
   # Rust checks (combined style, build, and test)
   rust-checks:
@@ -175,15 +194,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      # Use dtolnay/rust-toolchain (not setup-rust-toolchain) because we
+      # configure Swatinem/rust-cache separately with workspaces.
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Configure Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
-            stepflow-rs
+            ./stepflow-rs
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/stepflow-rs/.github/workflows/release.yml
+++ b/stepflow-rs/.github/workflows/release.yml
@@ -61,6 +61,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
+          workspaces: |
+            ./stepflow-rs
 
       - name: Build binaries (native)
         if: ${{ !matrix.cross }}


### PR DESCRIPTION
## Summary

- Replace `actions-rust-lang/setup-rust-toolchain` with `dtolnay/rust-toolchain` in all CI actions
- Fix empty `workspaces` value in `stepflow-rs/.github/workflows/release.yml`

### Why

`actions-rust-lang/setup-rust-toolchain` internally invokes `Swatinem/rust-cache` by default (with `cache: true`). Since we also have an explicit `Swatinem/rust-cache` step with `workspaces: ./stepflow-rs`, this caused a double-cache situation where the first (implicit) invocation ran `cargo metadata` in the repo root — failing because there's no `Cargo.toml` there.

`dtolnay/rust-toolchain` is minimal and has no built-in caching, so it works cleanly alongside our explicit rust-cache step.

### Changes

- **`.github/actions/rust-checks/action.yml`**: Switch to `dtolnay/rust-toolchain@master` (needs `master` for the `toolchain` input), add `RUSTFLAGS: -D warnings` to the check script step (previously set implicitly by `setup-rust-toolchain`)
- **`.github/actions/langflow-checks/action.yml`**: Switch to `dtolnay/rust-toolchain@stable`
- **`.github/actions/recovery-tests/action.yml`**: Switch to `dtolnay/rust-toolchain@stable`
- **`.github/workflows/ci.yml`**: Switch to `dtolnay/rust-toolchain@stable` (integration tests job)
- **`stepflow-rs/.github/workflows/release.yml`**: Fix empty `workspaces` value → `./stepflow-rs`

## Test plan

- [ ] CI passes without rust-cache errors
- [ ] Rust checks still enforce `-D warnings`