### PR TITLE
feat: Improve stepflow-langflow CLI run command

### DIFF
--- a/integrations/langflow/src/stepflow_langflow_integration/cli/main.py
+++ b/integrations/langflow/src/stepflow_langflow_integration/cli/main.py
@@ -15,6 +15,8 @@
 """Main CLI entry point for Langflow integration."""
 
 import json
+import logging
+import os
 import sys
 from pathlib import Path
 
@@ -228,6 +230,22 @@ def serve(
     type=click.Path(exists=True, path_type=Path),
     help="JSONL file with one input per line (replaces INPUT_JSON)",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Show verbose output",
+)
+@click.option(
+    "--show-flow",
+    is_flag=True,
+    help="Display the translated Stepflow YAML before execution",
+)
+@click.option(
+    "--env-file",
+    type=click.Path(exists=True, path_type=Path),
+    help="Path to .env file for API keys and other secrets",
+)
 def run(
     input_file: Path,
     input_json: str,
@@ -237,6 +255,9 @@ def run(
     timeout: int,
     dry_run: bool,
     batch: Path | None,
+    verbose: bool,
+    show_flow: bool,
+    env_file: Path | None,
 ):
     """Convert and run a Langflow workflow on Stepflow.
 
@@ -264,10 +285,29 @@ def run(
         # With tweaks to override component settings
         stepflow-langflow run flow.json '{}' --local \\
             --tweaks '{"LanguageModelComponent-kBOja": {"model_name": "gpt-4o"}}'
+
+    \b
+        # Load API keys from a .env file
+        stepflow-langflow run flow.json '{}' --local --env-file path/to/.env
+
+    \b
+        # Debug env var resolution and see orchestrator logs
+        stepflow-langflow run flow.json '{}' --local --verbose --show-flow
     """
     import asyncio
 
     import yaml
+
+    if verbose:
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format="%(levelname)s %(name)s: %(message)s",
+            stream=sys.stderr,
+        )
+
+    # Load explicit .env file if provided
+    if env_file:
+        load_dotenv(env_file)
 
     # Validate options
     if not local and not url:
