### PR TITLE
feat: Task retry coordination with ComponentHealthTracker

### DIFF
--- a/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_test__test_mock_directory.snap
+++ b/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_test__test_mock_directory.snap
@@ -27,6 +27,9 @@ Running 2 test cases in batch mode (max_concurrency=10)
 tests/mock/error_fail.yaml: 2/2 passed
 ----------
 Running 2 test cases in batch mode (max_concurrency=10)
+tests/mock/error_retry.yaml: 2/2 passed
+----------
+Running 2 test cases in batch mode (max_concurrency=10)
 tests/mock/error_use_default.yaml: 2/2 passed
 ----------
 Running 2 test cases in batch mode (max_concurrency=10)
@@ -37,16 +40,17 @@ tests/mock/lazy_evaluation.yaml: 2/2 passed
 tests/mock/stepflow-config.yml: 0/0 passed
 tests/mock/basic.yaml: 3/3 passed
 tests/mock/error_fail.yaml: 2/2 passed
+tests/mock/error_retry.yaml: 2/2 passed
 tests/mock/error_use_default.yaml: 2/2 passed
 tests/mock/error_use_default_value.yaml: 2/2 passed
 tests/mock/lazy_evaluation.yaml: 2/2 passed
 tests/mock/stepflow-config.yml: Skipped (no test cases)
 
 === Test Summary ===
-Files tested: 6
+Files tested: 7
 Files skipped: 1
-Total test cases: 11
-Passed: 11
+Total test cases: 13
+Passed: 13
 Failed: 0
 
 ----- stderr -----

