### PR TITLE
fix: Update CI to target docling-proto-step-worker

### DIFF
--- a/.github/actions/docling-step-worker/action.yml
+++ b/.github/actions/docling-step-worker/action.yml
@@ -1,5 +1,5 @@
-name: 'Docling Step Worker Checks'
-description: 'Run Docling step worker tests and validation using shared script logic'
+name: 'Docling Proto Step Worker Checks'
+description: 'Run Docling proto step worker tests and validation using shared script logic'
 
 inputs:
   python-version:
@@ -23,12 +23,12 @@ runs:
     - name: Set up Python ${{ inputs.python-version }}
       shell: bash
       run: uv python install ${{ inputs.python-version }}
-      working-directory: integrations/docling-step-worker
+      working-directory: integrations/docling-proto-step-worker
 
     - name: Install Dependencies
       shell: bash
       run: uv sync --all-extras --group dev
-      working-directory: integrations/docling-step-worker
+      working-directory: integrations/docling-proto-step-worker
 
     # Run Docling step worker checks using the shared script
     - name: Run Docling step worker checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
               - '.github/actions/docling-step-worker/**'
               - 'scripts/check-docling.sh'
               - 'scripts/_lib.sh'
-              - 'integrations/docling-step-worker/**'
+              - 'integrations/docling-proto-step-worker/**'
             firecracker:
               - '.github/actions/firecracker-checks/**'
               - 'stepflow-rs/crates/stepflow-isolation-proxy/**'
@@ -200,7 +200,7 @@ jobs:
 
   # Docling step worker checks
   docling-checks:
-    name: Docling Step Worker Checks
+    name: Docling Proto Step Worker Checks
     needs: changes
     if: needs.changes.outputs.docling == 'true'
     runs-on: ubuntu-latest

--- a/scripts/check-docling.sh
+++ b/scripts/check-docling.sh
@@ -13,8 +13,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# CI check script for Docling Step Worker - mirrors .github/actions/docling-step-worker behavior
-# This script runs all Docling-related checks that are performed in CI
+# CI check script for Docling Proto Step Worker - mirrors .github/actions/docling-step-worker behavior
+# This script runs all Docling proto-related checks that are performed in CI
 #
 # Usage: ./scripts/check-docling.sh [-v|--verbose]
 #   -v, --verbose  Show full command output (default: quiet, shows only pass/fail)
@@ -34,13 +34,13 @@ parse_flags "$@"
 
 echo "📄 Docling"
 
-cd "$PROJECT_ROOT/integrations/docling-step-worker"
+cd "$PROJECT_ROOT/integrations/docling-proto-step-worker"
 
 # Check for required tool
 require_tool "uv" "curl -LsSf https://astral.sh/uv/install.sh | sh"
 
 # =============================================================================
-# DOCLING STEP WORKER SETUP
+# DOCLING PROTO STEP WORKER SETUP
 # =============================================================================
 # NOTE: Each check uses `|| true` to continue running all checks even when one fails.
 # Failures are tracked by run_check in FAILED_CHECKS array and reported via print_summary,
@@ -50,7 +50,7 @@ run_check "Python install" uv python install || true
 run_check "Dependencies" uv sync --all-extras --group dev || true
 
 # =============================================================================
-# DOCLING STEP WORKER CHECKS
+# DOCLING PROTO STEP WORKER CHECKS
 # =============================================================================
 
 run_check "Formatting" --fix "uv run poe fmt-fix" uv run poe fmt-check || true


### PR DESCRIPTION
The HTTP-based docling-step-worker is deprecated in favor of the gRPC pull-based docling-proto-step-worker. Update the CI action, workflow, and check script to point at the new integration.