### PR TITLE
feat: Add custom docling processing metrics with Grafana panels

### DIFF
--- a/examples/production/k8s/stepflow-docling/worker/deployment.yaml
+++ b/examples/production/k8s/stepflow-docling/worker/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         runAsUser: 1001
       containers:
       - name: docling-step-worker
-        image: localhost/stepflow-docling-worker:o11y-fix-v4
+        image: localhost/stepflow-docling-worker:metrics-v1
         imagePullPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false

--- a/examples/production/k8s/stepflow-o11y/grafana/configmap-dashboard-docling-worker.yaml
+++ b/examples/production/k8s/stepflow-o11y/grafana/configmap-dashboard-docling-worker.yaml
@@ -42,6 +42,200 @@ data:
         {
           "collapsed": false,
           "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+          "id": 500,
+          "panels": [],
+          "title": "Chunking",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 5, "w": 8, "x": 0, "y": 1},
+          "id": 51,
+          "options": {
+            "colorMode": "value", "graphMode": "area", "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {"values": false, "calcs": ["lastNotNull"], "fields": ""},
+            "textMode": "auto"
+          },
+          "pluginVersion": "10.3.3",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "histogram_quantile(0.50, sum(rate(stepflow_docling_chunk_chunks_per_document_bucket[5m])) by (le))",
+              "legendFormat": "p50",
+              "refId": "A"
+            }
+          ],
+          "title": "Chunks per Document (p50)",
+          "type": "stat"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text",
+                "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0,
+                "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none",
+                "hideFrom": {"tooltip": false, "viz": false, "legend": false},
+                "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 1,
+                "pointSize": 5, "scaleDistribution": {"type": "linear"},
+                "showPoints": "never", "spanNulls": false,
+                "stacking": {"group": "A", "mode": "none"},
+                "thresholdsStyle": {"mode": "off"}
+              },
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 5, "w": 16, "x": 8, "y": 1},
+          "id": 52,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "pluginVersion": "10.3.3",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "sum(rate(stepflow_docling_chunk_tokens_total[5m]))",
+              "legendFormat": "tokens/sec",
+              "refId": "A"
+            }
+          ],
+          "title": "Token Throughput",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 6},
+          "id": 600,
+          "panels": [],
+          "title": "Document Processing",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 5, "w": 8, "x": 0, "y": 7},
+          "id": 53,
+          "options": {
+            "colorMode": "value", "graphMode": "area", "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {"values": false, "calcs": ["lastNotNull"], "fields": ""},
+            "textMode": "auto"
+          },
+          "pluginVersion": "10.3.3",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "sum(increase(stepflow_docling_documents_processed_total[5m]))",
+              "refId": "A"
+            }
+          ],
+          "title": "Documents Processed (5m)",
+          "type": "stat"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text",
+                "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0,
+                "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none",
+                "hideFrom": {"tooltip": false, "viz": false, "legend": false},
+                "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 1,
+                "pointSize": 5, "scaleDistribution": {"type": "linear"},
+                "showPoints": "never", "spanNulls": false,
+                "stacking": {"group": "A", "mode": "none"},
+                "thresholdsStyle": {"mode": "off"}
+              },
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 5, "w": 8, "x": 8, "y": 7},
+          "id": 54,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "pluginVersion": "10.3.3",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "histogram_quantile(0.50, sum(rate(stepflow_docling_convert_duration_seconds_bucket[5m])) by (le))",
+              "legendFormat": "p50",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "histogram_quantile(0.95, sum(rate(stepflow_docling_convert_duration_seconds_bucket[5m])) by (le))",
+              "legendFormat": "p95",
+              "refId": "B"
+            }
+          ],
+          "title": "Conversion Duration",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 5, "w": 8, "x": 16, "y": 7},
+          "id": 55,
+          "options": {
+            "colorMode": "value", "graphMode": "area", "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {"values": false, "calcs": ["lastNotNull"], "fields": ""},
+            "textMode": "auto"
+          },
+          "pluginVersion": "10.3.3",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "histogram_quantile(0.50, sum(rate(stepflow_docling_classify_page_count_pages_bucket[5m])) by (le))",
+              "legendFormat": "p50",
+              "refId": "A"
+            }
+          ],
+          "title": "Page Count (p50)",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 12},
           "id": 100,
           "panels": [],
           "title": "Worker HTTP Server",