--- a/stepflow-rs/crates/stepflow-grpc/src/component_health.rs
+++ b/stepflow-rs/crates/stepflow-grpc/src/component_health.rs
@@ -1,0 +1,154 @@
+// Copyright 2025 DataStax Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Per-component consecutive failure tracking (poison pill detection).
+//!
+//! Tracks consecutive task failures per component path. When a component
+//! exceeds the configured threshold, it is flagged as unhealthy. A single
+//! success resets the counter.
+//!
+//! This is observational only — unhealthy status is exposed via metrics and
+//! the API but does not block task dispatch.
+
+use dashmap::DashMap;
+
+/// Default number of consecutive failures before a component is flagged unhealthy.
+const DEFAULT_UNHEALTHY_THRESHOLD: u32 = 5;
+
+/// Tracks per-component consecutive failure counts for poison pill detection.
+pub struct ComponentHealthTracker {
+    /// Component path → consecutive failure count.
+    failures: DashMap<String, u32>,
+    /// Number of consecutive failures before a component is flagged unhealthy.
+    threshold: u32,
+}
+
+impl ComponentHealthTracker {
+    /// Create a new tracker with the default threshold.
+    pub fn new() -> Self {
+        Self {
+            failures: DashMap::new(),
+            threshold: DEFAULT_UNHEALTHY_THRESHOLD,
+        }
+    }
+
+    /// Create a new tracker with a custom threshold.
+    pub fn with_threshold(threshold: u32) -> Self {
+        Self {
+            failures: DashMap::new(),
+            threshold,
+        }
+    }
+
+    /// Record a successful task completion for a component.
+    ///
+    /// Resets the consecutive failure counter to zero.
+    pub fn record_success(&self, component: &str) {
+        self.failures.remove(component);
+    }
+
+    /// Record a failed task completion for a component.
+    ///
+    /// Returns `true` if the component just crossed the unhealthy threshold
+    /// (i.e., was healthy before this failure, unhealthy after).
+    pub fn record_failure(&self, component: &str) -> bool {
+        let mut entry = self.failures.entry(component.to_string()).or_insert(0);
+        *entry += 1;
+        *entry == self.threshold
+    }
+
+    /// Check whether a component is currently flagged as unhealthy.
+    pub fn is_unhealthy(&self, component: &str) -> bool {
+        self.failures
+            .get(component)
+            .is_some_and(|count| *count >= self.threshold)
+    }
+
+    /// Reset a component's failure counter (manual recovery).
+    pub fn reset(&self, component: &str) {
+        self.failures.remove(component);
+    }
+
+    /// Get the current consecutive failure count for a component.
+    pub fn failure_count(&self, component: &str) -> u32 {
+        self.failures.get(component).map_or(0, |c| *c)
+    }
+}
+
+impl Default for ComponentHealthTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_healthy_by_default() {
+        let health = ComponentHealthTracker::new();
+        assert!(!health.is_unhealthy("/python/my_func"));
+        assert_eq!(health.failure_count("/python/my_func"), 0);
+    }
+
+    #[test]
+    fn test_failures_below_threshold_stay_healthy() {
+        let health = ComponentHealthTracker::with_threshold(3);
+        assert!(!health.record_failure("/python/my_func")); // 1
+        assert!(!health.record_failure("/python/my_func")); // 2
+        assert!(!health.is_unhealthy("/python/my_func"));
+        assert_eq!(health.failure_count("/python/my_func"), 2);
+    }
+
+    #[test]
+    fn test_crossing_threshold_returns_true_once() {
+        let health = ComponentHealthTracker::with_threshold(3);
+        assert!(!health.record_failure("/python/f")); // 1
+        assert!(!health.record_failure("/python/f")); // 2
+        assert!(health.record_failure("/python/f")); // 3 — crosses threshold
+        assert!(!health.record_failure("/python/f")); // 4 — already unhealthy
+        assert!(health.is_unhealthy("/python/f"));
+    }
+
+    #[test]
+    fn test_success_resets_counter() {
+        let health = ComponentHealthTracker::with_threshold(3);
+        health.record_failure("/python/f");
+        health.record_failure("/python/f");
+        health.record_success("/python/f");
+        assert!(!health.is_unhealthy("/python/f"));
+        assert_eq!(health.failure_count("/python/f"), 0);
+    }
+
+    #[test]
+    fn test_components_are_independent() {
+        let health = ComponentHealthTracker::with_threshold(2);
+        health.record_failure("/python/a");
+        health.record_failure("/python/b");
+        assert!(!health.is_unhealthy("/python/a"));
+        assert!(!health.is_unhealthy("/python/b"));
+        health.record_failure("/python/a"); // 2 — threshold
+        assert!(health.is_unhealthy("/python/a"));
+        assert!(!health.is_unhealthy("/python/b"));
+    }
+
+    #[test]
+    fn test_manual_reset() {
+        let health = ComponentHealthTracker::with_threshold(2);
+        health.record_failure("/python/f");
+        health.record_failure("/python/f");
+        assert!(health.is_unhealthy("/python/f"));
+        health.reset("/python/f");
+        assert!(!health.is_unhealthy("/python/f"));
+    }
+}

--- a/stepflow-rs/crates/stepflow-grpc/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-grpc/src/lib.rs
@@ -36,6 +36,7 @@ mod built_info {
 }
 
 pub mod blob_binary_routes;
+pub mod component_health;
 pub mod conversions;
 pub mod error;
 pub mod grpc_plugin_config;
@@ -59,6 +60,7 @@ pub mod rest {
 }
 
 // Re-export commonly used types at the crate root.
+pub use component_health::ComponentHealthTracker;
 pub use grpc_plugin_config::PullPluginConfig;
 pub use grpc_server::StepflowGrpcServer;
 pub use in_memory_transport::InMemoryTaskTransport;

--- a/stepflow-rs/crates/stepflow-grpc/src/pending_tasks.rs
+++ b/stepflow-rs/crates/stepflow-grpc/src/pending_tasks.rs
@@ -75,6 +75,8 @@ use stepflow_core::{FlowError, FlowResult};
 use stepflow_plugin::TaskRegistry;
 use tokio::time::MissedTickBehavior;
 
