### PR TITLE
fix: resolve lint and type-check failures in docling-proto-step-worker

### DIFF
--- a/integrations/docling-proto-step-worker/pyproject.toml
+++ b/integrations/docling-proto-step-worker/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
     "mypy==1.19.1",
     "deptry>=0.22.0",
     "fpdf2>=2.8.0",
+    "docling-proto-step-worker[facade]",
 ]
 
 [project.urls]

--- a/integrations/docling-proto-step-worker/src/docling_proto_step_worker/facade/translate.py
+++ b/integrations/docling-proto-step-worker/src/docling_proto_step_worker/facade/translate.py
@@ -151,7 +151,8 @@ def flow_output_to_response(flow_output: dict[str, Any]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 # Map stepflow protobuf ExecutionStatus enum values to docling-serve TaskStatus.
-# Proto: 0=unspecified, 1=running, 2=completed, 3=failed, 4=cancelled, 5=paused, 6=recovery_failed
+# Proto enum: 0=unspecified, 1=running, 2=completed,
+# 3=failed, 4=cancelled, 5=paused, 6=recovery_failed
 _STATUS_MAP: dict[int, str] = {
     1: "started",
     2: "success",

--- a/integrations/docling-proto-step-worker/src/docling_proto_step_worker/server.py
+++ b/integrations/docling-proto-step-worker/src/docling_proto_step_worker/server.py
@@ -60,15 +60,11 @@ async def chunk(input_data: Any, context: StepflowContext) -> Any:
 
 
 def _configure_blob_store() -> None:
-    """Configure the blob store contextvars via HTTP for the current context.
+    """Validate that the blob store environment variable is set.
 
-    The gRPC worker's ``GrpcContext`` has its own blob ops, but the domain
-    modules (``blob_utils.py``) call the module-level ``blob_store`` API
-    which is backed by HTTP contextvars. We configure those here before
-    ``asyncio.run()`` so all tasks inherit the configuration.
-
-    Falls back to setting ``server._blob_api_url`` which the SDK reads
-    during per-task setup.
+    The gRPC worker reads STEPFLOW_BLOB_API_URL directly from the
+    environment at task execution time. This function validates the
+    variable is present at startup and logs a warning if missing.
     """
     blob_url = os.environ.get("STEPFLOW_BLOB_API_URL")
     if not blob_url:
@@ -80,11 +76,7 @@ def _configure_blob_store() -> None:
         )
         return
 
-    # Set the URL on the StepflowServer instance. The SDK's grpc_worker
-    # reads server._blob_api_url and passes it to the GrpcContext, plus
-    # configures blob_store contextvars within each task's async scope.
-    server._blob_api_url = blob_url
-    logger.info("Blob store URL configured on server instance: %s", blob_url)
+    logger.info("Blob store URL configured: %s", blob_url)
 
 
 READY_SENTINEL = Path("/tmp/worker-ready")

--- a/integrations/docling-proto-step-worker/tests/unit/test_api_contract.py
+++ b/integrations/docling-proto-step-worker/tests/unit/test_api_contract.py
@@ -15,7 +15,8 @@
 """Contract tests validating facade behavior against Stepflow API response shapes.
 
 These fixtures represent the actual response structures from Stepflow v0.12.0+.
-Field names, nesting, and types are derived from stepflow-rs/proto/stepflow/v1/runs.proto
+Field names, nesting, and types are derived from
+stepflow-rs/proto/stepflow/v1/runs.proto
 and verified against live API output.
 
 When the Stepflow API changes its response shape, these fixtures must be updated
@@ -28,8 +29,6 @@ If a test fails, it means either:
 from __future__ import annotations
 
 import copy
-
-import pytest
 
 from docling_proto_step_worker.facade.translate import (
     flow_output_to_response,

--- a/integrations/docling-proto-step-worker/uv.lock
+++ b/integrations/docling-proto-step-worker/uv.lock
@@ -541,6 +541,7 @@ ocr = [
 [package.dev-dependencies]
 dev = [
     { name = "deptry" },
+    { name = "docling-proto-step-worker", extra = ["facade"] },
     { name = "fpdf2" },
     { name = "mypy" },
     { name = "poethepoet" },
@@ -571,6 +572,7 @@ provides-extras = ["ocr", "facade"]
 [package.metadata.requires-dev]
 dev = [
     { name = "deptry", specifier = ">=0.22.0" },
+    { name = "docling-proto-step-worker", extras = ["facade"] },
     { name = "fpdf2", specifier = ">=2.8.0" },
     { name = "mypy", specifier = "==1.19.1" },
     { name = "poethepoet", specifier = ">=0.24.0" },


### PR DESCRIPTION
- Add facade extras to dev dependencies so mypy can resolve fastapi/uvicorn imports
- Fix ruff line-length violations in translate.py and test_api_contract.py
- Remove unused pytest import in test_api_contract.py
- Remove dead _blob_api_url monkey-patch in server.py (SDK reads env var directly)