### PR TITLE
fix: Remove stale --extra http from Dockerfiles

### DIFF
--- a/docker/docling-worker/Dockerfile
+++ b/docker/docling-worker/Dockerfile
@@ -56,7 +56,7 @@ RUN mkdir -p sdks/python/stepflow-py/src/stepflow_py && \
 
 # Install dependencies only (cached unless pyproject.toml/uv.lock change)
 # Use --frozen to ensure lock file is used exactly as-is
-RUN cd sdks/python && uv sync --frozen --no-install-workspace --no-dev --extra http
+RUN cd sdks/python && uv sync --frozen --no-install-workspace --no-dev
 RUN cd integrations/docling && uv sync --frozen --no-install-project --no-dev
 
 
@@ -68,7 +68,7 @@ COPY sdks/python ./sdks/python/
 COPY integrations/docling ./integrations/docling/
 
 # Install the actual packages (deps already installed)
-RUN cd sdks/python && uv sync --frozen --no-dev --extra http
+RUN cd sdks/python && uv sync --frozen --no-dev
 RUN cd integrations/docling && uv sync --frozen --no-dev
 
 

--- a/docker/langflow-component-server/Dockerfile
+++ b/docker/langflow-component-server/Dockerfile
@@ -59,7 +59,7 @@ ENV UV_PROJECT_ENVIRONMENT=/app/.venv
 # from the base image. Without this, uv may install Python 3.13+ into a location
 # that is inaccessible when running as non-root user 1000.
 ENV UV_PYTHON_PREFERENCE=only-system
-RUN cd sdks/python && uv sync --frozen --no-install-workspace --no-dev --extra http
+RUN cd sdks/python && uv sync --frozen --no-install-workspace --no-dev
 RUN cd integrations/langflow && uv sync --frozen --no-install-project --no-dev
 
 
@@ -77,7 +77,7 @@ COPY --chown=1000:0 integrations/langflow ./integrations/langflow/
 # Remove .python-version which pins Python 3.13 for development - the base image
 # only has Python 3.12.3 and we must use it.
 RUN rm -f sdks/python/.python-version integrations/langflow/.python-version && \
-    cd sdks/python && uv sync --frozen --no-dev --extra http && \
+    cd sdks/python && uv sync --frozen --no-dev && \
     cd /app/integrations/langflow && uv sync --frozen --no-dev && \
     uv pip install --python /app/.venv/bin/python "lfx==0.2.1" && \
     chown -R 1000:0 /app/.venv

--- a/examples/kubernetes-batch-demo/docker/Dockerfile.component-server
+++ b/examples/kubernetes-batch-demo/docker/Dockerfile.component-server
@@ -40,8 +40,7 @@ RUN mkdir -p sdks/python/stepflow-py/src/stepflow_py && \
     touch sdks/python/stepflow-orchestrator/README.md
 
 # Install dependencies only (cached unless pyproject.toml/uv.lock change)
-RUN cd sdks/python && uv sync --frozen --no-install-workspace --no-dev --extra http
-
+RUN cd sdks/python && uv sync --frozen --no-install-workspace --no-dev
 
 # Stage 2: Application code (changes frequently, but deps layer is cached)
 FROM deps AS builder
@@ -51,8 +50,7 @@ COPY sdks/python ./sdks/python/
 
 # Install the actual packages (deps already installed)
 RUN rm -f sdks/python/.python-version && \
-    cd sdks/python && uv sync --frozen --no-dev --extra http
-
+    cd sdks/python && uv sync --frozen --no-dev
 
 # Stage 3: Minimal runtime image (no build tools)
 FROM python:3.12-slim AS runtime

--- a/integrations/langflow/CLAUDE.md
+++ b/integrations/langflow/CLAUDE.md
@@ -57,9 +57,6 @@ integrations/langflow/
 # Install dependencies (development mode)
 cd integrations/langflow
 uv sync --dev
-
-# Install with HTTP server support
-uv sync --dev --extra http
 ```
 
 ### Testing


### PR DESCRIPTION
## Summary

The `[http]` extra was removed from the Python SDK (`stepflow-py`) when gRPC became the default transport. Several Dockerfiles still referenced `--extra http` in their `uv sync` commands, causing builds to fail with:

```
error: Extra `http` is not defined in any project's optional-dependencies table
```

Fixes the Langflow release Docker build failure: https://github.com/stepflow-ai/stepflow/actions/runs/23474170820

## Changes

- `docker/langflow-component-server/Dockerfile` — remove `--extra http` from 3 `uv sync` calls
- `docker/docling-worker/Dockerfile` — remove `--extra http` from 2 `uv sync` calls
- `examples/kubernetes-batch-demo/docker/Dockerfile.component-server` — remove `--extra http` from 2 `uv sync` calls
- `integrations/langflow/CLAUDE.md` — remove stale `--extra http` install example

## Test plan

- [ ] Langflow Docker image builds successfully
- [ ] Docling worker Docker image builds successfully
- [ ] K8s batch demo Docker image builds successfully