@@ -65,7 +259,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 6, "w": 6, "x": 0, "y": 1},
+          "gridPos": {"h": 6, "w": 6, "x": 0, "y": 13},
           "id": 1,
           "options": {
             "colorMode": "value",
@@ -100,7 +294,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 6, "w": 6, "x": 6, "y": 1},
+          "gridPos": {"h": 6, "w": 6, "x": 6, "y": 13},
           "id": 2,
           "options": {
             "colorMode": "value",
@@ -135,7 +329,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 6, "w": 6, "x": 12, "y": 1},
+          "gridPos": {"h": 6, "w": 6, "x": 12, "y": 13},
           "id": 3,
           "options": {
             "colorMode": "value",
@@ -173,7 +367,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 6, "w": 6, "x": 18, "y": 1},
+          "gridPos": {"h": 6, "w": 6, "x": 18, "y": 13},
           "id": 4,
           "options": {
             "colorMode": "value",
@@ -229,7 +423,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 7},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 19},
           "id": 5,
           "options": {
             "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true},
@@ -294,7 +488,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 7},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 19},
           "id": 6,
           "options": {
             "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true},
@@ -347,7 +541,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 15},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 27},
           "id": 7,
           "options": {
             "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true},
@@ -412,7 +606,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 15},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 27},
           "id": 8,
           "options": {
             "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true},
@@ -432,7 +626,7 @@ data:
         },
         {
           "collapsed": false,
-          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 23},
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 35},
           "id": 200,
           "panels": [],
           "title": "Load Balancer (Docling)",
@@ -473,7 +667,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 24},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 36},
           "id": 21,
           "options": {
             "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true},
@@ -526,7 +720,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 24},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 36},
           "id": 22,
           "options": {
             "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true},
@@ -572,7 +766,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 6, "w": 12, "x": 0, "y": 32},
+          "gridPos": {"h": 6, "w": 12, "x": 0, "y": 44},
           "id": 23,
           "options": {
             "colorMode": "background",
@@ -629,7 +823,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 6, "w": 12, "x": 12, "y": 32},
+          "gridPos": {"h": 6, "w": 12, "x": 12, "y": 44},
           "id": 24,
           "options": {
             "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true},
@@ -649,7 +843,7 @@ data:
         },
         {
           "collapsed": false,
-          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 38},
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 50},
           "id": 300,
           "panels": [],
           "title": "Blob Storage",
@@ -690,7 +884,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 39},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 51},
           "id": 31,
           "options": {
             "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true},
@@ -761,7 +955,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 39},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 51},
           "id": 32,
           "options": {
             "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true},
@@ -787,7 +981,7 @@ data:
         },
         {
           "collapsed": false,
-          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 47},
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 59},
           "id": 400,
           "panels": [],
           "title": "Traces & Logs",