@@ -339,9 +379,12 @@ def run(
                 click.echo(f"❌ Invalid tweaks JSON: {e}", err=True)
                 sys.exit(1)
 
-        if dry_run:
-            click.echo("\n📄 Converted workflow:")
+        if show_flow or dry_run:
+            click.echo("\n📄 Translated Stepflow flow:")
             click.echo(stepflow_yaml)
+            click.echo()
+
+        if dry_run:
             return
 
         # Parse flow for HTTP API submission
@@ -355,11 +398,15 @@ def run(
 
         if local:
             click.echo("🚀 Starting local orchestrator...")
-            result = asyncio.run(_run_local(flow_dict, inputs, timeout))
+            result = asyncio.run(
+                _run_local(flow_dict, inputs, timeout, verbose=verbose)
+            )
         else:
             assert url is not None
             click.echo(f"🚀 Submitting to {url}...")
-            result = asyncio.run(_run_remote(url, flow_dict, inputs, timeout))
+            result = asyncio.run(
+                _run_remote(url, flow_dict, inputs, timeout, verbose=verbose)
+            )
 
         # Display results
         _display_run_result(result)
@@ -377,6 +424,7 @@ async def _run_with_client(
     flow_dict: dict,
     inputs: list,
     timeout: int,
+    verbose: bool = False,
 ) -> dict:
     """Store a flow and execute it using a StepflowClient.
 
@@ -387,6 +435,9 @@ async def _run_with_client(
     store_response = await client.store_flow(flow_dict, timeout=float(timeout))
     flow_id = store_response.flow_id
     click.echo(f"✅ Flow stored (id: {flow_id[:12]}...)")
+
+    if verbose:
+        await _show_variable_resolution(client, flow_id)
 
     item_label = f"{len(inputs)} inputs" if len(inputs) > 1 else "1 input"
     click.echo(f"🎯 Executing {item_label}...")
@@ -400,10 +451,35 @@ async def _run_with_client(
     return response.model_dump(by_alias=True, exclude_unset=True)
 
 
+async def _show_variable_resolution(client: StepflowClient, flow_id: str) -> None:
+    """Print which variables the flow needs and whether they are set."""
+    try:
+        vars_response = await client._flow_api.get_flow_variables(flow_id)
+        env_vars = vars_response.env_vars or {}
+        if not env_vars:
+            click.echo("🔑 No environment variables required by this flow")
+            return
+        click.echo("🔑 Environment variables required by this flow:")
+        for var_name, env_var_name in sorted(env_vars.items()):
+            value = os.environ.get(env_var_name)
+            if value:
+                click.echo(
+                    f"   {var_name} ← ${env_var_name} ✅ (set, {len(value)} chars)"
+                )
+            else:
+                click.echo(
+                    f"   {var_name} ← ${env_var_name} ❌ NOT SET",
+                    err=True,
+                )
+    except Exception as e:
+        click.echo(f"⚠️  Could not retrieve flow variables: {e}", err=True)
+
+
 async def _run_local(
     flow_dict: dict,
     inputs: list,
     timeout: int,
+    verbose: bool = False,
 ) -> dict:
     """Run a flow using a local StepflowOrchestrator."""
     from stepflow_orchestrator import OrchestratorConfig, StepflowOrchestrator
@@ -435,13 +511,17 @@ async def _run_local(
             },
             "storageConfig": {"type": "inMemory"},
         },
+        log_level="debug" if verbose else "warn",
+        pipe_output=verbose,
     )
 
     async with StepflowOrchestrator.start(config) as orchestrator:
         click.echo(f"✅ Orchestrator running at {orchestrator.url}")
         client = StepflowClient.connect(orchestrator.url)
         async with client:
-            return await _run_with_client(client, flow_dict, inputs, timeout)
+            return await _run_with_client(
+                client, flow_dict, inputs, timeout, verbose=verbose
+            )
 
 
 async def _run_remote(
@@ -449,11 +529,14 @@ async def _run_remote(
     flow_dict: dict,
     inputs: list,
     timeout: int,
+    verbose: bool = False,
 ) -> dict:
     """Submit a flow to a remote Stepflow server and wait for results."""
     client = StepflowClient.connect(base_url)
     async with client:
-        return await _run_with_client(client, flow_dict, inputs, timeout)
+        return await _run_with_client(
+            client, flow_dict, inputs, timeout, verbose=verbose
+        )
 
 
 def _display_run_result(result: dict) -> None:
@@ -469,12 +552,12 @@ def _display_run_result(result: dict) -> None:
             item_result = item.get("result", {})
             outcome = item_result.get("outcome", "unknown")
             if outcome == "success":
-                output = item_result.get("output", {})
+                output = item_result.get("result", {})
                 click.echo("\n🎯 Output:")
                 click.echo(json.dumps(output, indent=2))
             else:
                 click.echo(f"\n❌ Item {item.get('itemIndex', '?')} failed: {outcome}")
-                error = item_result.get("error")
+                error = item_result.get("error") or item_result.get("message")
                 if error:
                     click.echo(f"   {error}")
     else:

--- a/integrations/langflow/tests/integration/test_example_flows.py
+++ b/integrations/langflow/tests/integration/test_example_flows.py
@@ -746,3 +746,32 @@ async def test_poc_flow_store(converter, stepflow_client):
     assert store_response.stored, (
         f"Failed to store poc flow: {store_response.diagnostics}"
     )
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_poc_flow_execution(test_executor):
+    """Test POC flow: full blog post generation pipeline.
+
+    The POC flow is a multi-step content generation pipeline from the Stepflow
+    documentation. It requires OPENAI_API_KEY, which is populated from the
+    environment via env_var annotations in the flow's variable schema
+    (using ``populate_variables_from_env=True``).
+
+    This exercises the same code path as ``stepflow-langflow run --local``.
+    """
+    result = await test_executor.execute_flow(
+        flow_name="poc_flow",
+        input_data={},
+        timeout=300.0,
+        populate_variables_from_env=True,
+    )
+
+    # Should return a Langflow Message with substantial text content
+    message_result = result["result"]
+    assert isinstance(message_result, dict)
+    assert "text" in message_result
+    # The flow produces a blog post — verify we got non-trivial text
+    text = message_result["text"]
+    assert len(text) > 100, (
+        f"Expected substantial text output (blog post), got: {text!r:.200}"
+    )

--- a/sdks/python/stepflow-orchestrator/src/stepflow_orchestrator/orchestrator.py
+++ b/sdks/python/stepflow-orchestrator/src/stepflow_orchestrator/orchestrator.py
@@ -21,6 +21,7 @@ import json
 import os
 import subprocess
 import sys
+import threading
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -63,6 +64,10 @@ class OrchestratorConfig:
 
     # Environment variables to pass to subprocess
     env: dict[str, str] = field(default_factory=dict)
+
+    # If True, pipe orchestrator stdout/stderr directly to the terminal.
+    # Useful for debugging: server logs appear inline with CLI output.
+    pipe_output: bool = False
 
     def __post_init__(self) -> None:
         """Validate configuration values."""
@@ -195,7 +200,7 @@ class StepflowOrchestrator:
             cmd,
             stdin=subprocess.PIPE if stdin_input else None,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=sys.stderr if self._config.pipe_output else subprocess.PIPE,
             env=env,
         )
 
@@ -206,6 +211,17 @@ class StepflowOrchestrator:
 
         # Read the port announcement from stdout
         await self._read_port_announcement()
+
+        # Forward any remaining stdout lines to the terminal when pipe_output is set.
+        # (Server logs go to stderr; stdout is mostly quiet after the port line.)
+        if self._config.pipe_output and self._process.stdout:
+            stdout_pipe = self._process.stdout
+            t = threading.Thread(
+                target=_forward_pipe,
+                args=(stdout_pipe, sys.stdout),
+                daemon=True,
+            )
+            t.start()
 
         # Wait for health check
         await self._wait_for_health()
@@ -378,3 +394,19 @@ class StepflowOrchestrator:
                 return  # Health check passed
             except (urllib.error.URLError, TimeoutError, OSError):
                 await asyncio.sleep(self._config.health_check_interval)
+
+
+def _forward_pipe(pipe: Any, dest: Any) -> None:
+    """Read lines from *pipe* and write them to *dest* until EOF.
+
+    Used by ``pipe_output=True`` to forward orchestrator stdout to the terminal
+    after the port announcement has been consumed.  Runs in a daemon thread.
+    """
+    try:
+        for line in pipe:
+            text = line.decode("utf-8", errors="replace").rstrip()
+            if text:
+                dest.write(text + "\n")
+                dest.flush()
+    except Exception:
+        pass

--- a/sdks/python/stepflow-py/src/stepflow_py/client.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/client.py
@@ -350,10 +350,10 @@ class StepflowClient:
         response = await self._flow_api.get_flow_variables(flow_id)
 
         if not response.env_vars:
-            logger.info("No env_var annotations found for flow %s", flow_id)
+            logger.debug("No env_var annotations found for flow %s", flow_id)
             return explicit_variables
 
-        logger.info(
+        logger.debug(
             "Flow %s env_var annotations: %s",
             flow_id,
             list(response.env_vars.items()),
@@ -364,7 +364,7 @@ class StepflowClient:
             env_value = os.environ.get(env_var_name)
             if env_value is not None:
                 env_variables[var_name] = _parse_env_value(env_value)
-                logger.info(
+                logger.debug(
                     "Populated variable %r from env %r",
                     var_name,
                     env_var_name,
@@ -376,7 +376,7 @@ class StepflowClient:
                     var_name,
                 )
 
-        logger.info(
+        logger.debug(
             "Merged variables for flow %s: %s (from env: %s, explicit: %s)",
             flow_id,
             list(env_variables.keys()),


### PR DESCRIPTION
## Summary

- Add `--verbose`/`-v`, `--show-flow`, and `--env-file` options to `stepflow-langflow run` for better debugging and flexibility
- Fix `_display_run_result` to use the correct `"result"` key (was `"output"`) matching the `FlowResultSuccess` model, with `"message"` fallback for errors
- Add `pipe_output` support to `OrchestratorConfig` so orchestrator subprocess logs can be forwarded to the terminal
- Change `StepflowClient._merge_env_variables` logging from `info` to `debug` so it's only visible with `--verbose`
- Add `test_poc_flow_execution` integration test that actually executes the POC flow end-to-end (existing test only stored it)

## Test plan
- [x] Existing integration tests pass (`test_poc_flow_store`, `test_poc_flow_execution`)
- [x] Manual: `stepflow-langflow run flow.json '{}' --local --verbose` shows orchestrator logs and env var resolution
- [x] Manual: `stepflow-langflow run flow.json '{}' --local --show-flow` displays translated YAML
- [x] Manual: `stepflow-langflow run flow.json '{}' --local --env-file .env` loads env file
- [x] Manual: successful run displays output correctly (result key fix)