### PR TITLE
test: Add API contract tests for docling facade response mapping

### DIFF
--- a/integrations/docling-proto-step-worker/tests/unit/test_api_contract.py
+++ b/integrations/docling-proto-step-worker/tests/unit/test_api_contract.py
@@ -1,0 +1,420 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Contract tests validating facade behavior against Stepflow API response shapes.
+
+These fixtures represent the actual response structures from Stepflow v0.12.0+.
+Field names, nesting, and types are derived from stepflow-rs/proto/stepflow/v1/runs.proto
+and verified against live API output.
+
+When the Stepflow API changes its response shape, these fixtures must be updated
+to match — and the facade extraction logic must be updated accordingly.
+If a test fails, it means either:
+  1. The API changed and the fixture is stale (update fixture + facade), or
+  2. The facade's extraction logic regressed (fix the facade).
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from docling_proto_step_worker.facade.translate import (
+    flow_output_to_response,
+    run_result_to_convert_response,
+    run_status_to_poll_response,
+)
+
+# ---------------------------------------------------------------------------
+# Stepflow v0.12.0 API response fixtures
+#
+# Source of truth: stepflow-rs/proto/stepflow/v1/runs.proto
+# ExecutionStatus enum: 0=unspecified, 1=running, 2=completed, 3=failed,
+#                       4=cancelled, 5=paused, 6=recovery_failed
+# ---------------------------------------------------------------------------
+
+# POST /api/v1/runs (wait=true) — completed successfully
+COMPLETED_RUN_RESPONSE: dict = {
+    "summary": {
+        "runId": "019d1d32-26d2-7af3-8368-7378b198918c",
+        "flowId": "5a2bc43a6089050d28348fefcde79e3d6d06a70dafac777a832497d9b10837dd",
+        "flowName": "docling-process-document",
+        "status": 2,
+        "items": {
+            "total": 1,
+            "completed": 1,
+            "running": 0,
+            "failed": 0,
+            "cancelled": 0,
+        },
+        "createdAt": "2026-03-25T10:30:00Z",
+        "completedAt": "2026-03-25T10:30:05Z",
+        "rootRunId": "019d1d32-26d2-7af3-8368-7378b198918c",
+        "orchestratorId": "test-orchestrator",
+        "createdAtSeqno": 1,
+        "finishedAtSeqno": 10,
+    },
+    "results": [
+        {
+            "itemIndex": 0,
+            "status": 2,
+            "output": {
+                "document": {
+                    "md_content": "# Docling Technical Report\n\nThis is test content.",
+                    "filename": "test.pdf",
+                },
+                "status": "success",
+                "errors": [],
+                "processing_time": 1.5,
+                "timings": {"classify": 0.1, "convert": 1.2, "chunk": 0.2},
+                "classification": {"format": "pdf", "has_text_layer": True},
+                "chunks": [{"text": "chunk1"}],
+            },
+            "completedAt": "2026-03-25T10:30:05Z",
+        }
+    ],
+}
+
+# POST /api/v1/runs (wait=true) — failed execution
+FAILED_RUN_RESPONSE: dict = {
+    "summary": {
+        "runId": "019d1d32-aaaa-bbbb-cccc-ddddeeeeeeee",
+        "flowId": "5a2bc43a6089050d28348fefcde79e3d6d06a70dafac777a832497d9b10837dd",
+        "flowName": "docling-process-document",
+        "status": 3,
+        "items": {
+            "total": 1,
+            "completed": 0,
+            "running": 0,
+            "failed": 1,
+            "cancelled": 0,
+        },
+        "createdAt": "2026-03-25T10:30:00Z",
+        "completedAt": "2026-03-25T10:30:02Z",
+        "rootRunId": "019d1d32-aaaa-bbbb-cccc-ddddeeeeeeee",
+        "orchestratorId": "test-orchestrator",
+        "createdAtSeqno": 1,
+        "finishedAtSeqno": 5,
+    },
+    "results": [
+        {
+            "itemIndex": 0,
+            "status": 3,
+            "output": {},
+            "error": {
+                "message": "Failed to retrieve document for conversion",
+                "code": "COMPONENT_ERROR",
+            },
+            "completedAt": "2026-03-25T10:30:02Z",
+        }
+    ],
+}
+
+# GET /api/v1/runs/{id} — running (no results yet)
+RUNNING_GET_RUN_RESPONSE: dict = {
+    "summary": {
+        "runId": "019d1d32-1111-2222-3333-444455556666",
+        "flowId": "5a2bc43a6089050d28348fefcde79e3d6d06a70dafac777a832497d9b10837dd",
+        "flowName": "docling-process-document",
+        "status": 1,
+        "items": {
+            "total": 1,
+            "completed": 0,
+            "running": 1,
+            "failed": 0,
+            "cancelled": 0,
+        },
+        "createdAt": "2026-03-25T10:30:00Z",
+        "rootRunId": "019d1d32-1111-2222-3333-444455556666",
+        "orchestratorId": "test-orchestrator",
+        "createdAtSeqno": 1,
+    },
+    "steps": [
+        {
+            "stepId": "classify",
+            "stepIndex": 0,
+            "itemIndex": 0,
+            "status": 1,
+            "component": "/docling/classify",
+            "startedAt": "2026-03-25T10:30:01Z",
+        }
+    ],
+}
+
+# GET /api/v1/runs/{id} — completed (with steps)
+COMPLETED_GET_RUN_RESPONSE: dict = {
+    "summary": {
+        "runId": "019d1d32-26d2-7af3-8368-7378b198918c",
+        "flowId": "5a2bc43a6089050d28348fefcde79e3d6d06a70dafac777a832497d9b10837dd",
+        "flowName": "docling-process-document",
+        "status": 2,
+        "items": {
+            "total": 1,
+            "completed": 1,
+            "running": 0,
+            "failed": 0,
+            "cancelled": 0,
+        },
+        "createdAt": "2026-03-25T10:30:00Z",
+        "completedAt": "2026-03-25T10:30:05Z",
+        "rootRunId": "019d1d32-26d2-7af3-8368-7378b198918c",
+        "orchestratorId": "test-orchestrator",
+        "createdAtSeqno": 1,
+        "finishedAtSeqno": 10,
+    },
+    "steps": [
+        {
+            "stepId": "classify",
+            "stepIndex": 0,
+            "itemIndex": 0,
+            "status": 2,
+            "component": "/docling/classify",
+            "startedAt": "2026-03-25T10:30:01Z",
+            "completedAt": "2026-03-25T10:30:02Z",
+        },
+        {
+            "stepId": "convert",
+            "stepIndex": 1,
+            "itemIndex": 0,
+            "status": 2,
+            "component": "/docling/convert",
+            "startedAt": "2026-03-25T10:30:02Z",
+            "completedAt": "2026-03-25T10:30:04Z",
+        },
+        {
+            "stepId": "chunk",
+            "stepIndex": 2,
+            "itemIndex": 0,
+            "status": 2,
+            "component": "/docling/chunk",
+            "startedAt": "2026-03-25T10:30:04Z",
+            "completedAt": "2026-03-25T10:30:05Z",
+        },
+    ],
+}
+
+# GET /api/v1/runs/{id}/items — same shape as POST results
+GET_RUN_ITEMS_RESPONSE: dict = {
+    "results": [
+        {
+            "itemIndex": 0,
+            "status": 2,
+            "output": {
+                "document": {
+                    "md_content": "# Docling Technical Report\n\nThis is test content.",
+                    "filename": "test.pdf",
+                },
+                "status": "success",
+                "errors": [],
+                "processing_time": 1.5,
+                "timings": {"classify": 0.1, "convert": 1.2, "chunk": 0.2},
+                "classification": {"format": "pdf", "has_text_layer": True},
+                "chunks": [{"text": "chunk1"}],
+            },
+            "completedAt": "2026-03-25T10:30:05Z",
+        }
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixture shape validation — catches stale fixtures
+# ---------------------------------------------------------------------------
+
+
+class TestResponseShapeValidation:
+    """Structural assertions on the fixture data itself.
+
+    If the Stepflow API shape changes, update the fixtures above and these
+    tests will verify the new shape is internally consistent.
+    """
+
+    def test_run_response_has_required_fields(self):
+        assert "summary" in COMPLETED_RUN_RESPONSE
+        assert "results" in COMPLETED_RUN_RESPONSE
+        assert isinstance(COMPLETED_RUN_RESPONSE["results"], list)
+
+    def test_summary_has_required_fields(self):
+        summary = COMPLETED_RUN_RESPONSE["summary"]
+        for field in ("runId", "status", "items", "createdAt"):
+            assert field in summary, f"Missing required summary field: {field}"
+
+    def test_result_item_has_required_fields(self):
+        item = COMPLETED_RUN_RESPONSE["results"][0]
+        for field in ("itemIndex", "status", "output"):
+            assert field in item, f"Missing required result item field: {field}"
+
+    def test_status_values_are_integers(self):
+        """The v0.12.0 change that broke the facade: status is int, not str."""
+        assert isinstance(COMPLETED_RUN_RESPONSE["summary"]["status"], int)
+        assert isinstance(COMPLETED_RUN_RESPONSE["results"][0]["status"], int)
+        assert isinstance(FAILED_RUN_RESPONSE["summary"]["status"], int)
+        assert isinstance(FAILED_RUN_RESPONSE["results"][0]["status"], int)
+        assert isinstance(RUNNING_GET_RUN_RESPONSE["summary"]["status"], int)
+
+    def test_get_run_response_has_steps_not_results(self):
+        """GET /api/v1/runs/{id} returns 'steps', not 'results'."""
+        assert "steps" in COMPLETED_GET_RUN_RESPONSE
+        assert "results" not in COMPLETED_GET_RUN_RESPONSE
+
+    def test_get_run_items_uses_results_key(self):
+        """GET /api/v1/runs/{id}/items returns 'results' key."""
+        assert "results" in GET_RUN_ITEMS_RESPONSE
+
+    def test_output_is_direct_field_not_nested(self):
+        """v0.12.0: output is results[i].output, NOT results[i].result.result."""
+        item = COMPLETED_RUN_RESPONSE["results"][0]
+        assert "output" in item
+        assert "result" not in item
+
+
+# ---------------------------------------------------------------------------
+# Run response extraction — mirrors app.py _submit_and_respond logic
+# ---------------------------------------------------------------------------
+
+
+class TestRunResponseExtraction:
+    """Validates that facade extraction logic works with v0.12.0 response shapes.
+
+    These tests replicate the extraction logic from app.py's _submit_and_respond
+    and _get_result methods against the contract fixtures.
+    """
+
+    def test_extract_flow_output_from_completed_run(self):
+        item = COMPLETED_RUN_RESPONSE["results"][0]
+        flow_output = item.get("output", {})
+        assert flow_output["document"]["md_content"] != ""
+        assert flow_output["status"] == "success"
+
+    def test_extract_status_completed(self):
+        item = COMPLETED_RUN_RESPONSE["results"][0]
+        assert item.get("status") == 2
+
+    def test_extract_status_failed(self):
+        item = FAILED_RUN_RESPONSE["results"][0]
+        assert item.get("status") == 3
+
+    def test_failed_run_has_error_info(self):
+        item = FAILED_RUN_RESPONSE["results"][0]
+        error = item.get("error", {})
+        assert error.get("message") is not None
+        assert len(error["message"]) > 0
+
+    def test_no_results_handled(self):
+        run_data = copy.deepcopy(COMPLETED_RUN_RESPONSE)
+        run_data["results"] = []
+        results = run_data.get("results") or []
+        assert len(results) == 0
+
+    def test_flow_output_to_response_with_contract_data(self):
+        """End-to-end: extract output from fixture → translate to docling response."""
+        item = COMPLETED_RUN_RESPONSE["results"][0]
+        flow_output = item.get("output", {})
+        response = flow_output_to_response(flow_output)
+
+        assert response["document"]["md_content"] != ""
+        assert response["status"] == "success"
+        assert response["errors"] == []
+        assert response["processing_time"] == 1.5
+        # chunks and classification must NOT appear in ConvertDocumentResponse
+        assert "chunks" not in response
+        assert "classification" not in response
+
+    def test_items_endpoint_same_extraction_pattern(self):
+        """GET /api/v1/runs/{id}/items uses same results[i].output pattern."""
+        item = GET_RUN_ITEMS_RESPONSE["results"][0]
+        flow_output = item.get("output", {})
+        response = flow_output_to_response(flow_output)
+        assert response["document"]["md_content"] != ""
+
+
+# ---------------------------------------------------------------------------
+# Poll response contract — run_status_to_poll_response
+# ---------------------------------------------------------------------------
+
+
+class TestPollResponseContract:
+    """Validates run_status_to_poll_response against v0.12.0 response shapes."""
+
+    def test_completed_run_maps_to_success(self):
+        result = run_status_to_poll_response(COMPLETED_GET_RUN_RESPONSE)
+        assert result["task_status"] == "success"
+
+    def test_running_run_maps_to_started(self):
+        result = run_status_to_poll_response(RUNNING_GET_RUN_RESPONSE)
+        assert result["task_status"] == "started"
+
+    def test_failed_run_maps_to_failure(self):
+        result = run_status_to_poll_response(FAILED_RUN_RESPONSE)
+        assert result["task_status"] == "failure"
+
+    def test_failed_run_includes_error_message(self):
+        result = run_status_to_poll_response(FAILED_RUN_RESPONSE)
+        assert result["error_message"] is not None
+        assert "Failed to retrieve" in result["error_message"]
+
+    def test_run_id_extracted_from_summary(self):
+        """runId lives in summary.runId, not at the top level."""
+        result = run_status_to_poll_response(COMPLETED_GET_RUN_RESPONSE)
+        assert result["task_id"] == COMPLETED_GET_RUN_RESPONSE["summary"]["runId"]
+
+    def test_poll_response_has_all_required_fields(self):
+        """docling-serve TaskStatusResponse requires these fields."""
+        result = run_status_to_poll_response(COMPLETED_GET_RUN_RESPONSE)
+        for field in (
+            "task_id",
+            "task_type",
+            "task_status",
+            "task_position",
+            "task_meta",
+            "error_message",
+        ):
+            assert field in result, f"Missing required poll response field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# Result extraction contract — run_result_to_convert_response
+# ---------------------------------------------------------------------------
+
+
+class TestResultExtractionContract:
+    """Validates run_result_to_convert_response against v0.12.0 response shapes."""
+
+    def test_extracts_document_from_output(self):
+        result = run_result_to_convert_response(COMPLETED_RUN_RESPONSE)
+        assert result is not None
+        assert result["document"]["md_content"] != ""
+
+    def test_strips_non_response_fields(self):
+        result = run_result_to_convert_response(COMPLETED_RUN_RESPONSE)
+        assert result is not None
+        assert "chunks" not in result
+        assert "classification" not in result
+
+    def test_returns_none_when_no_results(self):
+        run_data = {"summary": COMPLETED_RUN_RESPONSE["summary"], "results": []}
+        result = run_result_to_convert_response(run_data)
+        assert result is None
+
+    def test_returns_none_when_results_key_missing(self):
+        run_data = {"summary": COMPLETED_RUN_RESPONSE["summary"]}
+        result = run_result_to_convert_response(run_data)
+        assert result is None
+
+    def test_items_endpoint_response_works(self):
+        """GET /api/v1/runs/{id}/items response works with same function."""
+        result = run_result_to_convert_response(GET_RUN_ITEMS_RESPONSE)
+        assert result is not None
+        assert result["document"]["md_content"] != ""

--- a/integrations/docling-proto-step-worker/tests/unit/test_facade_translate.py
+++ b/integrations/docling-proto-step-worker/tests/unit/test_facade_translate.py
@@ -27,6 +27,8 @@ from docling_proto_step_worker.facade.translate import (
     flow_output_to_response,
     normalize_v1alpha_request,
     request_to_flow_input,
+    run_result_to_convert_response,
+    run_status_to_poll_response,
 )
 
 # ---------------------------------------------------------------------------
@@ -200,3 +202,118 @@ class TestFlowOutputToResponse:
         assert result["status"] == "failure"
         assert len(result["errors"]) == 1
         assert result["errors"][0]["error_message"] == "Conversion failed"
+
+
+# ---------------------------------------------------------------------------
+# run_status_to_poll_response
+# ---------------------------------------------------------------------------
+
+
+class TestRunStatusToPollResponse:
+    def test_completed_status(self):
+        run_data = {"summary": {"runId": "run-1", "status": 2}}
+        result = run_status_to_poll_response(run_data)
+        assert result["task_id"] == "run-1"
+        assert result["task_status"] == "success"
+        assert result["task_type"] == "convert"
+
+    def test_running_status(self):
+        run_data = {"summary": {"runId": "run-2", "status": 1}}
+        result = run_status_to_poll_response(run_data)
+        assert result["task_status"] == "started"
+
+    def test_failed_status(self):
+        run_data = {
+            "summary": {"runId": "run-3", "status": 3},
+            "results": [
+                {"error": {"message": "Component crashed"}},
+            ],
+        }
+        result = run_status_to_poll_response(run_data)
+        assert result["task_status"] == "failure"
+        assert result["error_message"] == "Component crashed"
+
+    def test_failed_without_results_uses_default_message(self):
+        run_data = {"summary": {"runId": "run-4", "status": 3}, "results": [{}]}
+        result = run_status_to_poll_response(run_data)
+        assert result["task_status"] == "failure"
+        assert result["error_message"] == "Flow execution failed"
+
+    def test_cancelled_maps_to_failure(self):
+        run_data = {"summary": {"runId": "run-5", "status": 4}}
+        result = run_status_to_poll_response(run_data)
+        assert result["task_status"] == "failure"
+
+    def test_unknown_status_maps_to_pending(self):
+        run_data = {"summary": {"runId": "run-6", "status": 0}}
+        result = run_status_to_poll_response(run_data)
+        assert result["task_status"] == "pending"
+
+    def test_custom_task_type(self):
+        run_data = {"summary": {"runId": "run-7", "status": 2}}
+        result = run_status_to_poll_response(run_data, task_type="chunk")
+        assert result["task_type"] == "chunk"
+
+    def test_all_response_fields_present(self):
+        run_data = {"summary": {"runId": "run-8", "status": 2}}
+        result = run_status_to_poll_response(run_data)
+        expected_fields = {
+            "task_id",
+            "task_type",
+            "task_status",
+            "task_position",
+            "task_meta",
+            "error_message",
+        }
+        assert set(result.keys()) == expected_fields
+
+    def test_fallback_when_no_summary_wrapper(self):
+        """Handles flat run_data (no summary wrapper) for backward compat."""
+        run_data = {"runId": "run-flat", "status": 2}
+        result = run_status_to_poll_response(run_data)
+        assert result["task_id"] == "run-flat"
+        assert result["task_status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# run_result_to_convert_response
+# ---------------------------------------------------------------------------
+
+
+class TestRunResultToConvertResponse:
+    def test_extracts_from_output(self):
+        run_data = {
+            "results": [
+                {
+                    "output": {
+                        "document": {"md_content": "# Hello", "filename": "doc.pdf"},
+                        "status": "success",
+                        "errors": [],
+                        "processing_time": 2.0,
+                        "timings": {"convert": 1.5},
+                        "chunks": [{"text": "c1"}],
+                        "classification": {"format": "pdf"},
+                    }
+                }
+            ]
+        }
+        result = run_result_to_convert_response(run_data)
+        assert result is not None
+        assert result["document"]["md_content"] == "# Hello"
+        assert result["status"] == "success"
+        assert result["processing_time"] == 2.0
+        assert "chunks" not in result
+        assert "classification" not in result
+
+    def test_returns_none_for_empty_results(self):
+        assert run_result_to_convert_response({"results": []}) is None
+
+    def test_returns_none_for_missing_results(self):
+        assert run_result_to_convert_response({}) is None
+
+    def test_empty_output(self):
+        run_data = {"results": [{"output": {}}]}
+        result = run_result_to_convert_response(run_data)
+        assert result is not None
+        assert result["document"] == {}
+        assert result["status"] == "success"

--- a/integrations/docling-proto-step-worker/uv.lock
+++ b/integrations/docling-proto-step-worker/uv.lock
@@ -72,15 +72,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asgiref"
-version = "3.11.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -533,7 +524,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "protobuf" },
     { name = "python-dotenv" },
-    { name = "stepflow-py", extra = ["http"] },
+    { name = "stepflow-py" },
 ]
 
 [package.optional-dependencies]
@@ -572,7 +563,7 @@ requires-dist = [
     { name = "protobuf", specifier = ">=5.26.0,<6" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", marker = "extra == 'facade'", specifier = ">=6.0" },
-    { name = "stepflow-py", extras = ["http"], editable = "../../sdks/python/stepflow-py" },
+    { name = "stepflow-py", editable = "../../sdks/python/stepflow-py" },
     { name = "uvicorn", marker = "extra == 'facade'", specifier = ">=0.24.0" },
 ]
 provides-extras = ["ocr", "facade"]
@@ -1713,53 +1704,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-instrumentation"
-version = "0.61b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "packaging" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/37/6bf8e66bfcee5d3c6515b79cb2ee9ad05fe573c20f7ceb288d0e7eeec28c/opentelemetry_instrumentation-0.61b0.tar.gz", hash = "sha256:cb21b48db738c9de196eba6b805b4ff9de3b7f187e4bbf9a466fa170514f1fc7", size = 32606, upload-time = "2026-03-04T14:20:16.825Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/3e/f6f10f178b6316de67f0dfdbbb699a24fbe8917cf1743c1595fb9dcdd461/opentelemetry_instrumentation-0.61b0-py3-none-any.whl", hash = "sha256:92a93a280e69788e8f88391247cc530fd81f16f2b011979d4d6398f805cfbc63", size = 33448, upload-time = "2026-03-04T14:19:02.447Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-asgi"
-version = "0.61b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asgiref" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/00/3e/143cf5c034e58037307e6a24f06e0dd64b2c49ae60a965fc580027581931/opentelemetry_instrumentation_asgi-0.61b0.tar.gz", hash = "sha256:9d08e127244361dc33976d39dd4ca8f128b5aa5a7ae425208400a80a095019b5", size = 26691, upload-time = "2026-03-04T14:20:21.038Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/78/154470cf9d741a7487fbb5067357b87386475bbb77948a6707cae982e158/opentelemetry_instrumentation_asgi-0.61b0-py3-none-any.whl", hash = "sha256:e4b3ce6b66074e525e717efff20745434e5efd5d9df6557710856fba356da7a4", size = 16980, upload-time = "2026-03-04T14:19:10.894Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-fastapi"
-version = "0.61b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-asgi" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/37/35/aa727bb6e6ef930dcdc96a617b83748fece57b43c47d83ba8d83fbeca657/opentelemetry_instrumentation_fastapi-0.61b0.tar.gz", hash = "sha256:3a24f35b07c557ae1bbc483bf8412221f25d79a405f8b047de8b670722e2fa9f", size = 24800, upload-time = "2026-03-04T14:20:32.759Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/05/acfeb2cccd434242a0a7d0ea29afaf077e04b42b35b485d89aee4e0d9340/opentelemetry_instrumentation_fastapi-0.61b0-py3-none-any.whl", hash = "sha256:a1a844d846540d687d377516b2ff698b51d87c781b59f47c214359c4a241047c", size = 13485, upload-time = "2026-03-04T14:19:30.351Z" },
-]
-
-[[package]]
 name = "opentelemetry-proto"
 version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1796,15 +1740,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755, upload-time = "2026-03-04T14:17:32.664Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621, upload-time = "2026-03-04T14:17:19.33Z" },
-]
-
-[[package]]
-name = "opentelemetry-util-http"
-version = "0.61b0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/3c/f0196223efc5c4ca19f8fad3d5462b171ac6333013335ce540c01af419e9/opentelemetry_util_http-0.61b0.tar.gz", hash = "sha256:1039cb891334ad2731affdf034d8fb8b48c239af9b6dd295e5fabd07f1c95572", size = 11361, upload-time = "2026-03-04T14:20:57.01Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/e5/c08aaaf2f64288d2b6ef65741d2de5454e64af3e050f34285fb1907492fe/opentelemetry_util_http-0.61b0-py3-none-any.whl", hash = "sha256:8e715e848233e9527ea47e275659ea60a57a75edf5206a3b937e236a6da5fc33", size = 9281, upload-time = "2026-03-04T14:20:08.364Z" },
 ]
 
 [[package]]