@@ -795,7 +989,7 @@ data:
         },
         {
           "datasource": {"type": "datasource", "uid": "-- Mixed --"},
-          "gridPos": {"h": 4, "w": 24, "x": 0, "y": 48},
+          "gridPos": {"h": 4, "w": 24, "x": 0, "y": 60},
           "id": 41,
           "options": {
             "mode": "markdown",
@@ -808,7 +1002,7 @@ data:
         },
         {
           "datasource": {"type": "loki", "uid": "loki"},
-          "gridPos": {"h": 10, "w": 24, "x": 0, "y": 52},
+          "gridPos": {"h": 10, "w": 24, "x": 0, "y": 64},
           "id": 42,
           "options": {
             "showTime": true,

--- a/integrations/docling-step-worker/src/docling_step_worker/chunk.py
+++ b/integrations/docling-step-worker/src/docling_step_worker/chunk.py
@@ -28,6 +28,7 @@ from stepflow_py.worker import StepflowContext
 
 from docling_step_worker.blob_utils import get_document_dict
 from docling_step_worker.exceptions import ChunkingError
+from docling_step_worker.metrics import chunk_tokens_total, chunks_per_document
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +105,16 @@ def _run_chunking(
                     chunk_data["metadata"]["page"] = sorted(page_numbers)
 
         chunks.append(chunk_data)
+
+    # Record chunking metrics
+    chunks_per_document.record(len(chunks))
+    total_tokens = sum(
+        chunker.tokenizer.count_tokens(text=c["text"])
+        for c in chunks
+        if c.get("text")
+    )
+    tokenizer_name = opts.get("tokenizer", "default")
+    chunk_tokens_total.add(total_tokens, {"tokenizer": tokenizer_name})
 
     return {
         "chunks": chunks,

--- a/integrations/docling-step-worker/src/docling_step_worker/classify.py
+++ b/integrations/docling-step-worker/src/docling_step_worker/classify.py
@@ -27,6 +27,7 @@ from typing import Any
 from stepflow_py.worker import StepflowContext
 
 from docling_step_worker.blob_utils import get_document_bytes
+from docling_step_worker.metrics import classify_page_count
 
 logger = logging.getLogger(__name__)
 
@@ -142,5 +143,7 @@ async def classify_document(
             "format": "pdf",
             "recommended_config": "default",
         }
+
+    classify_page_count.record(result["page_count"])
 
     return result

--- a/integrations/docling-step-worker/src/docling_step_worker/convert.py
+++ b/integrations/docling-step-worker/src/docling_step_worker/convert.py
@@ -36,6 +36,7 @@ from docling_step_worker.blob_utils import (
     put_document_blob,
 )
 from docling_step_worker.converter_cache import ConverterCache
+from docling_step_worker.metrics import convert_duration, documents_processed
 from docling_step_worker.response_builder import (
     _make_error_item,
     build_convert_response,
@@ -202,6 +203,10 @@ async def convert_document(
         )
     except Exception as e:
         logger.error("Document conversion failed: %s", e)
+        documents_processed.add(
+            1, {"format": filename.rsplit(".", 1)[-1] if "." in filename else "unknown",
+                "pipeline_config": pipeline_config, "status": "failure"}
+        )
         return {
             "document": None,
             "document_dict": None,
@@ -210,6 +215,16 @@ async def convert_document(
             "processing_time": 0.0,
             "timings": {},
         }
+
+    # Record conversion metrics
+    fmt = filename.rsplit(".", 1)[-1] if "." in filename else "unknown"
+    status = result.get("status", "unknown")
+    documents_processed.add(
+        1, {"format": fmt, "pipeline_config": pipeline_config, "status": status}
+    )
+    convert_duration.record(
+        result.get("processing_time", 0.0), {"pipeline_config": pipeline_config}
+    )
 
     # Store document_dict in blob store for downstream consumption
     try:

--- a/integrations/docling-step-worker/src/docling_step_worker/metrics.py
+++ b/integrations/docling-step-worker/src/docling_step_worker/metrics.py
@@ -1,0 +1,54 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Application-level OTel metrics for the docling processing pipeline.
+
+Metrics are exported via the existing MeterProvider (OTLP → OTel Collector →
+Prometheus). Instruments are created at module level so they are singletons
+shared across all component invocations.
+"""
+
+from opentelemetry import metrics
+
+meter = metrics.get_meter("docling-step-worker")
+
+documents_processed = meter.create_counter(
+    "docling.documents.processed",
+    description="Documents processed through conversion",
+    unit="documents",
+)
+
+convert_duration = meter.create_histogram(
+    "docling.convert.duration_seconds",
+    description="Document conversion duration",
+    unit="s",
+)
+
+classify_page_count = meter.create_histogram(
+    "docling.classify.page_count",
+    description="Page count per classified document",
+    unit="pages",
+)
+
+chunks_per_document = meter.create_histogram(
+    "docling.chunk.chunks_per_document",
+    description="Chunks produced per document",
+    unit="chunks",
+)
+
+chunk_tokens_total = meter.create_counter(
+    "docling.chunk.tokens.total",
+    description="Total tokens produced by chunking",
+    unit="tokens",
+)

--- a/sdks/python/stepflow-py/src/stepflow_py/worker/observability.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/observability.py
@@ -199,7 +199,9 @@ def setup_observability(config: ObservabilityConfig | None = None) -> None:
         metric_exporter = OTLPMetricExporter(
             endpoint=config.otlp_endpoint, insecure=True
         )
-        metric_reader = PeriodicExportingMetricReader(metric_exporter)
+        metric_reader = PeriodicExportingMetricReader(
+            metric_exporter, export_interval_millis=10_000
+        )
         meter_provider = MeterProvider(
             resource=resource, metric_readers=[metric_reader]
         )


### PR DESCRIPTION
Add 5 OTel application-level metrics to docling-step-worker for document processing visibility: documents processed (counter), conversion duration (histogram), classify page count (histogram), chunks per document (histogram), and chunk token throughput (counter).

- New metrics.py module with OTel metric instrument definitions
- Instrument classify, convert, and chunk components
- Add two Grafana dashboard rows (Chunking + Document Processing)
- Reduce metric export interval from 60s to 10s

Closes #717