+use crate::component_health::ComponentHealthTracker;
+
 /// Heartbeat crash-detection timeout. Executing tasks that do not send a
 /// heartbeat or CompleteTask within this window are presumed crashed.
 pub const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -153,6 +155,8 @@ pub struct PendingTasks {
     heartbeat_tracker: HeartbeatTracker,
     /// Shared task registry for result delivery.
     task_registry: Arc<TaskRegistry>,
+    /// Per-component consecutive failure tracking (poison pill detection).
+    component_health: Arc<ComponentHealthTracker>,
     /// Sender for queue-timeout deadlines. Per-task timeouts are pushed at
     /// [`track`] time; the `DelayQueue` in the scanner yields them in
     /// deadline order regardless of push order.
@@ -195,6 +199,7 @@ impl PendingTasks {
             tasks: DashMap::new(),
             heartbeat_tracker: HeartbeatTracker::new(),
             task_registry,
+            component_health: Arc::new(ComponentHealthTracker::new()),
             deadline_tx,
             scanner: Mutex::new(None),
         });
@@ -341,9 +346,20 @@ impl PendingTasks {
             match &result {
                 FlowResult::Success(_) => {
                     stepflow_observability::metrics::record_task_success(&entry.component);
+                    self.component_health.record_success(&entry.component);
                 }
                 FlowResult::Failed(_) => {
                     stepflow_observability::metrics::record_task_failure(&entry.component);
+                    if self.component_health.record_failure(&entry.component) {
+                        log::warn!(
+                            "Component '{}' flagged unhealthy after {} consecutive failures",
+                            entry.component,
+                            self.component_health.failure_count(&entry.component),
+                        );
+                        stepflow_observability::metrics::record_component_unhealthy(
+                            &entry.component,
+                        );
+                    }
                 }
             }
         }
