### PR TITLE
fix: Install protoc v28.3 in cross builds for proto3 optional support

### DIFF
--- a/scripts/check-proto.sh
+++ b/scripts/check-proto.sh
@@ -16,10 +16,11 @@
 # CI check script for Protocol Buffer definitions.
 #
 # Checks:
-#   1. buf lint — validate proto style and conventions
-#   2. buf breaking — detect backwards-incompatible changes (against main branch)
-#   3. OpenAPI spec freshness — verify generated spec matches committed version
-#   4. OpenAPI lint — validate OpenAPI spec with Redocly CLI
+#   1. buf build — verify proto files compile successfully
+#   2. buf lint — validate proto style and conventions
+#   3. buf breaking — detect backwards-incompatible changes (against main branch)
+#   4. OpenAPI spec freshness — verify generated spec matches committed version
+#   5. OpenAPI lint — validate OpenAPI spec with Redocly CLI
 #
 # Usage: ./scripts/check-proto.sh [-v|--verbose]
 #   -v, --verbose  Show full command output (default: quiet, shows only pass/fail)
@@ -46,6 +47,8 @@ cd "$PROJECT_ROOT/stepflow-rs/proto"
 # =============================================================================
 # PROTO CHECKS
 # =============================================================================
+
+run_check "Build (compile)" buf build || true
 
 run_check "Lint" buf lint || true
 

--- a/stepflow-rs/Cross.toml
+++ b/stepflow-rs/Cross.toml
@@ -1,11 +1,41 @@
 # Cross-compilation configuration for the `cross` tool.
-# Install protobuf compiler needed by prost/tonic build scripts.
+#
+# Proto files use proto3 `optional` (field presence), which requires
+# protoc >= 3.15.  The system `protobuf-compiler` on Ubuntu 22.04 is
+# only 3.12, so we install protoc from GitHub releases instead.
 
 [target.aarch64-unknown-linux-gnu]
-pre-build = ["apt-get update && apt-get install -y protobuf-compiler"]
+pre-build = ["""
+PROTOC_VERSION=28.3 && \
+ARCH=$(uname -m) && \
+case $ARCH in x86_64) PROTOC_ARCH=linux-x86_64;; aarch64) PROTOC_ARCH=linux-aarch_64;; *) echo "Unsupported arch: $ARCH" >&2; exit 1;; esac && \
+apt-get update && apt-get install -y curl unzip && \
+curl -fsSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${PROTOC_ARCH}.zip && \
+unzip -o /tmp/protoc.zip -d /usr/local bin/protoc 'include/*' && \
+rm /tmp/protoc.zip && \
+protoc --version
+"""]
 
 [target.x86_64-unknown-linux-musl]
-pre-build = ["apt-get update && apt-get install -y protobuf-compiler"]
+pre-build = ["""
+PROTOC_VERSION=28.3 && \
+ARCH=$(uname -m) && \
+case $ARCH in x86_64) PROTOC_ARCH=linux-x86_64;; aarch64) PROTOC_ARCH=linux-aarch_64;; *) echo "Unsupported arch: $ARCH" >&2; exit 1;; esac && \
+apt-get update && apt-get install -y curl unzip && \
+curl -fsSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${PROTOC_ARCH}.zip && \
+unzip -o /tmp/protoc.zip -d /usr/local bin/protoc 'include/*' && \
+rm /tmp/protoc.zip && \
+protoc --version
+"""]
 
 [target.aarch64-unknown-linux-musl]
-pre-build = ["apt-get update && apt-get install -y protobuf-compiler"]
+pre-build = ["""
+PROTOC_VERSION=28.3 && \
+ARCH=$(uname -m) && \
+case $ARCH in x86_64) PROTOC_ARCH=linux-x86_64;; aarch64) PROTOC_ARCH=linux-aarch_64;; *) echo "Unsupported arch: $ARCH" >&2; exit 1;; esac && \
+apt-get update && apt-get install -y curl unzip && \
+curl -fsSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${PROTOC_ARCH}.zip && \
+unzip -o /tmp/protoc.zip -d /usr/local bin/protoc 'include/*' && \
+rm /tmp/protoc.zip && \
+protoc --version
+"""]


### PR DESCRIPTION
## Summary

Two fixes for cross-platform release builds:

1. **Cross.toml** (Linux cross-compilation): Install protoc v28.3 from GitHub releases instead of `apt-get install protobuf-compiler`. Ubuntu 22.04's apt provides protoc 3.12, which rejects proto3 `optional` (field presence, added in protoc 3.15). All proto files legitimately use `optional` for explicit field presence — the syntax is valid modern proto3.

2. **build.rs** (Windows): Use `dunce::canonicalize()` instead of `std::path::canonicalize()`. On Windows, the standard canonicalize produces `\\?\`-prefixed UNC paths (e.g., `\\?\C:\a\b\c`), which protoc cannot handle as include paths, causing "File not found" errors for proto imports.

3. **check-proto.sh**: Add `buf build` check before lint/breaking checks to catch proto compilation issues earlier.

## Why wasn't this caught before?

| Build path | protoc source | Version | Result |
|---|---|---|---|
| Native Linux CI | `arduino/setup-protoc@v3` | v25+ | Pass |
| macOS CI | `arduino/setup-protoc@v3` | v25+ | Pass |
| Local dev | Homebrew/system | v25+ | Pass |
| Cross builds | `apt-get protobuf-compiler` | 3.12 | **Fail** (proto3 optional) |
| Windows CI | `arduino/setup-protoc@v3` | v25+ | **Fail** (UNC path prefix) |

The cross-compilation Docker containers were the only environment using the old apt protoc. The Windows `\\?\` prefix issue was masked because proto files were previously outside the workspace (so protoc wasn't invoked on Windows).

## Test plan

- [ ] Cross-compiled builds (aarch64-gnu, x86_64-musl, aarch64-musl) compile proto files successfully
- [ ] Windows build resolves proto imports correctly
- [ ] `./scripts/check-proto.sh` runs `buf build` as first check