### PR TITLE
ci: Gate PyPI publish on Docker build success

### DIFF
--- a/.github/workflows/release_langflow.yml
+++ b/.github/workflows/release_langflow.yml
@@ -166,7 +166,7 @@ jobs:
   publish-to-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-22.04
-    needs: [determine-version, build-and-test]
+    needs: [determine-version, build-and-test, build-docker]
     if: needs.determine-version.outputs.skip_tag == 'false'
     environment:
       name: pypi

--- a/.github/workflows/release_stepflow.yml
+++ b/.github/workflows/release_stepflow.yml
@@ -282,7 +282,7 @@ jobs:
   publish-stepflow-wheels:
     name: Publish Wheels to PyPI
     runs-on: ubuntu-22.04
-    needs: [determine-version, build-stepflow-wheels, verify-stepflow-wheels]
+    needs: [determine-version, build-docker, build-stepflow-wheels, verify-stepflow-wheels]
     if: needs.determine-version.outputs.skip_tag == 'false'
     environment:
       name: pypi


### PR DESCRIPTION
## Summary

PyPI publishes are not easily reversible. This PR ensures they only happen after all other release artifacts — including Docker images — have been successfully built and verified.

- **`release_stepflow.yml`**: Add `build-docker` to `publish-stepflow-wheels` `needs`, so wheels are not pushed to PyPI if the Docker image build fails.
- **`release_langflow.yml`**: Add `build-docker` to `publish-to-pypi` `needs`, so the package is not pushed to PyPI if the Docker image build fails.
- **`release_python.yml`**: No change needed — it has no Docker step, and its `build → publish → release` ordering was already correct.

## New job ordering (for workflows with Docker)

```
build / test / verify
    └── Docker images  (any failure here aborts the release)
            └── PyPI publish  (only if Docker succeeded)
                    └── GitHub Release  (only if PyPI succeeded)
```