@@ -3067,19 +3002,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sse-starlette"
-version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "starlette" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/9f/c3695c2d2d4ef70072c3a06992850498b01c6bc9be531950813716b426fa/sse_starlette-3.3.2.tar.gz", hash = "sha256:678fca55a1945c734d8472a6cad186a55ab02840b4f6786f5ee8770970579dcd", size = 32326, upload-time = "2026-02-28T11:24:34.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/28/8cb142d3fe80c4a2d8af54ca0b003f47ce0ba920974e7990fa6e016402d1/sse_starlette-3.3.2-py3-none-any.whl", hash = "sha256:5c3ea3dad425c601236726af2f27689b74494643f57017cafcb6f8c9acfbb862", size = 14270, upload-time = "2026-02-28T11:24:32.984Z" },
-]
-
-[[package]]
 name = "starlette"
 version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3094,7 +3016,7 @@ wheels = [
 
 [[package]]
 name = "stepflow-py"
-version = "0.11.2"
+version = "0.12.0"
 source = { editable = "../../sdks/python/stepflow-py" }
 dependencies = [
     { name = "grpcio" },
@@ -3109,40 +3031,28 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 
-[package.optional-dependencies]
-http = [
-    { name = "fastapi" },
-    { name = "opentelemetry-instrumentation-fastapi" },
-    { name = "sse-starlette" },
-    { name = "uvicorn" },
-]
-
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", marker = "extra == 'http'", specifier = ">=0.104.1" },
     { name = "grpcio", specifier = ">=1.67.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "jsonschema", specifier = ">=4.17.0" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=0.3" },
     { name = "msgspec", specifier = ">=0.19.0" },
+    { name = "nats-py", marker = "extra == 'nats'", specifier = ">=2.9.0" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20.0" },
-    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'http'", specifier = ">=0.44b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "protobuf", specifier = ">=5.26.0,<6" },
-    { name = "sse-starlette", marker = "extra == 'http'", specifier = ">=1.6.5" },
     { name = "stepflow-orchestrator", marker = "extra == 'local'", editable = "../../sdks/python/stepflow-orchestrator" },
     { name = "types-jsonschema", specifier = ">=4.17.0" },
     { name = "typing-extensions", specifier = ">=4.7.1" },
-    { name = "uvicorn", marker = "extra == 'http'", specifier = ">=0.24.0" },
 ]
-provides-extras = ["http", "langchain", "local"]
+provides-extras = ["nats", "langchain", "local"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "datamodel-code-generator", extras = ["http", "ruff"], specifier = ">=0.31.2" },
     { name = "deptry", specifier = ">=0.22.0" },
-    { name = "fastapi", specifier = ">=0.104.1" },
     { name = "grpcio-tools", specifier = ">=1.67.0,<1.75.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "langchain-core", specifier = ">=0.3.72" },
@@ -3155,9 +3065,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "ruff", specifier = ">=0.9.4" },
-    { name = "sse-starlette", specifier = ">=1.6.5" },
     { name = "types-grpcio", specifier = ">=1.0.0" },
-    { name = "uvicorn", specifier = ">=0.24.0" },
 ]
 
 [[package]]
@@ -3584,65 +3492,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
-]
-
-[[package]]
-name = "wrapt"
-version = "1.17.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
-    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
-    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
-    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
-    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
-    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
-    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
-    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
-    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
-    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
-    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
-    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
-    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
-    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
-    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
-    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
-    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
-    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
-    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The v0.12.0 API response shape change (results[i].output instead of results[i].result.result, int status enums) silently broke the facade. Add contract tests with fixtures derived from the live API so future shape changes are caught before deployment.

- Add test_api_contract.py with v0.12.0 response fixtures and 25 tests
- Add missing run_status_to_poll_response and run_result_to_convert_response coverage to test_facade_translate.py (15 new tests)