@@ -357,6 +373,11 @@ impl PendingTasks {
     /// Number of tasks currently tracked (any phase).
     pub fn pending_count(&self) -> usize {
         self.tasks.len()
+    }
+
+    /// Per-component health tracker for poison pill detection.
+    pub fn component_health(&self) -> &ComponentHealthTracker {
+        &self.component_health
     }
 
     // --- Internal ---

--- a/stepflow-rs/crates/stepflow-grpc/tests/grpc_server_test.rs
+++ b/stepflow-rs/crates/stepflow-grpc/tests/grpc_server_test.rs
@@ -31,7 +31,7 @@ use stepflow_grpc::proto::stepflow::v1::orchestrator_service_client::Orchestrato
 use stepflow_grpc::proto::stepflow::v1::tasks_service_client::TasksServiceClient;
 use stepflow_grpc::proto::stepflow::v1::{
     CompleteTaskRequest, ComponentExecuteResponse, ComponentInfo, GetBlobRequest, PullTasksRequest,
-    PutBlobRequest, TaskAssignment, TaskError, TaskHeartbeatRequest, TaskStatus,
+    PutBlobRequest, TaskAssignment, TaskError, TaskErrorCode, TaskHeartbeatRequest, TaskStatus,
 };
 use stepflow_plugin::TaskRegistry;
 
@@ -582,4 +582,83 @@ async fn test_task_heartbeat_lifecycle() {
         .into_inner();
     assert!(resp.should_abort);
     assert_eq!(resp.status, TaskStatus::NotFound as i32);
+}
+
+#[tokio::test]
+async fn test_component_health_tracks_consecutive_failures() {
+    let (server, _pq, _nq, address, task_registry) = setup_two_queue_server().await;
+
+    let channel = endpoint(&address).connect().await.unwrap();
+    let mut orch_client = OrchestratorServiceClient::new(channel);
+
+    let component = "/python/flaky";
+    let health = server.pending_tasks().component_health();
+
+    // Component starts healthy
+    assert!(!health.is_unhealthy(component));
+
+    // Send 5 consecutive failures (default threshold)
+    for i in 0..5 {
+        let task_id = format!("health-fail-{i}");
+        let _rx = task_registry.register(task_id.clone());
+        server.pending_tasks().track(
+            task_id.clone(),
+            component.to_string(),
+            Duration::from_secs(30),
+            None,
+        );
+
+        orch_client
+            .complete_task(CompleteTaskRequest {
+                task_id,
+                result: Some(
+                    stepflow_grpc::proto::stepflow::v1::complete_task_request::Result::Error(
+                        TaskError {
+                            code: TaskErrorCode::ComponentFailed.into(),
+                            message: format!("failure {i}"),
+                            data: None,
+                        },
+                    ),
+                ),
+                run_id: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    // Component should now be unhealthy
+    assert!(health.is_unhealthy(component));
+    assert_eq!(health.failure_count(component), 5);
+
+    // A success resets it
+    let task_id = "health-success".to_string();
+    let _rx = task_registry.register(task_id.clone());
+    server.pending_tasks().track(
+        task_id.clone(),
+        component.to_string(),
+        Duration::from_secs(30),
+        None,
+    );
+
+    orch_client
+        .complete_task(CompleteTaskRequest {
+            task_id,
+            result: Some(
+                stepflow_grpc::proto::stepflow::v1::complete_task_request::Result::Response(
+                    ComponentExecuteResponse {
+                        output: Some(prost_wkt_types::Value {
+                            kind: Some(prost_wkt_types::value::Kind::StringValue(
+                                "recovered".to_string(),
+                            )),
+                        }),
+                    },
+                ),
+            ),
+            run_id: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(!health.is_unhealthy(component));
+    assert_eq!(health.failure_count(component), 0);
 }

--- a/stepflow-rs/crates/stepflow-observability/src/metrics.rs
+++ b/stepflow-rs/crates/stepflow-observability/src/metrics.rs
@@ -174,6 +174,24 @@ pub fn record_step_retries_exhausted(reason: &str, component: &str) {
 }
 
 // =========================================================================
+// Component Health (Poison Pill Detection)
+// =========================================================================
+
+/// Components that crossed the consecutive failure threshold.
+static COMPONENT_UNHEALTHY: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    let meter = global::meter("stepflow");
+    meter
+        .u64_counter("component.unhealthy_total")
+        .with_description("Components flagged unhealthy (consecutive failure threshold crossed)")
+        .build()
+});
+
+/// Record that a component crossed the unhealthy threshold.
+pub fn record_component_unhealthy(component: &str) {
+    COMPONENT_UNHEALTHY.add(1, &[KeyValue::new("component", component.to_string())]);
+}
+
+// =========================================================================
 // Pending Component Executions (Backpressure)
 // =========================================================================
 

--- a/tests/mock/error_retry.yaml
+++ b/tests/mock/error_retry.yaml
@@ -1,0 +1,35 @@
+schema: https://stepflow.org/schemas/v1/flow.json
+inputSchema:
+  type: object
+outputSchema:
+  type: object
+steps:
+- id: retry_step
+  component: /mock/error
+  onError:
+    action: retry
+    maxRetries: 2
+  input:
+    mode:
+      $input: mode
+output:
+  result:
+    $step: retry_step
+test:
+  cases:
+  - name: retry exhaustion fails after max retries
+    input:
+      mode: error
+    output:
+      outcome: failed
+      error:
+        code: COMPONENT_FAILED
+        message: error
+  - name: success case does not retry
+    input:
+      mode: succeed
+    output:
+      outcome: success
+      result:
+        result:
+          output: succeeded


### PR DESCRIPTION
## Summary

Closes #742.

- **ComponentHealthTracker**: Per-component consecutive failure tracking (poison pill detection). When a component fails 5 times consecutively across different tasks, it is flagged as unhealthy via `component.unhealthy_total` metric and a warning log. A single success resets the counter. Observational only — does not block dispatch.
- **`component.unhealthy_total` metric**: New OpenTelemetry counter emitted when a component crosses the unhealthy threshold.
- **`onError: retry` e2e test**: New mock test workflow (`tests/mock/error_retry.yaml`) that validates retry exhaustion and success paths.

### Already implemented (prior PRs on this branch)

The bulk of the retry coordination infrastructure was already in place:
- `FlowError` uses `TaskErrorCode` (protobuf enum) — no integer codes
- `CompleteTask` → `FlowError` conversion preserves `TaskErrorCode` 1:1
- `maybe_retry_task()` handles transport + component retries with backoff
- `onError: retry` wired into retry decisions via step config
- Retry metrics (`step.retries_total`, `step.retries_exhausted_total`) already recorded

## Test plan

- [x] `cargo test -p stepflow-grpc` — unit tests for ComponentHealthTracker + integration test for consecutive failure tracking through gRPC CompleteTask
- [x] `cargo test` — full suite passes (including new mock retry e2e test)
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean