### PR TITLE
fix: Capture LocalOrchestrator stdout into ring buffer to prevent broken pipe errors

### DIFF
--- a/sdks/rust/crates/stepflow-client/src/local_server.rs
+++ b/sdks/rust/crates/stepflow-client/src/local_server.rs
@@ -538,9 +538,7 @@ mod tests {
         // After the guard kills + waits, the pid should be reaped.
         // Verify by trying to send signal 0 (existence check).
         std::thread::sleep(Duration::from_millis(50));
-        let status = Command::new("kill")
-            .args(["-0", &id.to_string()])
-            .status();
+        let status = Command::new("kill").args(["-0", &id.to_string()]).status();
         assert!(
             status.is_err() || !status.unwrap().success(),
             "process should no longer exist"


### PR DESCRIPTION
## Summary

- After port discovery, a background thread drains the orchestrator's stdout into a 500-line ring buffer, preventing "broken pipe (os error 32)" errors in integration tests
- On test panics, recent orchestrator logs are automatically dumped to stderr for debugging context
- New `set_dump_logs_on_panic(bool)` method to disable the automatic dump, and `recent_logs(n)` for programmatic access

Closes #857

## Test plan

- [ ] Run integration tests with `STEPFLOW_DEV_BINARY` set and verify no more broken pipe errors in output
- [ ] Intentionally break a test assertion to verify orchestrator logs are dumped on panic
- [ ] Verify `set_dump_logs_on_panic(false)` suppresses the log dump