### PR TITLE
fix: Update docling-grpc deployment and facade for v0.12.0 API changes

### DIFF
--- a/examples/production/k8s/stepflow-docling-grpc/orchestrator/deployment.yaml
+++ b/examples/production/k8s/stepflow-docling-grpc/orchestrator/deployment.yaml
@@ -114,7 +114,7 @@ spec:
 
       # Container 2: stepflow-server — Rust orchestrator with gRPC TasksService
       - name: stepflow-server
-        image: localhost/stepflow-server:alpine-0.10.0
+        image: localhost/stepflow-server:alpine-0.12.0
         imagePullPolicy: Never
         securityContext:
           allowPrivilegeEscalation: false
@@ -125,13 +125,7 @@ spec:
         - name: http
           containerPort: 7840
           protocol: TCP
-        - name: grpc
-          containerPort: 7837
-          protocol: TCP
         env:
-        # Pull plugin gRPC bind address — must be 0.0.0.0 for external worker pods
-        - name: STEPFLOW_BIND_ADDRESS
-          value: "0.0.0.0:7837"
         # Pod metadata (defined first so later env vars can reference them)
         - name: POD_NAME
           valueFrom:
@@ -148,7 +142,7 @@ spec:
         # Advertised URL for workers to call back (pod IP, not service DNS,
         # so callbacks reach the specific pod that dispatched the task)
         - name: STEPFLOW_ORCHESTRATOR_URL
-          value: "$(POD_IP):7837"
+          value: "$(POD_IP):7840"
         # Stepflow logging
         - name: STEPFLOW_LOG_LEVEL
           value: "debug"

--- a/examples/production/k8s/stepflow-docling-grpc/orchestrator/service.yaml
+++ b/examples/production/k8s/stepflow-docling-grpc/orchestrator/service.yaml
@@ -12,9 +12,9 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# Orchestrator service — exposes facade (5001), HTTP API (7840), and gRPC (7837).
+# Orchestrator service — exposes facade (5001) and HTTP+gRPC (7840).
+# In v0.12.0+, HTTP and gRPC share port 7840 (tonic serves both HTTP/1.1 and HTTP/2).
 # NodePort 30501 maps to facade port for kind cluster access (matches kind-config.yaml).
-# gRPC port 7837 exposed as ClusterIP for worker pods to connect.
 
 apiVersion: v1
 kind: Service
@@ -34,12 +34,8 @@ spec:
     targetPort: facade
     protocol: TCP
     nodePort: 30501
-  - name: http
+  - name: http-grpc
     port: 7840
     targetPort: http
-    protocol: TCP
-  - name: grpc
-    port: 7837
-    targetPort: grpc
     protocol: TCP
   sessionAffinity: None

--- a/examples/production/k8s/stepflow-docling-grpc/worker/deployment.yaml
+++ b/examples/production/k8s/stepflow-docling-grpc/worker/deployment.yaml
@@ -49,9 +49,9 @@ spec:
         # Transport selection
         - name: STEPFLOW_TRANSPORT
           value: "grpc"
-        # gRPC TasksService address (orchestrator's pull-plugin gRPC server)
+        # gRPC TasksService address (v0.12.0+: HTTP+gRPC share port 7840)
         - name: STEPFLOW_TASKS_URL
-          value: "docling-orchestrator:7837"
+          value: "docling-orchestrator:7840"
         # Queue name matching orchestrator plugin config
         - name: STEPFLOW_QUEUE_NAME
           value: "docling"

--- a/integrations/docling-proto-step-worker/docker/Dockerfile
+++ b/integrations/docling-proto-step-worker/docker/Dockerfile
@@ -17,11 +17,11 @@ FROM quay.io/docling-project/docling-serve-cpu:v1.14.3
 
 USER 0
 
-# Install local stepflow-py SDK with http extras (needed for blob_store HTTP client)
+# Install local stepflow-py SDK (gRPC-only, HTTP transport removed in v0.12.0)
 # plus gRPC and protobuf deps for pull-based transport
 COPY sdks/python/stepflow-py/ /tmp/stepflow-py/
 RUN pip install --no-cache-dir \
-    "/tmp/stepflow-py[http]" \
+    "/tmp/stepflow-py" \
     "grpcio>=1.67.0" \
     "protobuf>=5.26.0,<6" \
     "python-dotenv>=1.0.0" && \

--- a/integrations/docling-proto-step-worker/pyproject.toml
+++ b/integrations/docling-proto-step-worker/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "stepflow-py[http]>=0.8.0",
+    "stepflow-py>=0.11.2",
     "docling>=2.77.0",
     "docling-core>=2.67.1",
     "grpcio>=1.67.0",

--- a/integrations/docling-proto-step-worker/src/docling_proto_step_worker/facade/app.py
+++ b/integrations/docling-proto-step-worker/src/docling_proto_step_worker/facade/app.py
@@ -304,7 +304,9 @@ async def _submit_and_respond(flow_input: dict[str, Any]) -> JSONResponse:
 
     run_data = resp.json()
 
