### PR TITLE
feat: Randomize worker heartbeat to avoid thundering herd

### DIFF
--- a/sdks/python/stepflow-py/src/stepflow_py/worker/grpc_worker.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/grpc_worker.py
@@ -46,6 +46,7 @@ import inspect
 import logging
 import math
 import os
+import random
 import traceback
 import uuid
 from typing import TYPE_CHECKING, Any
@@ -518,10 +519,16 @@ async def _heartbeat_loop(
     interval_secs: int,
     run_id: str | None = None,
 ) -> None:
-    """Send periodic heartbeats until cancelled."""
+    """Send periodic heartbeats until cancelled.
+
+    Each sleep is jittered by ±20% to avoid thundering-herd effects when
+    many workers heartbeat against the same orchestrator.
+    """
+    jitter_min = interval_secs * 0.8
+    jitter_max = interval_secs * 1.2
     try:
         while True:
-            await asyncio.sleep(interval_secs)
+            await asyncio.sleep(random.uniform(jitter_min, jitter_max))
             try:
                 response = await stub.TaskHeartbeat(
                     TaskHeartbeatRequest(


### PR DESCRIPTION
## Summary
- Jitter each worker heartbeat sleep by ±20% (`random.uniform(interval * 0.8, interval * 1.2)`) to prevent synchronized heartbeat spikes when many workers connect to the same orchestrator.
- For the default 1s interval, each tick sleeps between 0.8s and 1.2s. The server-side crash detection timeout is 5s, providing ample safety margin.

Closes #744

## Test plan
- [x] All 208 Python SDK tests pass
- [x] All Rust tests pass
- [ ] Verify with multiple concurrent workers that heartbeat load is smoothed