### PR TITLE
refactor: Prep K8s manifests for Helm parameterization (#788)

### DIFF
--- a/examples/production/k8s/CLAUDE.md
+++ b/examples/production/k8s/CLAUDE.md
@@ -40,8 +40,9 @@ stepflow-docling-grpc/
 ├── kind-config.yaml              # Kind cluster with NodePort 30501→5001
 ├── namespaces.yaml               # stepflow-docling-grpc + stepflow-o11y
 ├── orchestrator/
-│   ├── configmap.yaml            # stepflow-config.yml (pull plugin) + flow YAML
-│   ├── deployment.yaml           # 2-container pod: facade + stepflow-server
+│   ├── configmap-stepflow-config.yaml  # stepflow-config.yml (pull plugin, routes, blob API)
+│   ├── configmap-flow.yaml            # docling-process-document.yaml (workflow definition)
+│   ├── deployment.yaml           # 2-container pod: facade + stepflow-server (projected volume)
 │   └── service.yaml              # NodePort 30501→5001, ClusterIP 7840+7837
 ├── worker/
 │   └── deployment.yaml           # 3 replicas, no ports, file-based probes
@@ -57,15 +58,15 @@ stepflow-docling-grpc/
 |----------|-------|---------|
 | `STEPFLOW_BIND_ADDRESS` | `0.0.0.0:7837` | gRPC server binds all interfaces for external workers |
 | `STEPFLOW_ORCHESTRATOR_URL` | `$(POD_IP):7837` | Advertised callback URL (pod IP, not service DNS) |
-| `STEPFLOW_OTLP_ENDPOINT` | `http://otel-collector.stepflow-o11y...:4317` | OTel trace/metric export |
+| `STEPFLOW_OTLP_ENDPOINT` | `http://otel-collector.stepflow-o11y.svc.cluster.local:4317` | OTel trace/metric export (cross-namespace FQDN) |
 
 **Worker container:**
 | Variable | Value | Purpose |
 |----------|-------|---------|
 | `STEPFLOW_TRANSPORT` | `grpc` | Selects pull-based gRPC transport |
-| `STEPFLOW_TASKS_URL` | `docling-orchestrator...:7837` | Orchestrator gRPC endpoint |
+| `STEPFLOW_TASKS_URL` | `docling-orchestrator:7837` | Orchestrator gRPC endpoint (same-namespace short name) |
 | `STEPFLOW_QUEUE_NAME` | `docling` | Must match plugin config `queueName` |
-| `STEPFLOW_BLOB_API_URL` | `http://docling-orchestrator...:7840/api/v1/blobs` | HTTP blob store for `$blob` refs |
+| `STEPFLOW_BLOB_API_URL` | `http://docling-orchestrator:7840/api/v1/blobs` | HTTP blob store for `$blob` refs (same-namespace short name) |
 | `STEPFLOW_MAX_CONCURRENT` | `1` | Tasks per worker pod (docling is CPU-heavy) |
 
 ### Worker Probes
@@ -79,7 +80,7 @@ gRPC workers have **no HTTP server**, so K8s probes use a file sentinel:
 
 ## Building Images
 
-All three images are built from the repo root. The Kind cluster name is `stepflow`.
+All three images are built from the repo root. The Kind cluster name is `stepflow-docling-grpc`.
 
 ### 1. stepflow-server (Rust orchestrator)
 
@@ -91,7 +92,7 @@ docker build --load \
   -f stepflow-rs/release/Dockerfile.stepflow-server.build \
   -t localhost/stepflow-server:alpine-0.10.0 .
 
-kind load docker-image localhost/stepflow-server:alpine-0.10.0 --name stepflow
+kind load docker-image localhost/stepflow-server:alpine-0.10.0 --name stepflow-docling-grpc
 ```
 
 Build takes 5-10 minutes from scratch; subsequent builds use Docker layer caching. The Dockerfile auto-detects architecture (x86_64/aarch64).
@@ -106,7 +107,7 @@ docker build --load \
   -f docker/Dockerfile.facade \
   -t localhost/docling-facade:grpc-v1 .
 
-kind load docker-image localhost/docling-facade:grpc-v1 --name stepflow
+kind load docker-image localhost/docling-facade:grpc-v1 --name stepflow-docling-grpc
 ```
 
 ### 3. docling-proto-step-worker (Python gRPC worker)
@@ -119,7 +120,7 @@ docker build --load \
   -f integrations/docling-proto-step-worker/docker/Dockerfile \
   -t localhost/stepflow-docling-proto-worker:latest .
 
-kind load docker-image localhost/stepflow-docling-proto-worker:latest --name stepflow
+kind load docker-image localhost/stepflow-docling-proto-worker:latest --name stepflow-docling-grpc
 ```
 
 Build is fast (~1 min) if the base image is cached. Worker runs as UID 1001 (matches base image).
@@ -157,8 +158,8 @@ Shared across all deployments. Namespace: `stepflow-o11y`.
 | OTel Collector | Receives OTLP, exports to Prometheus/Jaeger/Loki | `:4317` (gRPC), `:4318` (HTTP) |
 | Prometheus | Metrics storage, scraped from OTel Collector `:8889` | `localhost:9090` (port-forward) |
 | Jaeger | Distributed traces | `localhost:16686` (port-forward) |
-| Loki + Promtail | Log aggregation | Queried via Grafana |
-| Grafana | Dashboards | `localhost:30001` (NodePort) or port-forward `:3000` |
+| Loki + Promtail | Log aggregation (scrapes `stepflow` + `stepflow-docling-grpc` namespaces) | Queried via Grafana |
+| Grafana | Dashboards | `localhost:3000` (NodePort 30001→host 3000) |
 
 ### Grafana Dashboards
 
@@ -203,6 +204,22 @@ All metrics carry a `queue_name` label.
 ---
 
 ## Conventions
+
+### Service DNS Names
+
+Use **short names** for same-namespace references and **FQDNs** for cross-namespace references:
+- Same-namespace: `docling-orchestrator:7837`, `otel-collector:4317`, `loki:3100`
+- Cross-namespace: `otel-collector.stepflow-o11y.svc.cluster.local:4317` (app → o11y)
+
+This minimizes the namespace parameterization surface for Helm migration — only cross-namespace FQDNs need templating.
+
+### ConfigMap Split
+
+The orchestrator uses two ConfigMaps combined via a `projected` volume:
+- `docling-orchestrator-config` — infrastructure config (`stepflow-config.yml`): plugins, routes, blob API, storage, retry. Will need Helm templating.
+- `docling-flow-config` — workflow definition (`docling-process-document.yaml`): opaque application logic. Swap without touching infrastructure config.
+
+Both mount at `/app/config` via a single projected volume, so container volumeMounts are unchanged.
 
 ### Container Users
 - Dockerfiles: Create named user `stepflow` with UID 1000 (`useradd -m -u 1000 stepflow`)
@@ -268,7 +285,7 @@ OTel metrics are exported through the Collector's Prometheus exporter:
 | `exported_job` | OTel: `{service.namespace}/{service.name}` | `stepflow-docling-grpc/stepflow-server` |
 | `exported_instance` | OTel: `service.instance.id` | `docling-orchestrator-5c96688ccf-tmr5s` |
 | `job` | Prometheus scrape config | `stepflow-via-otel` |
-| `instance` | Prometheus scrape target | `otel-collector.stepflow-o11y:8889` |
+| `instance` | Prometheus scrape target | `otel-collector:8889` |
 
 **Dashboard queries must use `exported_job`** for filtering OTel-sourced metrics.
 
@@ -327,7 +344,7 @@ kubectl scale deployment prometheus -n stepflow-o11y --replicas=1
 When code changes don't take effect in a pod:
 
 1. Rebuild with `--load`: `docker build --load -t localhost/image:tag ...`
-2. Load into Kind: `kind load docker-image localhost/image:tag --name stepflow`
+2. Load into Kind: `kind load docker-image localhost/image:tag --name stepflow-docling-grpc`
 3. Restart deployment: `kubectl rollout restart deployment/name -n namespace`
 4. Verify new pod starts: `kubectl get pods -n namespace -w`
 

--- a/examples/production/k8s/stepflow-docling-grpc/orchestrator/configmap-flow.yaml
+++ b/examples/production/k8s/stepflow-docling-grpc/orchestrator/configmap-flow.yaml
@@ -12,50 +12,18 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+# Workflow definition — opaque application logic, no Helm templating needed.
+# Swap this file to change the workflow without touching infrastructure config.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: docling-orchestrator-config
+  name: docling-flow-config
   namespace: stepflow-docling-grpc
   labels:
     app: docling-orchestrator
     component: orchestration
 data:
-  stepflow-config.yml: |
-    # Stepflow Configuration for docling gRPC parity testbed
-    # Uses pull-based (gRPC) transport — no load balancer needed
-
-    plugins:
-      builtin:
-        type: builtin
-
-      docling:
-        type: pull
-        queueName: docling
-
-    routes:
-      "/docling/{*component}":
-        - plugin: docling
-
-      "/builtin/{*component}":
-        - plugin: builtin
-
-    # Blob API URL exposed to workers so they can resolve $blob references.
-    # The orchestrator auto-configures to 127.0.0.1 which is unreachable from
-    # worker pods; this overrides it with the cluster-internal service address.
-    blobApi:
-      url: "http://docling-orchestrator.stepflow-docling-grpc.svc.cluster.local:7840/api/v1/blobs"
-
-    storageConfig:
-      type: inMemory
-
-    retry:
-      transportMaxRetries: 60
-      backoff:
-        type: fibonacci
-        minDelayMs: 2000
-        maxDelayMs: 15000
-
   docling-process-document.yaml: |
     schema: https://stepflow.org/schemas/v1/flow.json
     name: docling-process-document

--- a/examples/production/k8s/stepflow-docling-grpc/orchestrator/configmap-stepflow-config.yaml
+++ b/examples/production/k8s/stepflow-docling-grpc/orchestrator/configmap-stepflow-config.yaml
@@ -1,0 +1,63 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Infrastructure configuration for the orchestrator.
+# Contains plugin config, routes, blob API, storage, and retry settings.
+# This is the config that will need Helm templating (parameterized values).
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: docling-orchestrator-config
+  namespace: stepflow-docling-grpc
+  labels:
+    app: docling-orchestrator
+    component: orchestration
+data:
+  stepflow-config.yml: |
+    # Stepflow Configuration for docling gRPC parity testbed
+    # Uses pull-based (gRPC) transport — no load balancer needed
+
+    plugins:
+      builtin:
+        type: builtin
+
+      docling:
+        type: pull
+        # NOTE: queueName must match STEPFLOW_QUEUE_NAME in worker deployment.
+        # Both are "docling" — a single Helm value should feed both locations.
+        queueName: docling
+
+    routes:
+      "/docling/{*component}":
+        - plugin: docling
+
+      "/builtin/{*component}":
+        - plugin: builtin
+
+    # Blob API URL exposed to workers so they can resolve $blob references.
+    # The orchestrator auto-configures to 127.0.0.1 which is unreachable from
+    # worker pods; this overrides it with the cluster-internal service address.
+    blobApi:
+      url: "http://docling-orchestrator:7840/api/v1/blobs"
+
+    storageConfig:
+      type: inMemory
+
+    retry:
+      transportMaxRetries: 60
+      backoff:
+        type: fibonacci
+        minDelayMs: 2000
+        maxDelayMs: 15000

--- a/examples/production/k8s/stepflow-docling-grpc/orchestrator/deployment.yaml
+++ b/examples/production/k8s/stepflow-docling-grpc/orchestrator/deployment.yaml
@@ -45,8 +45,12 @@ spec:
         runAsUser: 1000
       volumes:
       - name: config
-        configMap:
-          name: docling-orchestrator-config
+        projected:
+          sources:
+          - configMap:
+              name: docling-orchestrator-config
+          - configMap:
+              name: docling-flow-config
       # No init container — workers connect to orchestrator, not the other way around
       containers:
       # Container 1: docling-facade — docling-serve compatible HTTP API

--- a/examples/production/k8s/stepflow-docling-grpc/orchestrator/service.yaml
+++ b/examples/production/k8s/stepflow-docling-grpc/orchestrator/service.yaml
@@ -13,7 +13,7 @@
 # the License.
 
 # Orchestrator service — exposes facade (5001), HTTP API (7840), and gRPC (7837).
-# NodePort 30080 maps to facade port for kind cluster access.
+# NodePort 30501 maps to facade port for kind cluster access (matches kind-config.yaml).
 # gRPC port 7837 exposed as ClusterIP for worker pods to connect.
 
 apiVersion: v1
@@ -33,7 +33,7 @@ spec:
     port: 5001
     targetPort: facade
     protocol: TCP
-    nodePort: 30080
+    nodePort: 30501
   - name: http
     port: 7840
     targetPort: http

--- a/examples/production/k8s/stepflow-docling-grpc/worker/deployment.yaml
+++ b/examples/production/k8s/stepflow-docling-grpc/worker/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           value: "grpc"
         # gRPC TasksService address (orchestrator's pull-plugin gRPC server)
         - name: STEPFLOW_TASKS_URL
-          value: "docling-orchestrator.stepflow-docling-grpc.svc.cluster.local:7837"
+          value: "docling-orchestrator:7837"
         # Queue name matching orchestrator plugin config
         - name: STEPFLOW_QUEUE_NAME
           value: "docling"
@@ -63,7 +63,7 @@ spec:
           value: "4"
         # Blob store — explicit URL so workers can resolve $blob refs
         - name: STEPFLOW_BLOB_API_URL
-          value: "http://docling-orchestrator.stepflow-docling-grpc.svc.cluster.local:7840/api/v1/blobs"
+          value: "http://docling-orchestrator:7840/api/v1/blobs"
         # Pod metadata
         - name: POD_NAME
           valueFrom:

--- a/examples/production/k8s/stepflow-o11y/grafana/configmap-datasources.yaml
+++ b/examples/production/k8s/stepflow-o11y/grafana/configmap-datasources.yaml
@@ -32,7 +32,7 @@ data:
         type: prometheus
         uid: prometheus
         access: proxy
-        url: http://prometheus.stepflow-o11y.svc.cluster.local:9090
+        url: http://prometheus:9090
         isDefault: true
         editable: true
         jsonData:
@@ -48,7 +48,7 @@ data:
         type: loki
         uid: loki
         access: proxy
-        url: http://loki.stepflow-o11y.svc.cluster.local:3100
+        url: http://loki:3100
         editable: true
         jsonData:
           maxLines: 1000
@@ -67,7 +67,7 @@ data:
       - name: Jaeger
         type: jaeger
         access: proxy
-        url: http://jaeger.stepflow-o11y.svc.cluster.local:16686
+        url: http://jaeger:16686
         uid: jaeger
         editable: true
         jsonData:

--- a/examples/production/k8s/stepflow-o11y/otel-collector/configmap.yaml
+++ b/examples/production/k8s/stepflow-o11y/otel-collector/configmap.yaml
@@ -78,7 +78,7 @@ data:
     exporters:
       # Export traces to Jaeger
       otlp/jaeger:
-        endpoint: jaeger.stepflow-o11y.svc.cluster.local:4317
+        endpoint: jaeger:4317
         tls:
           insecure: true
 
@@ -96,7 +96,7 @@ data:
 
       # Export logs to Loki
       loki:
-        endpoint: http://loki.stepflow-o11y.svc.cluster.local:3100/loki/api/v1/push
+        endpoint: http://loki:3100/loki/api/v1/push
 
       # Logging exporter for debugging (outputs to collector's stdout)
       logging:

--- a/examples/production/k8s/stepflow-o11y/prometheus/configmap.yaml
+++ b/examples/production/k8s/stepflow-o11y/prometheus/configmap.yaml
@@ -39,7 +39,7 @@ data:
       # Scrape OpenTelemetry Collector's own metrics
       - job_name: 'otel-collector'
         static_configs:
-          - targets: ['otel-collector.stepflow-o11y.svc.cluster.local:8888']
+          - targets: ['otel-collector:8888']
             labels:
               component: 'otel-collector'
 
@@ -47,28 +47,28 @@ data:
       # This is where Stepflow application metrics will appear
       - job_name: 'stepflow-via-otel'
         static_configs:
-          - targets: ['otel-collector.stepflow-o11y.svc.cluster.local:8889']
+          - targets: ['otel-collector:8889']
             labels:
               source: 'otlp'
 
       # Jaeger metrics
       - job_name: 'jaeger'
         static_configs:
-          - targets: ['jaeger.stepflow-o11y.svc.cluster.local:14269']
+          - targets: ['jaeger:14269']
             labels:
               component: 'jaeger'
 
       # Loki metrics
       - job_name: 'loki'
         static_configs:
-          - targets: ['loki.stepflow-o11y.svc.cluster.local:3100']
+          - targets: ['loki:3100']
             labels:
               component: 'loki'
 
       # Grafana metrics
       - job_name: 'grafana'
         static_configs:
-          - targets: ['grafana.stepflow-o11y.svc.cluster.local:3000']
+          - targets: ['grafana:3000']
             labels:
               component: 'grafana'
 

--- a/examples/production/k8s/stepflow-o11y/promtail/configmap.yaml
+++ b/examples/production/k8s/stepflow-o11y/promtail/configmap.yaml
@@ -27,16 +27,17 @@ data:
       filename: /tmp/positions.yaml
 
     clients:
-      - url: http://loki.stepflow-o11y.svc.cluster.local:3100/loki/api/v1/push
+      - url: http://loki:3100/loki/api/v1/push
 
     scrape_configs:
-      # Scrape logs from all pods in stepflow namespace
+      # Scrape logs from all stepflow application pods
       - job_name: kubernetes-pods
         kubernetes_sd_configs:
           - role: pod
             namespaces:
               names:
                 - stepflow
+                - stepflow-docling-grpc
         pipeline_stages:
           - cri: {}  # Parse CRI format (containerd)
           # Extract trace context from key=value format logs


### PR DESCRIPTION
Reduce the parameterization surface of the stepflow-docling-grpc and stepflow-o11y K8s manifests ahead of Helm migration. All changes were validated end-to-end: full cluster teardown/recreate, o11y deploy, application deploy, 6/6 parity tests passing, and telemetry verification (traces in Jaeger, metrics in Prometheus, logs in Loki).

Shorten same-namespace FQDNs:
- stepflow-o11y: Replace 11 intra-namespace FQDNs (e.g. jaeger.stepflow-o11y.svc.cluster.local:4317 -> jaeger:4317) across otel-collector, prometheus, promtail, and grafana configmaps.
- stepflow-docling-grpc: Replace 3 intra-namespace FQDNs in orchestrator configmap and worker deployment (e.g. docling-orchestrator:7837 instead of docling-orchestrator.stepflow-docling-grpc.svc.cluster.local:7837).
- Cross-namespace refs (app -> otel-collector.stepflow-o11y) remain as FQDNs since they genuinely require them.

Split orchestrator ConfigMap:
- configmap.yaml (combined) -> configmap-stepflow-config.yaml (infrastructure: plugins, routes, blob API, storage, retry) + configmap-flow.yaml (workflow definition: opaque application logic).
- Deployment updated to use a projected volume combining both ConfigMaps at the same /app/config mount point. No container changes needed.
- Enables swapping workflow definitions without touching infra config, and cleanly separates what needs Helm templating from what does not.

Fix NodePort mismatch:
- orchestrator/service.yaml had nodePort: 30080 but kind-config.yaml maps host port 5001 to container port 30501. Updated to 30501.

Extend Promtail scrape scope:
- Add stepflow-docling-grpc namespace to Promtail's kubernetes_sd_configs so container logs from application pods are shipped to Loki alongside the existing OTLP log pipeline.

Update CLAUDE.md:
- Document service DNS naming convention (short names for same-namespace, FQDNs for cross-namespace).
- Document ConfigMap split and projected volume pattern.
- Update Kind cluster name from stepflow to stepflow-docling-grpc in all kind load commands.
- Correct Grafana access URL, Prometheus instance label, worker env var values, and Promtail namespace coverage.