-    # Extract the flow result from the run response
+    # Extract the flow result from the run response.
+    # v0.12.0+: results[i].output holds the flow output directly,
+    # results[i].status is a protobuf enum int (1=running, 2=completed, 3=failed).
     results = run_data.get("results") or []
     if not results:
         return JSONResponse(
@@ -313,11 +315,9 @@ async def _submit_and_respond(flow_input: dict[str, Any]) -> JSONResponse:
         )
 
     item = results[0]
-    flow_result = item.get("result", {})
-    outcome = flow_result.get("outcome")
 
-    if outcome == "failed":
-        error = flow_result.get("error", {})
+    if item.get("status") == 3:  # EXECUTION_STATUS_FAILED
+        error = item.get("error", {})
         return JSONResponse(
             status_code=500,
             content={
@@ -326,7 +326,7 @@ async def _submit_and_respond(flow_input: dict[str, Any]) -> JSONResponse:
             },
         )
 
-    flow_output = flow_result.get("result", {})
+    flow_output = item.get("output", {})
     response_body = flow_output_to_response(flow_output)
     return JSONResponse(content=response_body)
 
@@ -409,7 +409,7 @@ async def _get_result(task_id: str) -> JSONResponse:
         )
 
     items_data = resp.json()
-    items = items_data.get("items") or []
+    items = items_data.get("results") or []
     if not items:
         raise HTTPException(
             status_code=409,
@@ -417,11 +417,9 @@ async def _get_result(task_id: str) -> JSONResponse:
         )
 
     item = items[0]
-    flow_result = item.get("result", {})
-    outcome = flow_result.get("outcome")
 
-    if outcome == "failed":
-        error = flow_result.get("error", {})
+    if item.get("status") == 3:  # EXECUTION_STATUS_FAILED
+        error = item.get("error", {})
         return JSONResponse(
             status_code=500,
             content={
@@ -430,7 +428,7 @@ async def _get_result(task_id: str) -> JSONResponse:
             },
         )
 
-    flow_output = flow_result.get("result", {})
+    flow_output = item.get("output", {})
     response_body = flow_output_to_response(flow_output)
     return JSONResponse(content=response_body)
 

--- a/integrations/docling-proto-step-worker/src/docling_proto_step_worker/facade/translate.py
+++ b/integrations/docling-proto-step-worker/src/docling_proto_step_worker/facade/translate.py
@@ -150,12 +150,15 @@ def flow_output_to_response(flow_output: dict[str, Any]) -> dict[str, Any]:
 # Stepflow run status -> async poll response
 # ---------------------------------------------------------------------------
 
-# Map stepflow run statuses to docling-serve TaskStatus values.
-_STATUS_MAP: dict[str, str] = {
-    "running": "started",
-    "pending": "pending",
-    "completed": "success",
-    "failed": "failure",
+# Map stepflow protobuf ExecutionStatus enum values to docling-serve TaskStatus.
+# Proto: 0=unspecified, 1=running, 2=completed, 3=failed, 4=cancelled, 5=paused, 6=recovery_failed
+_STATUS_MAP: dict[int, str] = {
+    1: "started",
+    2: "success",
+    3: "failure",
+    4: "failure",
+    5: "started",
+    6: "failure",
 }
 
 
@@ -172,12 +175,16 @@ def run_status_to_poll_response(
     - ``task_position``: optional int (queue position)
     - ``task_meta``: optional processing progress
     - ``error_message``: optional str on failure
+
+    v0.12.0+: GET /api/v1/runs/{id} returns ``{summary: {...}, steps: [...]}``.
+    Status is a protobuf enum int in ``summary.status``.
     """
-    stepflow_status = run_data.get("status", "pending")
+    summary = run_data.get("summary", run_data)
+    stepflow_status = summary.get("status", 0)
     task_status = _STATUS_MAP.get(stepflow_status, "pending")
 
     response: dict[str, Any] = {
-        "task_id": run_data.get("runId", ""),
+        "task_id": summary.get("runId", ""),
         "task_type": task_type,
         "task_status": task_status,
         "task_position": None,
@@ -189,8 +196,7 @@ def run_status_to_poll_response(
         results = run_data.get("results") or []
         if results:
             item = results[0]
-            flow_result = item.get("result", {})
-            error = flow_result.get("error", {})
+            error = item.get("error", {})
             response["error_message"] = error.get(
                 "message", "Flow execution failed"
             )
@@ -202,11 +208,12 @@ def run_result_to_convert_response(run_data: dict[str, Any]) -> dict[str, Any] |
     """Extract the ``ConvertDocumentResponse`` from a completed run.
 
     Returns ``None`` if the run has no results yet.
+
+    v0.12.0+: results[i].output holds flow output directly.
     """
     results = run_data.get("results") or []
     if not results:
         return None
     item = results[0]
-    flow_result = item.get("result", {})
-    flow_output = flow_result.get("result", {})
+    flow_output = item.get("output", {})
     return flow_output_to_response(flow_output)


### PR DESCRIPTION
The v0.12.0 release consolidated HTTP and gRPC onto a single port and changed the run API response structure. This updates the K8s manifests, worker Dockerfile, and facade response mapping to match.

- Remove stale [http] pip extra from stepflow-py dependency
- Consolidate gRPC port 7837 into shared HTTP+gRPC port 7840
- Fix facade to read flow output from results[i].output (not result.result)
- Map protobuf int status enums in poll/result endpoints