### PR TITLE
fix: Detect malformed flow files in `stepflow test` via schema header

### DIFF
--- a/examples/production/k8s/ingestion_flow.yaml
+++ b/examples/production/k8s/ingestion_flow.yaml
@@ -3,83 +3,83 @@ name: OpenSearch Ingestion Flow
 description: null
 version: null
 schemas:
+  type: object
   defs: {}
-  input: null
-  output: null
-  variables:
-    type: object
-    properties:
-      OLLAMA_BASE_URL:
-        type:
-        - string
-        - 'null'
-        default: null
-      DOCLING_SERVE_URL:
-        type:
-        - string
-        - 'null'
-        default: null
-      OWNER:
-        type:
-        - string
-        - 'null'
-        default: null
-      OPENAI_API_KEY:
-        type:
-        - string
-        - 'null'
-        default: null
-      WATSONX_API_KEY:
-        type:
-        - string
-        - 'null'
-        default: null
-      WATSONX_PROJECT_ID:
-        type:
-        - string
-        - 'null'
-        default: null
-      OWNER_NAME:
-        type:
-        - string
-        - 'null'
-        default: null
-      CONNECTOR_TYPE:
-        type:
-        - string
-        - 'null'
-        default: null
-      OWNER_EMAIL:
-        type:
-        - string
-        - 'null'
-        default: null
-      FILENAME:
-        type:
-        - string
-        - 'null'
-        default: null
-      FILESIZE:
-        type:
-        - string
-        - 'null'
-        default: null
-      MIMETYPE:
-        type:
-        - string
-        - 'null'
-        default: null
-      SELECTED_EMBEDDING_MODEL:
-        type:
-        - string
-        - 'null'
-        default: null
-      OPENSEARCH_URL:
-        type:
-        - string
-        - 'null'
-        default: null
-  steps: {}
+  properties:
+    variables:
+      type: object
+      properties:
+        OLLAMA_BASE_URL:
+          type:
+          - string
+          - 'null'
+          default: null
+        DOCLING_SERVE_URL:
+          type:
+          - string
+          - 'null'
+          default: null
+        OWNER:
+          type:
+          - string
+          - 'null'
+          default: null
+        OPENAI_API_KEY:
+          type:
+          - string
+          - 'null'
+          default: null
+        WATSONX_API_KEY:
+          type:
+          - string
+          - 'null'
+          default: null
+        WATSONX_PROJECT_ID:
+          type:
+          - string
+          - 'null'
+          default: null
+        OWNER_NAME:
+          type:
+          - string
+          - 'null'
+          default: null
+        CONNECTOR_TYPE:
+          type:
+          - string
+          - 'null'
+          default: null
+        OWNER_EMAIL:
+          type:
+          - string
+          - 'null'
+          default: null
+        FILENAME:
+          type:
+          - string
+          - 'null'
+          default: null
+        FILESIZE:
+          type:
+          - string
+          - 'null'
+          default: null
+        MIMETYPE:
+          type:
+          - string
+          - 'null'
+          default: null
+        SELECTED_EMBEDDING_MODEL:
+          type:
+          - string
+          - 'null'
+          default: null
+        OPENSEARCH_URL:
+          type:
+          - string
+          - 'null'
+          default: null
+    steps: {}
 steps:
 - id: langflow_EmbeddingModel-E0hvR
   component: /langflow/core/lfx/components/models_and_agents/embedding_model/EmbeddingModelComponent

--- a/stepflow-rs/crates/stepflow-cli/src/test.rs
+++ b/stepflow-rs/crates/stepflow-cli/src/test.rs
@@ -525,13 +525,17 @@ const FLOW_SCHEMA_URL: &str = "https://stepflow.org/schemas/v1/flow.json";
 
 /// Check whether a YAML file declares itself as a Stepflow flow by looking for
 /// the `schema` key with the Stepflow flow schema URL.
-fn has_flow_schema(path: &Path) -> Result<bool> {
-    let content =
-        fs::read_to_string(path).change_context_lazy(|| MainError::InvalidFile(path.to_owned()))?;
-    let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(&content)
-        .change_context_lazy(|| MainError::InvalidFile(path.to_owned()))?;
-    let schema = value.get("schema").and_then(|v| v.as_str());
-    Ok(schema == Some(FLOW_SCHEMA_URL))
+///
+/// Returns `false` if the file cannot be read or parsed as single-document YAML
+/// (e.g., multi-document K8s manifests), since such files cannot be flow files.
+fn has_flow_schema(path: &Path) -> bool {
+    let Ok(content) = fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(value) = serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&content) else {
+        return false;
+    };
+    value.get("schema").and_then(|v| v.as_str()) == Some(FLOW_SCHEMA_URL)
 }
 
 fn load_flow(path: &Path) -> Result<Option<Arc<Flow>>> {
@@ -544,7 +548,7 @@ fn load_flow(path: &Path) -> Result<Option<Arc<Flow>>> {
             // Check if the file declares itself as a flow via the schema key.
             // If it does, this is a broken flow file and should be reported as an error.
             // If not, it's just a non-flow YAML file and should be skipped.
-            if has_flow_schema(path)? {
+            if has_flow_schema(path) {
                 return Err(e).change_context_lazy(|| MainError::InvalidFile(path.to_owned()));
             }
             return Ok(None);
@@ -795,6 +799,25 @@ mod tests {
 
         let result = load_flow(&path).unwrap();
         assert!(result.is_none(), "Non-flow YAML should be skipped");
+    }
+
+    #[test]
+    fn test_load_flow_skips_multi_document_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi_doc.yaml");
+        // Multi-document YAML (e.g., K8s manifests) cannot be parsed as a single
+        // serde_yaml_ng::Value, so has_flow_schema returns false and we skip.
+        std::fs::write(
+            &path,
+            "apiVersion: v1\nkind: Namespace\n---\napiVersion: v1\nkind: Namespace\n",
+        )
+        .unwrap();
+
+        let result = load_flow(&path).unwrap();
+        assert!(
+            result.is_none(),
+            "Multi-document YAML should be skipped, not errored"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `stepflow test` now distinguishes between non-flow YAML files and broken flow files by checking for the `schema: https://stepflow.org/schemas/v1/flow.json` key
- Files with the schema header that fail deserialization are reported as `files_error` (failing CI) instead of being silently skipped
- Non-flow YAML files (K8s manifests, configs, etc.) without the schema header continue to be skipped as before

Closes #787

## Test plan

- [x] `test_load_flow_skips_non_flow_yaml` — non-flow YAML without schema header is skipped
- [x] `test_load_flow_errors_on_malformed_flow_with_schema` — malformed flow with schema header returns error
- [x] `test_load_flow_succeeds_for_valid_flow` — valid flow file loads correctly
- [x] All existing tests pass (`cargo test -p stepflow-cli --lib`)
- [x] Clippy clean