### PR TITLE
feat: Add benchmark suite for orchestrator and worker throughput

### DIFF
--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -1,304 +1,131 @@
-# Stepflow Load Testing
+# Stepflow Load Testing & Benchmarks
 
-This directory contains load testing setup for Stepflow service using k6. The tests evaluate performance and reliability of different workflow execution patterns with OpenAI API calls.
+## Benchmarks (Orchestrator & Worker Performance)
 
-## Test Scenarios
+Measure orchestrator throughput, concurrent flow capacity, and worker overhead.
 
-The load test uses the proper Stepflow API pattern: **POST /flows** (to store workflows and get hashes) → **POST /runs** (to execute by hash).
-
-### 1. Python UDF OpenAI (`python-udf-openai.yaml/.json`)
-- Uses Python User-Defined Functions (UDF) to call OpenAI API
-- Creates a blob containing Python code that makes OpenAI API calls
-- Executes the code using the `/python/udf` component
-- Model: `gpt-4o-mini`
-
-### 2. Python Custom Component OpenAI (`python-custom-openai.yaml/.json`)
-- Uses a custom Python component server (`openai_custom_server.py`)
-- Direct component-to-OpenAI API integration
-- Uses structured input/output with msgspec
-- Model: `gpt-4o-mini`
-
-### 3. Rust Built-in OpenAI (`rust-builtin-openai.yaml/.json`)
-- Uses Stepflow's built-in Rust OpenAI component
-- Leverages `/create_messages` and `/openai` built-in components
-- Most direct integration path
-- Model: `gpt-4o-mini`
-
-**Note**: Both YAML and JSON versions of workflows are provided. The k6 load test uses JSON files for compatibility.
-
-## Prerequisites
-
-1. **k6**: Install k6 for load testing
-   ```bash
-   # macOS
-   brew install k6
-   
-   # Linux
-   sudo gpg -k
-   sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
-   echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
-   sudo apt-get update
-   sudo apt-get install k6
-   
-   # Windows
-   choco install k6
-   ```
-
-2. **OpenAI API Key**: Set your OpenAI API key
-   ```bash
-   export OPENAI_API_KEY="your-openai-api-key-here"
-   ```
-
-3. **Stepflow Dependencies**: Ensure Python SDK dependencies are available
-   ```bash
-   cd ../stepflow-rs
-   # Python dependencies should be managed by uv as configured
-   ```
-
-## Running Load Tests
-
-### Option 1: Standalone Tests (Fast, No OpenAI API required)
-
-**Recommended for basic performance testing without external dependencies.**
-
-1. **Start Standalone Service**:
-   ```bash
-   cd load-tests
-   ./scripts/start-standalone-service.sh
-   ```
-   This will:
-   - Build Stepflow in release mode
-   - Start the service on port 7837
-   - Use standalone configuration (no OpenAI required)
-
-2. **Run Standalone Tests** (in a separate terminal):
-   ```bash
-   cd load-tests
-   ./scripts/run-single-standalone-tests.sh
-   ```
-   This tests three workflow types with simple message creation:
-   - `rust-builtin-messages` - Direct Rust built-in components
-   - `python-custom-messages` - Python custom component server
-   - `python-udf-messages` - Python UDF with blob storage
-
-### Option 2: OpenAI Tests (Requires API key)
-
-**For testing with actual OpenAI API calls.**
-
-1. **Set OpenAI API Key**:
-   ```bash
-   export OPENAI_API_KEY="your-key-here"
-   ```
-
-2. **Start OpenAI Service**:
-   ```bash
-   cd load-tests
-   ./scripts/start-service.sh
-   ```
-
-3. **Run OpenAI Tests**:
-   ```bash
-   cd load-tests
-   ./scripts/run-single-openai-tests.sh
-   ```
-   This tests three workflow types with OpenAI GPT-4o-mini calls:
-   - `rust-builtin-openai` - Direct Rust built-in OpenAI component
-   - `python-custom-openai` - Python custom component with OpenAI
-   - `python-udf-openai` - Python UDF with OpenAI integration
-
-### Option 3: Combined Workflow Test (All workflows mixed)
-
-**For testing multiple workflow types simultaneously.**
+### Quick Start
 
 ```bash
 cd load-tests
-./scripts/run-load-test.sh
+./bench.sh              # Build, start server, run all benchmarks, print results
+./bench.sh --quick      # Shorter run (good for smoke testing)
 ```
-This runs all workflows randomly mixed together.
 
-### Option 4: Individual Test Control
+### What it measures
 
-**Test specific workflow types:**
+| Benchmark | What it tests |
+|-----------|--------------|
+| `bench-noop` | Pure orchestrator overhead — single noop step, instant return |
+| `bench-noop-parallel` | Parallel step scheduling — 10 concurrent noop steps per run |
+| `bench-sleep-10ms` | Concurrent flow capacity with 10ms simulated latency |
+| `bench-sleep-100ms` | Concurrent flow capacity with 100ms simulated latency |
+| `bench-routed-noop` | Full gRPC dispatch path (requires bench worker) |
+| `bench-python-echo` | Python worker roundtrip overhead (requires Python + uv) |
 
-**Standalone:**
+### Output
+
+Each benchmark prints a table like:
+
+```
+== bench-noop ==
+
+  Total runs:    15234
+  Completed:     15234
+  Failed:        0 (0.0%)
+  Throughput:    84.6 runs/sec
+
+  Load Level                p50       p95       p99       min       max    count
+  ----------------------------------------------------------------------------------
+  Overall                   8ms      45ms     120ms       2ms     350ms    15234
+  Low (≤10 VUs)             3ms       8ms      15ms       2ms      25ms     1200
+  Medium (≤100 VUs)        12ms      35ms      55ms       3ms     120ms     5400
+  High (≤500 VUs)          25ms      80ms     150ms       5ms     350ms     8634
+```
+
+A final summary table compares all benchmarks:
+
+```
+  Workflow                     Runs/sec        p50        p95    Errors
+  --------                     --------        ---        ---    ------
+  bench-noop                      84.6        8ms       45ms      0.0%
+  bench-noop-parallel             42.1       18ms       90ms      0.0%
+  bench-sleep-10ms                78.2       15ms       55ms      0.0%
+  bench-sleep-100ms               55.3      110ms      180ms      0.0%
+```
+
+### Options
+
 ```bash
-cd load-tests/scripts
-k6 run --env WORKFLOW_TYPE=rust-builtin-messages single-standalone-test.js
-k6 run --env WORKFLOW_TYPE=python-custom-messages single-standalone-test.js
-k6 run --env WORKFLOW_TYPE=python-udf-messages single-standalone-test.js
+./bench.sh --help           # Show all options
+./bench.sh --url URL        # Use an already-running server (skip build/start)
+./bench.sh --with-python    # Include Python worker benchmarks
+./bench.sh --with-routed    # Include routed-noop (needs bench worker running)
+./bench.sh --port 8080      # Use a different port
 ```
 
-**OpenAI:**
+### Running with the bench worker (for gRPC dispatch benchmarks)
+
 ```bash
-cd load-tests/scripts
-k6 run --env WORKFLOW_TYPE=rust-builtin-openai single-openai-test.js
-k6 run --env WORKFLOW_TYPE=python-custom-openai single-openai-test.js
-k6 run --env WORKFLOW_TYPE=python-udf-openai single-openai-test.js
+# Terminal 1: Start the benchmark suite (will start the server)
+./bench.sh --with-routed
+
+# Terminal 2: Start the bench worker (before bench.sh reaches bench-routed-noop)
+cd sdks/rust
+cargo run -p stepflow-bench-worker --release -- --queue-name bench --workers 10
 ```
 
-### Option 3: Manual Setup
+### Running individual benchmarks
 
-1. **Build and Start Stepflow Service**:
-   ```bash
-   cd stepflow-rs
-   cargo build --release
-   cargo run --release -- serve --port=7837 --config=../load-tests/workflows/stepflow-config.yml
-   ```
+```bash
+# Start server manually
+cd stepflow-rs
+cargo run --release -- serve --port=7837 --config=../load-tests/workflows/bench-config.yml
 
-2. **Run k6 Load Test**:
-   ```bash
-   cd load-tests/scripts
-   # Mixed workflow test
-   k6 run --env STEPFLOW_URL=http://localhost:7837 load-test.js
-   
-   # Individual workflow tests
-   k6 run --env STEPFLOW_URL=http://localhost:7837 --env WORKFLOW_TYPE=rust-builtin-openai single-workflow-test.js
-   ```
+# Run a specific benchmark
+cd load-tests/scripts
+k6 run --env WORKFLOW_TYPE=bench-noop bench-orchestrator.js
+k6 run --env WORKFLOW_TYPE=bench-sleep-100ms bench-orchestrator.js
+k6 run bench-worker.js  # Python worker benchmark
+```
 
-## Test Configuration
+### Results
 
-### Load Test Stages
+JSON results are saved to `results/bench_TIMESTAMP/` for sharing and comparison across hardware.
 
-#### Mixed Workflow Test (load-test.js)
-- **Warm up**: 30s with 1 user
-- **Ramp up**: 1m to reach 5 users
-- **Sustain**: 2m at 5 users
-- **Scale up**: 1m to reach 10 users  
-- **Sustain**: 2m at 10 users
-- **Peak load**: 1m to reach 20 users
-- **Peak sustain**: 2m at 20 users
-- **Ramp down**: 30s to 0 users
+---
 
-Total test duration: ~9 minutes
+## Load Tests (End-to-End with OpenAI)
 
-#### Individual Workflow Test (single-workflow-test.js) - Aggressive Load Testing
-- **Quick warm up**: 10s to 5 users
-- **Low load tier**: 20s to 10 users (baseline performance)
-- **Medium ramp**: 30s to 25 users → 20s to 50 users
-- **Medium load tier**: 30s at 100 users (load impact measurement)
-- **High ramp**: 20s to 200 users
-- **High load tier**: 30s at 300 users (stress testing)
-- **Peak test**: 15s to 500 users (extreme limit finding)
-- **Peak sustain**: 20s at 500 users
-- **Ramp down**: 10s to 0 users
+Older load tests that measure end-to-end performance including OpenAI API calls.
 
-Total test duration: ~3.5 minutes (aggressive load testing optimized for finding breaking points)
+### Standalone Tests (No OpenAI)
 
-### Performance Thresholds
-- **Response Time**: 95% of requests must complete within 30 seconds
-- **Failure Rate**: Must be less than 10%
+```bash
+cd load-tests
+./scripts/start-standalone-service.sh       # Terminal 1
+./scripts/run-single-standalone-tests.sh    # Terminal 2
+```
 
-### Test Data
-- **20 diverse prompts** covering various topics (AI, technology, health, etc.)
-- **Random selection** of prompts and workflows for each request
-- **Structured system messages** tailored to each prompt type
+Tests three workflow types with simple message creation:
+- `rust-builtin-messages` — Direct Rust built-in components
+- `python-custom-messages` — Python custom component server
+- `python-udf-messages` — Python UDF with blob storage
 
-## Interpreting Results
+### OpenAI Tests
 
-### Key Metrics to Monitor
+```bash
+export OPENAI_API_KEY="your-key"
+cd load-tests
+./scripts/start-service.sh                  # Terminal 1
+./scripts/run-single-openai-tests.sh        # Terminal 2
+```
 
-#### Overall Metrics
-1. **Average Response Time**: Overall latency per request
-2. **95th Percentile Response Time**: Performance under load
-3. **Request Rate**: Requests per second handled
-4. **Failure Rate**: Percentage of failed requests
-5. **HTTP Request Duration**: Time spent in HTTP calls
-6. **Iterations**: Total number of test iterations completed
+---
 
-#### Per-Workflow Metrics (Available in mixed tests)
-1. **python_udf_response_time**: Response times for Python UDF workflow
-2. **python_udf_failure_rate**: Failure rate for Python UDF workflow
-3. **python_custom_response_time**: Response times for Python custom component workflow
-4. **python_custom_failure_rate**: Failure rate for Python custom component workflow
-5. **rust_builtin_response_time**: Response times for Rust built-in workflow
-6. **rust_builtin_failure_rate**: Failure rate for Rust built-in workflow
-7. **Request distribution**: How many requests went to each workflow type
+## Prerequisites
 
-#### Load-Level Performance Metrics (Individual workflow tests)
-
-**Latency Metrics:**
-1. **low_load_latency**: Response times at ≤10 concurrent users (baseline performance)
-2. **medium_load_latency**: Response times at ≤100 concurrent users (moderate load impact)
-3. **high_load_latency**: Response times at ≤500 concurrent users (extreme stress conditions)
-
-**Throughput Metrics (Request Counters - k6 shows both count and RPS):**
-1. **low_load_requests**: Request count and rate at ≤10 concurrent users (baseline throughput)
-2. **medium_load_requests**: Request count and rate at ≤100 concurrent users (throughput under load)
-3. **high_load_requests**: Request count and rate at ≤500 concurrent users (throughput under extreme stress)
-
-These metrics help identify:
-- **Performance scaling**: How latency changes as load increases
-- **Throughput limits**: Maximum RPS each workflow can handle at different load levels
-- **Breaking points**: Where each integration approach starts failing
-
-### Expected Performance Characteristics
-
-- **Rust Built-in**: Fastest due to direct integration
-- **Python Custom**: Moderate performance with component overhead
-- **Python UDF**: Potentially slower due to blob creation and Python execution
-
-### Common Performance Bottlenecks
-
-1. **OpenAI API Rate Limits**: May cause failures at high load
-2. **Python Process Startup**: UDF and custom components need Python processes
-3. **Network Latency**: OpenAI API calls add external dependency latency
-4. **Memory Usage**: Large blobs (UDF code) may impact memory
-5. **Plugin Communication**: Stdio transport adds serialization overhead
-
-## Customization
-
-### Adjusting Load Patterns
-Edit `load-test.js` to modify:
-- **User counts**: Change `target` values in `stages`
-- **Duration**: Adjust `duration` values for each stage
-- **Ramp patterns**: Add/remove stages for different load curves
-
-### Adding Test Prompts
-Edit `test-prompts.json` to:
-- Add more prompts for variety
-- Adjust system messages for different contexts
-- Include edge cases (very long/short prompts)
-
-### Modifying Workflows
-- Edit workflow YAML files to test different configurations
-- Adjust OpenAI parameters (temperature, max_tokens, etc.)
-- Add new workflow types by creating additional YAML files
-
-### Different Models
-Change the model in workflow files from `gpt-4o-mini` to:
-- `gpt-4o`
-- `gpt-4-turbo`
-- `gpt-3.5-turbo`
-- Any other supported OpenAI model
-
-## Troubleshooting
-
-### Service Won't Start
-- Check `OPENAI_API_KEY` is set
-- Verify port 7837 is available: `lsof -i :7837`
-- Check Stepflow builds successfully: `cd stepflow-rs && cargo build`
-
-### Load Test Failures
-- Verify service is healthy: `curl http://localhost:7837/health`
-- Check OpenAI API key validity
-- Monitor OpenAI rate limits and quotas
-- Review Stepflow service logs for errors
-
-### Python Component Issues
-- Ensure Python SDK dependencies are installed
-- Check Python environment: `cd sdks/python && uv run python --version`
-- Verify custom server script permissions
-
-### Performance Issues
-- Monitor system resources (CPU, memory)
-- Check OpenAI API response times
-- Consider reducing concurrent users
-- Review workflow complexity
-
-## Output Files
-
-Load test results are saved to the `scripts/results/` directory:
-- `results_TIMESTAMP.json`: Raw k6 metrics data
-- `summary_TIMESTAMP.json`: Test summary statistics
-
-Use k6's built-in analysis tools or import JSON data into your preferred analysis platform for detailed performance analysis.
+- **Rust toolchain** (cargo)
+- **k6**: `brew install k6` (macOS) or see [k6 installation](https://k6.io/docs/getting-started/installation/)
+- **For Python benchmarks**: Python + uv
+- **For OpenAI tests**: `OPENAI_API_KEY` environment variable

--- a/load-tests/bench.sh
+++ b/load-tests/bench.sh
@@ -1,0 +1,531 @@
+#!/bin/bash
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# ============================================================================
+# Stepflow Benchmark Suite
+# ============================================================================
+#
+# Single command to build, start the server, run benchmarks, and print results.
+#
+# Usage:
+#   ./bench.sh                    # Run all orchestrator benchmarks
+#   ./bench.sh --quick            # Shorter test (fewer VUs, shorter stages)
+#   ./bench.sh --skip-python      # Skip Python worker benchmarks
+#   ./bench.sh --skip-routed      # Skip routed-noop (needs bench worker)
+#   ./bench.sh --url URL          # Use an already-running server
+#
+# Prerequisites:
+#   - Rust toolchain (cargo)
+#   - k6 (https://k6.io/docs/getting-started/installation/)
+#   - For Python benchmarks: Python + uv
+#
+# ============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PORT=7837
+STEPFLOW_URL=""
+SKIP_PYTHON=true   # Skip Python by default (requires extra setup)
+SKIP_ROUTED=true   # Skip routed by default (requires bench worker)
+SKIP_RUST=true     # Skip Rust echo by default (requires bench worker echo mode)
+EXTERNAL_SERVER=false
+QUICK=false
+WORKER_CONCURRENCY=100  # Max concurrent tasks per worker process
+SERVER_PID=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --url)
+            STEPFLOW_URL="$2"
+            EXTERNAL_SERVER=true
+            shift 2
+            ;;
+        --port)
+            PORT="$2"
+            shift 2
+            ;;
+        --skip-python)
+            SKIP_PYTHON=true
+            shift
+            ;;
+        --with-python)
+            SKIP_PYTHON=false
+            shift
+            ;;
+        --skip-routed)
+            SKIP_ROUTED=true
+            shift
+            ;;
+        --with-routed)
+            SKIP_ROUTED=false
+            shift
+            ;;
+        --skip-rust)
+            SKIP_RUST=true
+            shift
+            ;;
+        --with-rust)
+            SKIP_RUST=false
+            shift
+            ;;
+        --concurrency)
+            WORKER_CONCURRENCY="$2"
+            shift 2
+            ;;
+        --quick)
+            QUICK=true
+            shift
+            ;;
+        -h|--help)
+            echo "Stepflow Benchmark Suite"
+            echo ""
+            echo "Usage: $0 [options]"
+            echo ""
+            echo "Options:"
+            echo "  --url URL          Use an already-running server (skip build/start)"
+            echo "  --port PORT        Server port (default: 7837, ignored with --url)"
+            echo "  --quick            Shorter test run (good for smoke testing)"
+            echo "  --concurrency N    Max concurrent tasks per worker (default: 100)"
+            echo "  --with-python      Include Python worker benchmarks (requires uv)"
+            echo "  --with-rust        Include Rust echo worker benchmark (requires bench worker)"
+            echo "  --with-routed      Include routed-noop (requires bench worker running)"
+            echo "  --skip-python      Skip Python worker benchmarks (default)"
+            echo "  --skip-rust        Skip Rust echo worker benchmarks (default)"
+            echo "  --skip-routed      Skip routed-noop benchmarks (default)"
+            echo "  -h, --help         Show this help"
+            echo ""
+            echo "Benchmarks run by default (builtin-only, no external deps):"
+            echo "  bench-noop-1         Single noop step (per-flow overhead baseline)"
+            echo "  bench-noop-parallel  10 parallel noop steps (per-step scaling)"
+            echo "  bench-noop-100       100 parallel noop steps (per-step scaling)"
+            echo "  bench-sleep-10ms     Concurrent flow capacity (10ms simulated latency)"
+            echo "  bench-sleep-100ms    Concurrent flow capacity (100ms simulated latency)"
+            echo ""
+            echo "Optional benchmarks (require extra setup):"
+            echo "  bench-rust-echo      Rust worker overhead (needs: stepflow-bench-worker echo)"
+            echo "  bench-routed-noop    gRPC dispatch path (needs: stepflow-bench-worker instant)"
+            echo "  bench-python-echo    Python worker overhead (needs: Python + uv)"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1 (try --help)"
+            exit 1
+            ;;
+    esac
+done
+
+if [ "$EXTERNAL_SERVER" = false ]; then
+    # Use 127.0.0.1 (not localhost) to match the orchestrator's advertised
+    # address in TaskContext, so workers reuse the same gRPC channel.
+    STEPFLOW_URL="http://127.0.0.1:${PORT}"
+fi
+
+# Results directory
+RESULTS_DIR="$SCRIPT_DIR/results/bench_$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$RESULTS_DIR"
+
+# --- Checks ---
+
+if ! command -v k6 &> /dev/null; then
+    echo "Error: k6 is not installed"
+    echo "Install: https://grafana.com/docs/k6/latest/set-up/install-k6/"
+    exit 1
+fi
+
+# --- Cleanup handler ---
+
+RUST_ECHO_PID=""
+INSTANT_PID=""
+
+cleanup() {
+    for pid_var in RUST_ECHO_PID INSTANT_PID SERVER_PID; do
+        pid="${!pid_var}"
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    done
+}
+trap cleanup EXIT
+
+# --- Build and start server ---
+
+if [ "$EXTERNAL_SERVER" = false ]; then
+    echo "Building Stepflow (release)..."
+    cd "$SCRIPT_DIR/../stepflow-rs"
+    cargo build --release -p stepflow-server 2>&1 | tail -1
+
+    CONFIG_PATH="$SCRIPT_DIR/workflows/bench-config.yml"
+    if [ ! -f "$CONFIG_PATH" ]; then
+        echo "Error: Config not found at $CONFIG_PATH"
+        exit 1
+    fi
+
+    # Check port
+    if lsof -Pi :"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
+        echo "Error: Port $PORT already in use (lsof -i :$PORT to check)"
+        exit 1
+    fi
+
+    # Export so Python worker subprocess inherits the concurrency setting
+    export STEPFLOW_MAX_CONCURRENT="$WORKER_CONCURRENCY"
+
+    echo "Starting Stepflow server on port $PORT (worker concurrency: $WORKER_CONCURRENCY)..."
+    ./target/release/stepflow-server \
+        --port="$PORT" \
+        --config="$CONFIG_PATH" \
+        --log-level=warn \
+        > "$RESULTS_DIR/stepflow-server.log" 2>&1 &
+    SERVER_PID=$!
+
+    # Wait for server to be ready
+    echo -n "Waiting for server"
+    for i in $(seq 1 30); do
+        if curl -sf "$STEPFLOW_URL/api/v1/health" > /dev/null 2>&1; then
+            echo " ready."
+            break
+        fi
+        if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            echo ""
+            echo "Error: Server process died. Check $RESULTS_DIR/stepflow-server.log"
+            exit 1
+        fi
+        echo -n "."
+        sleep 1
+    done
+
+    if ! curl -sf "$STEPFLOW_URL/api/v1/health" > /dev/null 2>&1; then
+        echo ""
+        echo "Error: Server failed to start within 30s"
+        exit 1
+    fi
+else
+    echo "Using external server at $STEPFLOW_URL"
+    if ! curl -sf "$STEPFLOW_URL/api/v1/health" > /dev/null 2>&1; then
+        echo "Error: Server not responding at $STEPFLOW_URL"
+        exit 1
+    fi
+    echo "Server is healthy."
+fi
+
+# --- Start bench workers if needed ---
+
+BENCH_WORKER_BIN="$SCRIPT_DIR/../sdks/rust/target/release/stepflow-bench-worker"
+
+if [ "$SKIP_RUST" = false ] || [ "$SKIP_ROUTED" = false ]; then
+    # Build the bench worker binary
+    echo "Building stepflow-bench-worker (release)..."
+    cd "$SCRIPT_DIR/../sdks/rust"
+    cargo build --release -p stepflow-bench-worker 2>&1 | tail -1
+fi
+
+if [ "$SKIP_RUST" = false ]; then
+    echo "Starting Rust echo worker (concurrency: $WORKER_CONCURRENCY)..."
+    "$BENCH_WORKER_BIN" echo \
+        --tasks-url "$STEPFLOW_URL" \
+        --queue-name rust \
+        --max-concurrent "$WORKER_CONCURRENCY" \
+        > "$RESULTS_DIR/rust-echo-worker.log" 2>&1 &
+    RUST_ECHO_PID=$!
+    sleep 2
+    if ! kill -0 "$RUST_ECHO_PID" 2>/dev/null; then
+        echo "Warning: Rust echo worker failed to start. Check $RESULTS_DIR/rust-echo-worker.log"
+        SKIP_RUST=true
+    else
+        echo "Rust echo worker started (pid $RUST_ECHO_PID)"
+    fi
+fi
+
+if [ "$SKIP_ROUTED" = false ]; then
+    echo "Starting instant-completion worker..."
+    "$BENCH_WORKER_BIN" instant \
+        --tasks-url "$STEPFLOW_URL" \
+        --queue-name bench \
+        --workers 10 \
+        > "$RESULTS_DIR/instant-worker.log" 2>&1 &
+    INSTANT_PID=$!
+    sleep 2
+    if ! kill -0 "$INSTANT_PID" 2>/dev/null; then
+        echo "Warning: Instant worker failed to start. Check $RESULTS_DIR/instant-worker.log"
+        SKIP_ROUTED=true
+    else
+        echo "Instant worker started (pid $INSTANT_PID)"
+    fi
+fi
+
+# --- Run benchmarks ---
+
+cd "$SCRIPT_DIR/scripts"
+
+# Override k6 stages for quick mode
+K6_QUICK_OPTS=""
+if [ "$QUICK" = true ]; then
+    # k6 doesn't support overriding stages via CLI, so we use a shorter duration multiplier
+    # by setting an env var that the script can check
+    K6_QUICK_OPTS="--env QUICK=true"
+    echo ""
+    echo "Quick mode: running with reduced load (good for smoke testing)"
+fi
+
+# Run worker-dependent benchmarks FIRST (lower load, avoids port exhaustion
+# from the high-throughput orchestrator benchmarks that follow).
+
+echo ""
+echo "============================================"
+echo "  Stepflow Benchmark Suite"
+echo "============================================"
+echo ""
+
+# Rust echo worker (requires bench worker echo mode)
+if [ "$SKIP_RUST" = false ]; then
+    echo "--- Running: bench-rust-echo ---"
+    k6 run --quiet \
+        --env STEPFLOW_URL="$STEPFLOW_URL" \
+        --env WORKFLOW_TYPE="bench-rust-echo" \
+        --env RESULTS_DIR="$RESULTS_DIR" \
+        $K6_QUICK_OPTS \
+        bench-orchestrator.js || true
+    sleep 2
+fi
+
+# Routed noop (requires bench worker instant mode)
+if [ "$SKIP_ROUTED" = false ]; then
+    echo "--- Running: bench-routed-noop ---"
+    k6 run --quiet \
+        --env STEPFLOW_URL="$STEPFLOW_URL" \
+        --env WORKFLOW_TYPE="bench-routed-noop" \
+        --env RESULTS_DIR="$RESULTS_DIR" \
+        $K6_QUICK_OPTS \
+        bench-orchestrator.js || true
+    sleep 2
+fi
+
+# Python worker (requires Python + uv)
+if [ "$SKIP_PYTHON" = false ]; then
+    echo "--- Running: bench-python-echo ---"
+    k6 run --quiet \
+        --env STEPFLOW_URL="$STEPFLOW_URL" \
+        --env RESULTS_DIR="$RESULTS_DIR" \
+        $K6_QUICK_OPTS \
+        bench-worker.js || true
+    sleep 2
+fi
+
+# Orchestrator benchmarks (builtin-only, high throughput — run last to
+# avoid ephemeral port exhaustion affecting worker benchmarks above).
+ORCHESTRATOR_WORKFLOWS=("bench-noop-1" "bench-noop-parallel" "bench-noop-100" "bench-sleep-10ms" "bench-sleep-100ms")
+
+for workflow in "${ORCHESTRATOR_WORKFLOWS[@]}"; do
+    echo "--- Running: $workflow ---"
+    k6 run --quiet \
+        --env STEPFLOW_URL="$STEPFLOW_URL" \
+        --env WORKFLOW_TYPE="$workflow" \
+        --env RESULTS_DIR="$RESULTS_DIR" \
+        $K6_QUICK_OPTS \
+        bench-orchestrator.js || true
+    sleep 2
+done
+
+# --- Final summary ---
+
+echo ""
+echo "============================================"
+echo "  Results saved to: $RESULTS_DIR/"
+echo "============================================"
+echo ""
+
+# Print combined JSON results if any exist
+JSON_FILES=("$RESULTS_DIR"/*.json)
+if [ ${#JSON_FILES[@]} -gt 0 ] && [ -f "${JSON_FILES[0]}" ]; then
+    echo "Summary (throughput across all benchmarks):"
+    echo ""
+    printf "  %-24s %12s %10s %10s %10s %10s\n" "Workflow" "Runs/sec" "avg" "med" "p95" "Errors"
+    printf "  %-24s %12s %10s %10s %10s %10s\n" "--------" "--------" "---" "---" "---" "------"
+    for f in "$RESULTS_DIR"/*.json; do
+        [ -f "$f" ] || continue
+        if command -v python3 &> /dev/null; then
+            python3 -c "
+import json, sys
+d = json.load(open('$f'))
+name = d.get('workflow', '?')
+rps = d.get('throughput_rps', 0)
+err = d.get('error_rate_pct', 0)
+lat = d.get('latency', {}).get('overall', {})
+avg = lat.get('avg', 0)
+med = lat.get('med', 0)
+p95 = lat.get('p95', 0)
+def fmt(ms):
+    if ms < 1: return '<1ms'
+    if ms < 1000: return f'{ms:.0f}ms'
+    return f'{ms/1000:.2f}s'
+print(f'  {name:<24} {rps:>12.1f} {fmt(avg):>10} {fmt(med):>10} {fmt(p95):>10} {err:>9.1f}%')
+" 2>/dev/null || true
+        fi
+    done
+    echo ""
+
+    # --- Derived analysis ---
+    if command -v python3 &> /dev/null; then
+        python3 -c "
+import json, glob, os
+
+# Load all results
+results = {}
+for f in sorted(glob.glob(os.path.join('$RESULTS_DIR', '*.json'))):
+    d = json.load(open(f))
+    results[d['workflow']] = d
+
+# --- Per-step analysis (from noop scaling series) ---
+noop_series = []
+for name, steps in [('bench-noop-1', 1), ('bench-noop-parallel', 10), ('bench-noop-100', 100)]:
+    if name in results:
+        r = results[name]
+        med = r.get('latency', {}).get('overall', {}).get('med', 0)
+        rps = r.get('throughput_rps', 0)
+        noop_series.append((name, steps, med, rps))
+
+if len(noop_series) >= 2:
+    print('Derived Metrics:')
+    print('')
+
+    # Steps/sec throughput
+    print('  Steps/sec throughput:')
+    for name, steps, med, rps in noop_series:
+        sps = rps * steps
+        print(f'    {name:<24} {sps:>10,.0f} steps/sec  ({steps} steps x {rps:,.0f} runs/sec)')
+    print('')
+
+    # Per-step overhead estimation
+    # Model: median_ms = flow_overhead + steps * per_step_overhead
+    # Solve using least-squares with 2+ points
+    if len(noop_series) >= 2:
+        # Simple linear regression: t = a + b*n
+        n_vals = [s[1] for s in noop_series]
+        t_vals = [s[2] for s in noop_series]
+        n_mean = sum(n_vals) / len(n_vals)
+        t_mean = sum(t_vals) / len(t_vals)
+        num = sum((n - n_mean) * (t - t_mean) for n, t in zip(n_vals, t_vals))
+        den = sum((n - n_mean) ** 2 for n in n_vals)
+        if den > 0:
+            per_step = num / den  # ms per step
+            flow_overhead = t_mean - per_step * n_mean
+            print(f'  Per-flow overhead:      ~{max(0, flow_overhead):.1f}ms  (estimated from noop scaling)')
+            print(f'  Per-step overhead:      ~{per_step:.2f}ms  (median, parallel scheduling)')
+            print('')
+
+# --- Concurrency estimation (from sleep benchmarks, Little's Law) ---
+sleep_data = []
+for name, sleep_ms in [('bench-sleep-10ms', 10), ('bench-sleep-100ms', 100)]:
+    if name in results:
+        r = results[name]
+        med = r.get('latency', {}).get('overall', {}).get('med', 0)
+        rps = r.get('throughput_rps', 0)
+        if rps > 0 and med > 0:
+            concurrency = rps * (med / 1000.0)  # Little's Law: L = lambda * W
+            overhead = med - sleep_ms
+            sleep_data.append((name, sleep_ms, rps, med, concurrency, overhead))
+
+if sleep_data:
+    print('  Concurrent flow capacity (Little\\'s Law: concurrency = throughput x latency):')
+    for name, sleep_ms, rps, med, conc, overhead in sleep_data:
+        print(f'    {name:<24} ~{conc:,.0f} concurrent flows  ({rps:,.0f} rps x {med:.0f}ms med, {overhead:.0f}ms overhead)')
+    print('')
+
+# --- Orchestrator capacity ---
+if len(noop_series) >= 2:
+    max_sps = max(rps * steps for _, steps, _, rps in noop_series)
+    max_fps = max(rps for _, steps, _, rps in noop_series if steps == 1) if any(s == 1 for _, s, _, _ in noop_series) else noop_series[0][3]
+    print(f'  Orchestrator ceiling (free components):')
+    print(f'    Max steps/sec:       ~{max_sps:,.0f}')
+    print(f'    Max flows/sec:       ~{max_fps:,.0f}  (single-step flows)')
+    print('')
+
+# --- Worker overhead and crossover analysis ---
+# Collect per-task overhead from echo benchmarks
+workers = []  # (label, overhead_ms, max_concurrent)
+
+# Builtin: overhead from noop-1 median
+if 'bench-noop-1' in results:
+    noop1 = results['bench-noop-1']
+    noop1_med = noop1.get('latency', {}).get('overall', {}).get('med', 0)
+    if noop1_med > 0:
+        workers.append(('Builtin', noop1_med, None, noop1.get('throughput_rps', 0)))
+
+# Rust echo worker
+if 'bench-rust-echo' in results:
+    r = results['bench-rust-echo']
+    med = r.get('latency', {}).get('overall', {}).get('med', 0)
+    rps = r.get('throughput_rps', 0)
+    if med > 0:
+        workers.append(('Rust worker', med, 10, rps))
+
+# Routed instant (bench worker)
+if 'bench-routed-noop' in results:
+    r = results['bench-routed-noop']
+    med = r.get('latency', {}).get('overall', {}).get('med', 0)
+    rps = r.get('throughput_rps', 0)
+    if med > 0:
+        workers.append(('Instant (gRPC)', med, None, rps))
+
+# Python echo worker
+if 'bench-python-echo' in results:
+    r = results['bench-python-echo']
+    med = r.get('latency', {}).get('overall', {}).get('med', 0)
+    rps = r.get('throughput_rps', 0)
+    if med > 0:
+        workers.append(('Python worker', med, 4, rps))
+
+if len(workers) >= 2:
+    print('  Worker overhead (per-task gRPC + execution cost):')
+    print(f'    {\"Backend\":<20} {\"Overhead\":>10} {\"Observed rps\":>14} {\"Plumbing bottleneck if task <\":>30}')
+    print(f'    {\"-\" * 20} {\"-\" * 10} {\"-\" * 14} {\"-\" * 30}')
+    for label, overhead, conc, rps in workers:
+        print(f'    {label:<20} {overhead:>9.1f}ms {rps:>13,.0f} {overhead:>25.0f}ms')
+    print('')
+
+    # Throughput projection table
+    print('  Projected throughput by component execution time:')
+    compute_times = [0, 1, 10, 100, 1000]
+    header = f'    {\"Compute time\":<14}'
+    for label, _, _, _ in workers:
+        header += f' {label:>16}'
+    print(header)
+    print(f'    {\"-\" * 14}' + ''.join(f' {\"-\" * 16}' for _ in workers))
+
+    for ct in compute_times:
+        row = f'    {str(ct) + \"ms\":<14}'
+        for label, overhead, conc, observed_rps in workers:
+            if ct == 0:
+                rps_est = observed_rps
+            else:
+                total_ms = ct + overhead
+                if conc is not None:
+                    rps_est = conc / (total_ms / 1000.0)
+                else:
+                    # For builtin/instant, use observed throughput scaled
+                    rps_est = 1000.0 / total_ms * (observed_rps * overhead / 1000.0) if overhead > 0 else observed_rps
+                    # Simpler: just use Little's Law with observed concurrency
+                    observed_conc = observed_rps * (overhead / 1000.0)
+                    rps_est = observed_conc / (total_ms / 1000.0)
+            row += f' {rps_est:>14,.0f}/s'
+        print(row)
+    print('')
+" 2>/dev/null || true
+    fi
+fi
+
+echo "To share results, copy the JSON files from $RESULTS_DIR/"

--- a/load-tests/scripts/bench-orchestrator.js
+++ b/load-tests/scripts/bench-orchestrator.js
@@ -1,0 +1,247 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Rate, Trend, Counter } from 'k6/metrics';
+// Custom metrics
+const failureRate = new Rate('failed_requests');
+const runLatency = new Trend('run_latency');
+const completedRuns = new Counter('completed_runs');
+const failedRuns = new Counter('failed_runs');
+
+// Load-level metrics
+const lowLoadLatency = new Trend('low_load_latency');       // ≤10 VUs
+const mediumLoadLatency = new Trend('medium_load_latency');  // ≤100 VUs
+const highLoadLatency = new Trend('high_load_latency');      // ≤500 VUs
+const extremeLoadLatency = new Trend('extreme_load_latency'); // >500 VUs
+
+// Get workflow type from environment variable
+const WORKFLOW_TYPE = __ENV.WORKFLOW_TYPE || 'bench-noop';
+const RESULTS_DIR = __ENV.RESULTS_DIR || '';
+
+// Valid workflow types and their files
+const workflowFiles = {
+  'bench-noop': '../workflows/bench-noop.json',
+  'bench-noop-1': '../workflows/bench-noop-1.json',
+  'bench-noop-parallel': '../workflows/bench-noop-parallel.json',
+  'bench-noop-100': '../workflows/bench-noop-100.json',
+  'bench-sleep-10ms': '../workflows/bench-sleep-10ms.json',
+  'bench-sleep-100ms': '../workflows/bench-sleep-100ms.json',
+  'bench-routed-noop': '../workflows/bench-routed-noop.json',
+  'bench-rust-echo': '../workflows/bench-rust-echo.json',
+  'bench-python-echo': '../workflows/bench-python-echo.json',
+};
+
+if (!workflowFiles[WORKFLOW_TYPE]) {
+  throw new Error(
+    `Unknown WORKFLOW_TYPE: ${WORKFLOW_TYPE}. Valid types: ${Object.keys(workflowFiles).join(', ')}`
+  );
+}
+
+const workflowDefinition = JSON.parse(open(workflowFiles[WORKFLOW_TYPE]));
+
+// Stepflow service configuration
+const STEPFLOW_URL = __ENV.STEPFLOW_URL || 'http://localhost:7837';
+const API_BASE = `${STEPFLOW_URL}/api/v1`;
+
+// Test configuration - aggressive ramp to find throughput ceiling
+const QUICK = __ENV.QUICK === 'true';
+
+const fullStages = [
+  { duration: '10s', target: 10 },     // Warm up
+  { duration: '20s', target: 10 },     // Baseline at low load
+  { duration: '15s', target: 100 },    // Ramp to medium
+  { duration: '30s', target: 100 },    // Sustain medium
+  { duration: '15s', target: 500 },    // Ramp to high
+  { duration: '30s', target: 500 },    // Sustain high
+  { duration: '15s', target: 1000 },   // Ramp to extreme
+  { duration: '30s', target: 1000 },   // Sustain extreme
+  { duration: '15s', target: 0 },      // Ramp down
+];
+
+const quickStages = [
+  { duration: '5s', target: 10 },      // Warm up
+  { duration: '10s', target: 10 },     // Low load
+  { duration: '5s', target: 100 },     // Ramp
+  { duration: '10s', target: 100 },    // Medium load
+  { duration: '5s', target: 500 },     // Ramp
+  { duration: '10s', target: 500 },    // High load
+  { duration: '5s', target: 0 },       // Ramp down
+];
+
+export const options = {
+  stages: QUICK ? quickStages : fullStages,
+  // No thresholds — benchmarks measure limits, not enforce them.
+  // Threshold failures would just add noise to the output.
+  thresholds: {},
+};
+
+export function setup() {
+  // Health check
+  const healthCheck = http.get(`${STEPFLOW_URL}/api/v1/health`);
+  if (healthCheck.status !== 200) {
+    throw new Error(`Stepflow service not available at ${STEPFLOW_URL}`);
+  }
+
+  // Store workflow definition
+  const storeParams = {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: '30s',
+  };
+
+  const flowPayload = { flow: workflowDefinition };
+  const storeResponse = http.post(
+    `${API_BASE}/flows`,
+    JSON.stringify(flowPayload),
+    storeParams
+  );
+
+  if (storeResponse.status !== 200) {
+    throw new Error(
+      `Failed to store workflow: ${storeResponse.status} - ${storeResponse.body}`
+    );
+  }
+
+  const storeResult = JSON.parse(storeResponse.body);
+  if (!storeResult.flowId) {
+    throw new Error(`No flowId returned: ${storeResponse.body}`);
+  }
+
+  return { flowId: storeResult.flowId };
+}
+
+export default function (data) {
+  const runPayload = {
+    flowId: data.flowId,
+    input: [{ data: 'bench' }],
+    wait: true,
+  };
+
+  const params = {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: '120s',
+  };
+
+  const startTime = Date.now();
+  const response = http.post(
+    `${API_BASE}/runs`,
+    JSON.stringify(runPayload),
+    params
+  );
+  const duration = Date.now() - startTime;
+
+  // Record latency
+  runLatency.add(duration);
+
+  // Bucket by load level
+  if (__VU <= 10) {
+    lowLoadLatency.add(duration);
+  } else if (__VU <= 100) {
+    mediumLoadLatency.add(duration);
+  } else if (__VU <= 500) {
+    highLoadLatency.add(duration);
+  } else {
+    extremeLoadLatency.add(duration);
+  }
+
+  const success = check(response, {
+    'status is 200': (r) => r.status === 200,
+    'response has summary': (r) => {
+      try {
+        return JSON.parse(r.body).summary !== undefined;
+      } catch (e) {
+        return false;
+      }
+    },
+  });
+
+  if (success) {
+    completedRuns.add(1);
+  } else {
+    failedRuns.add(1);
+  }
+  failureRate.add(!success);
+
+  if (!success && __ITER % 100 === 0) {
+    console.error(`Request failed: ${response.status} - ${response.body}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Custom summary — print a concise results table
+// ---------------------------------------------------------------------------
+
+function fmt(ms) {
+  if (ms === undefined || ms === null) return '-';
+  if (ms < 1) return '<1ms';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function trendRow(label, trend) {
+  if (!trend || !trend.values) return null;
+  const v = trend.values;
+  // Skip rows with no actual data (metric created but no .add() calls)
+  if (v['count'] === 0 || (v['avg'] === 0 && v['min'] === 0 && v['max'] === 0)) return null;
+  return `  ${label.padEnd(22)} ${fmt(v['avg']).padStart(8)}  ${fmt(v['med']).padStart(8)}  ${fmt(v['p(90)']).padStart(8)}  ${fmt(v['p(95)']).padStart(8)}  ${fmt(v['max']).padStart(8)}`;
+}
+
+export function handleSummary(data) {
+  const m = data.metrics;
+  const completed = m.completed_runs ? m.completed_runs.values.count : 0;
+  const failed = m.failed_runs ? m.failed_runs.values.count : 0;
+  const total = completed + failed;
+  const duration = m.iteration_duration ? m.iteration_duration.values['max'] : 0;
+  const testDurationSecs = (data.state ? data.state.testRunDurationMs : 0) / 1000 || 1;
+  const rps = (total / testDurationSecs).toFixed(1);
+  const errorRate = total > 0 ? ((failed / total) * 100).toFixed(1) : '0.0';
+
+  const header = `  ${'Load Level'.padEnd(22)} ${'avg'.padStart(8)}  ${'med'.padStart(8)}  ${'p90'.padStart(8)}  ${'p95'.padStart(8)}  ${'max'.padStart(8)}`;
+  const sep = '  ' + '-'.repeat(header.length - 2);
+
+  const rows = [
+    trendRow('Overall', m.run_latency),
+    trendRow('Low (≤10 VUs)', m.low_load_latency),
+    trendRow('Medium (≤100 VUs)', m.medium_load_latency),
+    trendRow('High (≤500 VUs)', m.high_load_latency),
+    trendRow('Extreme (>500 VUs)', m.extreme_load_latency),
+  ].filter(Boolean);
+
+  const table = [
+    '',
+    `== ${WORKFLOW_TYPE} ==`,
+    '',
+    `  Total runs:    ${total}`,
+    `  Completed:     ${completed}`,
+    `  Failed:        ${failed} (${errorRate}%)`,
+    `  Throughput:    ${rps} runs/sec`,
+    '',
+    header,
+    sep,
+    ...rows,
+    sep,
+    '',
+  ].join('\n');
+
+  const outputs = { stdout: table + '\n' };
+
+  // Write JSON summary if RESULTS_DIR is set
+  if (RESULTS_DIR) {
+    const jsonSummary = {
+      workflow: WORKFLOW_TYPE,
+      total_runs: total,
+      completed,
+      failed,
+      error_rate_pct: parseFloat(errorRate),
+      throughput_rps: parseFloat(rps),
+      latency: {},
+    };
+    for (const [key, label] of [['run_latency', 'overall'], ['low_load_latency', 'low'], ['medium_load_latency', 'medium'], ['high_load_latency', 'high'], ['extreme_load_latency', 'extreme']]) {
+      if (m[key] && m[key].values) {
+        const v = m[key].values;
+        jsonSummary.latency[label] = { avg: v['avg'], med: v['med'], p90: v['p(90)'], p95: v['p(95)'], min: v['min'], max: v['max'] };
+      }
+    }
+    outputs[`${RESULTS_DIR}/${WORKFLOW_TYPE}.json`] = JSON.stringify(jsonSummary, null, 2);
+  }
+
+  return outputs;
+}

--- a/load-tests/scripts/bench-worker.js
+++ b/load-tests/scripts/bench-worker.js
@@ -1,0 +1,221 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Rate, Trend, Counter } from 'k6/metrics';
+
+// Custom metrics
+const failureRate = new Rate('failed_requests');
+const runLatency = new Trend('run_latency');
+const completedRuns = new Counter('completed_runs');
+const failedRuns = new Counter('failed_runs');
+
+// Load-level metrics
+const lowLoadLatency = new Trend('low_load_latency');       // ≤10 VUs
+const mediumLoadLatency = new Trend('medium_load_latency');  // ≤50 VUs
+const highLoadLatency = new Trend('high_load_latency');      // >50 VUs
+
+// Stepflow service configuration
+const STEPFLOW_URL = __ENV.STEPFLOW_URL || 'http://localhost:7837';
+const API_BASE = `${STEPFLOW_URL}/api/v1`;
+const RESULTS_DIR = __ENV.RESULTS_DIR || '';
+
+// Python echo workflow
+const workflowDefinition = JSON.parse(open('../workflows/bench-python-echo.json'));
+
+// Test configuration - tuned for worker concurrency limits (lower than orchestrator)
+const QUICK = __ENV.QUICK === 'true';
+
+const fullStages = [
+  { duration: '10s', target: 5 },      // Warm up
+  { duration: '20s', target: 5 },      // Baseline
+  { duration: '15s', target: 10 },     // Light load
+  { duration: '30s', target: 10 },     // Sustain
+  { duration: '15s', target: 25 },     // Medium load
+  { duration: '30s', target: 25 },     // Sustain
+  { duration: '15s', target: 50 },     // High load
+  { duration: '30s', target: 50 },     // Sustain
+  { duration: '15s', target: 100 },    // Push limits
+  { duration: '30s', target: 100 },    // Sustain
+  { duration: '15s', target: 0 },      // Ramp down
+];
+
+const quickStages = [
+  { duration: '5s', target: 10 },      // Warm up
+  { duration: '10s', target: 10 },     // Low load
+  { duration: '5s', target: 100 },     // Ramp
+  { duration: '10s', target: 100 },    // Medium load
+  { duration: '5s', target: 500 },     // Ramp
+  { duration: '10s', target: 500 },    // High load
+  { duration: '5s', target: 0 },       // Ramp down
+];
+
+export const options = {
+  stages: QUICK ? quickStages : fullStages,
+  // No thresholds — benchmarks measure limits, not enforce them.
+  thresholds: {},
+};
+
+export function setup() {
+  // Health check
+  const healthCheck = http.get(`${STEPFLOW_URL}/api/v1/health`);
+  if (healthCheck.status !== 200) {
+    throw new Error(`Stepflow service not available at ${STEPFLOW_URL}`);
+  }
+
+  // Store workflow
+  const storeParams = {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: '30s',
+  };
+
+  const flowPayload = { flow: workflowDefinition };
+  const storeResponse = http.post(
+    `${API_BASE}/flows`,
+    JSON.stringify(flowPayload),
+    storeParams
+  );
+
+  if (storeResponse.status !== 200) {
+    throw new Error(
+      `Failed to store workflow: ${storeResponse.status} - ${storeResponse.body}`
+    );
+  }
+
+  const storeResult = JSON.parse(storeResponse.body);
+  if (!storeResult.flowId) {
+    throw new Error(`No flowId returned: ${storeResponse.body}`);
+  }
+
+  return { flowId: storeResult.flowId };
+}
+
+export default function (data) {
+  const runPayload = {
+    flowId: data.flowId,
+    input: [{ data: 'bench' }],
+    wait: true,
+  };
+
+  const params = {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: '120s',
+  };
+
+  const startTime = Date.now();
+  const response = http.post(
+    `${API_BASE}/runs`,
+    JSON.stringify(runPayload),
+    params
+  );
+  const duration = Date.now() - startTime;
+
+  // Record latency
+  runLatency.add(duration);
+
+  // Bucket by load level
+  if (__VU <= 10) {
+    lowLoadLatency.add(duration);
+  } else if (__VU <= 50) {
+    mediumLoadLatency.add(duration);
+  } else {
+    highLoadLatency.add(duration);
+  }
+
+  const success = check(response, {
+    'status is 200': (r) => r.status === 200,
+    'response has summary': (r) => {
+      try {
+        return JSON.parse(r.body).summary !== undefined;
+      } catch (e) {
+        return false;
+      }
+    },
+  });
+
+  if (success) {
+    completedRuns.add(1);
+  } else {
+    failedRuns.add(1);
+  }
+  failureRate.add(!success);
+
+  if (!success && __ITER % 50 === 0) {
+    console.error(`Request failed: ${response.status} - ${response.body}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Custom summary — print a concise results table
+// ---------------------------------------------------------------------------
+
+function fmt(ms) {
+  if (ms === undefined || ms === null) return '-';
+  if (ms < 1) return '<1ms';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function trendRow(label, trend) {
+  if (!trend || !trend.values) return null;
+  const v = trend.values;
+  if (v['count'] === 0 || (v['avg'] === 0 && v['min'] === 0 && v['max'] === 0)) return null;
+  return `  ${label.padEnd(22)} ${fmt(v['avg']).padStart(8)}  ${fmt(v['med']).padStart(8)}  ${fmt(v['p(90)']).padStart(8)}  ${fmt(v['p(95)']).padStart(8)}  ${fmt(v['max']).padStart(8)}`;
+}
+
+export function handleSummary(data) {
+  const m = data.metrics;
+  const completed = m.completed_runs ? m.completed_runs.values.count : 0;
+  const failed = m.failed_runs ? m.failed_runs.values.count : 0;
+  const total = completed + failed;
+  const testDurationSecs = (data.state ? data.state.testRunDurationMs : 0) / 1000 || 1;
+  const rps = (total / testDurationSecs).toFixed(1);
+  const errorRate = total > 0 ? ((failed / total) * 100).toFixed(1) : '0.0';
+
+  const header = `  ${'Load Level'.padEnd(22)} ${'avg'.padStart(8)}  ${'med'.padStart(8)}  ${'p90'.padStart(8)}  ${'p95'.padStart(8)}  ${'max'.padStart(8)}`;
+  const sep = '  ' + '-'.repeat(header.length - 2);
+
+  const rows = [
+    trendRow('Overall', m.run_latency),
+    trendRow('Low (≤10 VUs)', m.low_load_latency),
+    trendRow('Medium (≤50 VUs)', m.medium_load_latency),
+    trendRow('High (>50 VUs)', m.high_load_latency),
+  ].filter(Boolean);
+
+  const table = [
+    '',
+    `== bench-python-echo ==`,
+    '',
+    `  Total runs:    ${total}`,
+    `  Completed:     ${completed}`,
+    `  Failed:        ${failed} (${errorRate}%)`,
+    `  Throughput:    ${rps} runs/sec`,
+    '',
+    header,
+    sep,
+    ...rows,
+    sep,
+    '',
+  ].join('\n');
+
+  const outputs = { stdout: table + '\n' };
+
+  if (RESULTS_DIR) {
+    const jsonSummary = {
+      workflow: 'bench-python-echo',
+      total_runs: total,
+      completed,
+      failed,
+      error_rate_pct: parseFloat(errorRate),
+      throughput_rps: parseFloat(rps),
+      latency: {},
+    };
+    for (const [key, label] of [['run_latency', 'overall'], ['low_load_latency', 'low'], ['medium_load_latency', 'medium'], ['high_load_latency', 'high']]) {
+      if (m[key] && m[key].values) {
+        const v = m[key].values;
+        jsonSummary.latency[label] = { avg: v['avg'], med: v['med'], p90: v['p(90)'], p95: v['p(95)'], min: v['min'], max: v['max'] };
+      }
+    }
+    outputs[`${RESULTS_DIR}/bench-python-echo.json`] = JSON.stringify(jsonSummary, null, 2);
+  }
+
+  return outputs;
+}

--- a/load-tests/workflows/bench-config.yml
+++ b/load-tests/workflows/bench-config.yml
@@ -1,0 +1,35 @@
+plugins:
+  builtin:
+    type: builtin
+
+  # External bench worker connects via gRPC PullTasks.
+  # Start stepflow-bench-worker separately with --queue-name bench.
+  bench:
+    type: grpc
+    queueName: bench
+
+  # Rust worker for echo component benchmarks.
+  # Start stepflow-bench-worker echo --queue-name rust separately.
+  rust:
+    type: grpc
+    queueName: rust
+
+  # Python worker for echo component benchmarks.
+  python:
+    type: grpc
+    queueName: python
+    command: uv
+    args: ["--project", "../../sdks/python", "run", "stepflow_worker"]
+
+routes:
+  "/bench/{*component}":
+    - plugin: bench
+  "/rust/{*component}":
+    - plugin: rust
+  "/python/{*component}":
+    - plugin: python
+  "/{*component}":
+    - plugin: builtin
+
+storageConfig:
+  type: inMemory

--- a/load-tests/workflows/bench-noop-1.json
+++ b/load-tests/workflows/bench-noop-1.json
@@ -1,0 +1,8 @@
+{
+  "name": "Benchmark - Noop x1",
+  "description": "1 noop step. Baseline for per-step scaling measurement.",
+  "steps": [
+    { "id": "noop_1", "component": "/noop", "input": { "step": 1 } }
+  ],
+  "output": { "$step": "noop_1" }
+}

--- a/load-tests/workflows/bench-noop-100.json
+++ b/load-tests/workflows/bench-noop-100.json
@@ -1,0 +1,1008 @@
+{
+  "name": "Benchmark - Noop x100",
+  "description": "100 independent noop steps. For per-step scaling measurement.",
+  "steps": [
+    {
+      "id": "noop_1",
+      "component": "/noop",
+      "input": {
+        "step": 1
+      }
+    },
+    {
+      "id": "noop_2",
+      "component": "/noop",
+      "input": {
+        "step": 2
+      }
+    },
+    {
+      "id": "noop_3",
+      "component": "/noop",
+      "input": {
+        "step": 3
+      }
+    },
+    {
+      "id": "noop_4",
+      "component": "/noop",
+      "input": {
+        "step": 4
+      }
+    },
+    {
+      "id": "noop_5",
+      "component": "/noop",
+      "input": {
+        "step": 5
+      }
+    },
+    {
+      "id": "noop_6",
+      "component": "/noop",
+      "input": {
+        "step": 6
+      }
+    },
+    {
+      "id": "noop_7",
+      "component": "/noop",
+      "input": {
+        "step": 7
+      }
+    },
+    {
+      "id": "noop_8",
+      "component": "/noop",
+      "input": {
+        "step": 8
+      }
+    },
+    {
+      "id": "noop_9",
+      "component": "/noop",
+      "input": {
+        "step": 9
+      }
+    },
+    {
+      "id": "noop_10",
+      "component": "/noop",
+      "input": {
+        "step": 10
+      }
+    },
+    {
+      "id": "noop_11",
+      "component": "/noop",
+      "input": {
+        "step": 11
+      }
+    },
+    {
+      "id": "noop_12",
+      "component": "/noop",
+      "input": {
+        "step": 12
+      }
+    },
+    {
+      "id": "noop_13",
+      "component": "/noop",
+      "input": {
+        "step": 13
+      }
+    },
+    {
+      "id": "noop_14",
+      "component": "/noop",
+      "input": {
+        "step": 14
+      }
+    },
+    {
+      "id": "noop_15",
+      "component": "/noop",
+      "input": {
+        "step": 15
+      }
+    },
+    {
+      "id": "noop_16",
+      "component": "/noop",
+      "input": {
+        "step": 16
+      }
+    },
+    {
+      "id": "noop_17",
+      "component": "/noop",
+      "input": {
+        "step": 17
+      }
+    },
+    {
+      "id": "noop_18",
+      "component": "/noop",
+      "input": {
+        "step": 18
+      }
+    },
+    {
+      "id": "noop_19",
+      "component": "/noop",
+      "input": {
+        "step": 19
+      }
+    },
+    {
+      "id": "noop_20",
+      "component": "/noop",
+      "input": {
+        "step": 20
+      }
+    },
+    {
+      "id": "noop_21",
+      "component": "/noop",
+      "input": {
+        "step": 21
+      }
+    },
+    {
+      "id": "noop_22",
+      "component": "/noop",
+      "input": {
+        "step": 22
+      }
+    },
+    {
+      "id": "noop_23",
+      "component": "/noop",
+      "input": {
+        "step": 23
+      }
+    },
+    {
+      "id": "noop_24",
+      "component": "/noop",
+      "input": {
+        "step": 24
+      }
+    },
+    {
+      "id": "noop_25",
+      "component": "/noop",
+      "input": {
+        "step": 25
+      }
+    },
+    {
+      "id": "noop_26",
+      "component": "/noop",
+      "input": {
+        "step": 26
+      }
+    },
+    {
+      "id": "noop_27",
+      "component": "/noop",
+      "input": {
+        "step": 27
+      }
+    },
+    {
+      "id": "noop_28",
+      "component": "/noop",
+      "input": {
+        "step": 28
+      }
+    },
+    {
+      "id": "noop_29",
+      "component": "/noop",
+      "input": {
+        "step": 29
+      }
+    },
+    {
+      "id": "noop_30",
+      "component": "/noop",
+      "input": {
+        "step": 30
+      }
+    },
+    {
+      "id": "noop_31",
+      "component": "/noop",
+      "input": {
+        "step": 31
+      }
+    },
+    {
+      "id": "noop_32",
+      "component": "/noop",
+      "input": {
+        "step": 32
+      }
+    },
+    {
+      "id": "noop_33",
+      "component": "/noop",
+      "input": {
+        "step": 33
+      }
+    },
+    {
+      "id": "noop_34",
+      "component": "/noop",
+      "input": {
+        "step": 34
+      }
+    },
+    {
+      "id": "noop_35",
+      "component": "/noop",
+      "input": {
+        "step": 35
+      }
+    },
+    {
+      "id": "noop_36",
+      "component": "/noop",
+      "input": {
+        "step": 36
+      }
+    },
+    {
+      "id": "noop_37",
+      "component": "/noop",
+      "input": {
+        "step": 37
+      }
+    },
+    {
+      "id": "noop_38",
+      "component": "/noop",
+      "input": {
+        "step": 38
+      }
+    },
+    {
+      "id": "noop_39",
+      "component": "/noop",
+      "input": {
+        "step": 39
+      }
+    },
+    {
+      "id": "noop_40",
+      "component": "/noop",
+      "input": {
+        "step": 40
+      }
+    },
+    {
+      "id": "noop_41",
+      "component": "/noop",
+      "input": {
+        "step": 41
+      }
+    },
+    {
+      "id": "noop_42",
+      "component": "/noop",
+      "input": {
+        "step": 42
+      }
+    },
+    {
+      "id": "noop_43",
+      "component": "/noop",
+      "input": {
+        "step": 43
+      }
+    },
+    {
+      "id": "noop_44",
+      "component": "/noop",
+      "input": {
+        "step": 44
+      }
+    },
+    {
+      "id": "noop_45",
+      "component": "/noop",
+      "input": {
+        "step": 45
+      }
+    },
+    {
+      "id": "noop_46",
+      "component": "/noop",
+      "input": {
+        "step": 46
+      }
+    },
+    {
+      "id": "noop_47",
+      "component": "/noop",
+      "input": {
+        "step": 47
+      }
+    },
+    {
+      "id": "noop_48",
+      "component": "/noop",
+      "input": {
+        "step": 48
+      }
+    },
+    {
+      "id": "noop_49",
+      "component": "/noop",
+      "input": {
+        "step": 49
+      }
+    },
+    {
+      "id": "noop_50",
+      "component": "/noop",
+      "input": {
+        "step": 50
+      }
+    },
+    {
+      "id": "noop_51",
+      "component": "/noop",
+      "input": {
+        "step": 51
+      }
+    },
+    {
+      "id": "noop_52",
+      "component": "/noop",
+      "input": {
+        "step": 52
+      }
+    },
+    {
+      "id": "noop_53",
+      "component": "/noop",
+      "input": {
+        "step": 53
+      }
+    },
+    {
+      "id": "noop_54",
+      "component": "/noop",
+      "input": {
+        "step": 54
+      }
+    },
+    {
+      "id": "noop_55",
+      "component": "/noop",
+      "input": {
+        "step": 55
+      }
+    },
+    {
+      "id": "noop_56",
+      "component": "/noop",
+      "input": {
+        "step": 56
+      }
+    },
+    {
+      "id": "noop_57",
+      "component": "/noop",
+      "input": {
+        "step": 57
+      }
+    },
+    {
+      "id": "noop_58",
+      "component": "/noop",
+      "input": {
+        "step": 58
+      }
+    },
+    {
+      "id": "noop_59",
+      "component": "/noop",
+      "input": {
+        "step": 59
+      }
+    },
+    {
+      "id": "noop_60",
+      "component": "/noop",
+      "input": {
+        "step": 60
+      }
+    },
+    {
+      "id": "noop_61",
+      "component": "/noop",
+      "input": {
+        "step": 61
+      }
+    },
+    {
+      "id": "noop_62",
+      "component": "/noop",
+      "input": {
+        "step": 62
+      }
+    },
+    {
+      "id": "noop_63",
+      "component": "/noop",
+      "input": {
+        "step": 63
+      }
+    },
+    {
+      "id": "noop_64",
+      "component": "/noop",
+      "input": {
+        "step": 64
+      }
+    },
+    {
+      "id": "noop_65",
+      "component": "/noop",
+      "input": {
+        "step": 65
+      }
+    },
+    {
+      "id": "noop_66",
+      "component": "/noop",
+      "input": {
+        "step": 66
+      }
+    },
+    {
+      "id": "noop_67",
+      "component": "/noop",
+      "input": {
+        "step": 67
+      }
+    },
+    {
+      "id": "noop_68",
+      "component": "/noop",
+      "input": {
+        "step": 68
+      }
+    },
+    {
+      "id": "noop_69",
+      "component": "/noop",
+      "input": {
+        "step": 69
+      }
+    },
+    {
+      "id": "noop_70",
+      "component": "/noop",
+      "input": {
+        "step": 70
+      }
+    },
+    {
+      "id": "noop_71",
+      "component": "/noop",
+      "input": {
+        "step": 71
+      }
+    },
+    {
+      "id": "noop_72",
+      "component": "/noop",
+      "input": {
+        "step": 72
+      }
+    },
+    {
+      "id": "noop_73",
+      "component": "/noop",
+      "input": {
+        "step": 73
+      }
+    },
+    {
+      "id": "noop_74",
+      "component": "/noop",
+      "input": {
+        "step": 74
+      }
+    },
+    {
+      "id": "noop_75",
+      "component": "/noop",
+      "input": {
+        "step": 75
+      }
+    },
+    {
+      "id": "noop_76",
+      "component": "/noop",
+      "input": {
+        "step": 76
+      }
+    },
+    {
+      "id": "noop_77",
+      "component": "/noop",
+      "input": {
+        "step": 77
+      }
+    },
+    {
+      "id": "noop_78",
+      "component": "/noop",
+      "input": {
+        "step": 78
+      }
+    },
+    {
+      "id": "noop_79",
+      "component": "/noop",
+      "input": {
+        "step": 79
+      }
+    },
+    {
+      "id": "noop_80",
+      "component": "/noop",
+      "input": {
+        "step": 80
+      }
+    },
+    {
+      "id": "noop_81",
+      "component": "/noop",
+      "input": {
+        "step": 81
+      }
+    },
+    {
+      "id": "noop_82",
+      "component": "/noop",
+      "input": {
+        "step": 82
+      }
+    },
+    {
+      "id": "noop_83",
+      "component": "/noop",
+      "input": {
+        "step": 83
+      }
+    },
+    {
+      "id": "noop_84",
+      "component": "/noop",
+      "input": {
+        "step": 84
+      }
+    },
+    {
+      "id": "noop_85",
+      "component": "/noop",
+      "input": {
+        "step": 85
+      }
+    },
+    {
+      "id": "noop_86",
+      "component": "/noop",
+      "input": {
+        "step": 86
+      }
+    },
+    {
+      "id": "noop_87",
+      "component": "/noop",
+      "input": {
+        "step": 87
+      }
+    },
+    {
+      "id": "noop_88",
+      "component": "/noop",
+      "input": {
+        "step": 88
+      }
+    },
+    {
+      "id": "noop_89",
+      "component": "/noop",
+      "input": {
+        "step": 89
+      }
+    },
+    {
+      "id": "noop_90",
+      "component": "/noop",
+      "input": {
+        "step": 90
+      }
+    },
+    {
+      "id": "noop_91",
+      "component": "/noop",
+      "input": {
+        "step": 91
+      }
+    },
+    {
+      "id": "noop_92",
+      "component": "/noop",
+      "input": {
+        "step": 92
+      }
+    },
+    {
+      "id": "noop_93",
+      "component": "/noop",
+      "input": {
+        "step": 93
+      }
+    },
+    {
+      "id": "noop_94",
+      "component": "/noop",
+      "input": {
+        "step": 94
+      }
+    },
+    {
+      "id": "noop_95",
+      "component": "/noop",
+      "input": {
+        "step": 95
+      }
+    },
+    {
+      "id": "noop_96",
+      "component": "/noop",
+      "input": {
+        "step": 96
+      }
+    },
+    {
+      "id": "noop_97",
+      "component": "/noop",
+      "input": {
+        "step": 97
+      }
+    },
+    {
+      "id": "noop_98",
+      "component": "/noop",
+      "input": {
+        "step": 98
+      }
+    },
+    {
+      "id": "noop_99",
+      "component": "/noop",
+      "input": {
+        "step": 99
+      }
+    },
+    {
+      "id": "noop_100",
+      "component": "/noop",
+      "input": {
+        "step": 100
+      }
+    }
+  ],
+  "output": {
+    "s1": {
+      "$step": "noop_1"
+    },
+    "s2": {
+      "$step": "noop_2"
+    },
+    "s3": {
+      "$step": "noop_3"
+    },
+    "s4": {
+      "$step": "noop_4"
+    },
+    "s5": {
+      "$step": "noop_5"
+    },
+    "s6": {
+      "$step": "noop_6"
+    },
+    "s7": {
+      "$step": "noop_7"
+    },
+    "s8": {
+      "$step": "noop_8"
+    },
+    "s9": {
+      "$step": "noop_9"
+    },
+    "s10": {
+      "$step": "noop_10"
+    },
+    "s11": {
+      "$step": "noop_11"
+    },
+    "s12": {
+      "$step": "noop_12"
+    },
+    "s13": {
+      "$step": "noop_13"
+    },
+    "s14": {
+      "$step": "noop_14"
+    },
+    "s15": {
+      "$step": "noop_15"
+    },
+    "s16": {
+      "$step": "noop_16"
+    },
+    "s17": {
+      "$step": "noop_17"
+    },
+    "s18": {
+      "$step": "noop_18"
+    },
+    "s19": {
+      "$step": "noop_19"
+    },
+    "s20": {
+      "$step": "noop_20"
+    },
+    "s21": {
+      "$step": "noop_21"
+    },
+    "s22": {
+      "$step": "noop_22"
+    },
+    "s23": {
+      "$step": "noop_23"
+    },
+    "s24": {
+      "$step": "noop_24"
+    },
+    "s25": {
+      "$step": "noop_25"
+    },
+    "s26": {
+      "$step": "noop_26"
+    },
+    "s27": {
+      "$step": "noop_27"
+    },
+    "s28": {
+      "$step": "noop_28"
+    },
+    "s29": {
+      "$step": "noop_29"
+    },
+    "s30": {
+      "$step": "noop_30"
+    },
+    "s31": {
+      "$step": "noop_31"
+    },
+    "s32": {
+      "$step": "noop_32"
+    },
+    "s33": {
+      "$step": "noop_33"
+    },
+    "s34": {
+      "$step": "noop_34"
+    },
+    "s35": {
+      "$step": "noop_35"
+    },
+    "s36": {
+      "$step": "noop_36"
+    },
+    "s37": {
+      "$step": "noop_37"
+    },
+    "s38": {
+      "$step": "noop_38"
+    },
+    "s39": {
+      "$step": "noop_39"
+    },
+    "s40": {
+      "$step": "noop_40"
+    },
+    "s41": {
+      "$step": "noop_41"
+    },
+    "s42": {
+      "$step": "noop_42"
+    },
+    "s43": {
+      "$step": "noop_43"
+    },
+    "s44": {
+      "$step": "noop_44"
+    },
+    "s45": {
+      "$step": "noop_45"
+    },
+    "s46": {
+      "$step": "noop_46"
+    },
+    "s47": {
+      "$step": "noop_47"
+    },
+    "s48": {
+      "$step": "noop_48"
+    },
+    "s49": {
+      "$step": "noop_49"
+    },
+    "s50": {
+      "$step": "noop_50"
+    },
+    "s51": {
+      "$step": "noop_51"
+    },
+    "s52": {
+      "$step": "noop_52"
+    },
+    "s53": {
+      "$step": "noop_53"
+    },
+    "s54": {
+      "$step": "noop_54"
+    },
+    "s55": {
+      "$step": "noop_55"
+    },
+    "s56": {
+      "$step": "noop_56"
+    },
+    "s57": {
+      "$step": "noop_57"
+    },
+    "s58": {
+      "$step": "noop_58"
+    },
+    "s59": {
+      "$step": "noop_59"
+    },
+    "s60": {
+      "$step": "noop_60"
+    },
+    "s61": {
+      "$step": "noop_61"
+    },
+    "s62": {
+      "$step": "noop_62"
+    },
+    "s63": {
+      "$step": "noop_63"
+    },
+    "s64": {
+      "$step": "noop_64"
+    },
+    "s65": {
+      "$step": "noop_65"
+    },
+    "s66": {
+      "$step": "noop_66"
+    },
+    "s67": {
+      "$step": "noop_67"
+    },
+    "s68": {
+      "$step": "noop_68"
+    },
+    "s69": {
+      "$step": "noop_69"
+    },
+    "s70": {
+      "$step": "noop_70"
+    },
+    "s71": {
+      "$step": "noop_71"
+    },
+    "s72": {
+      "$step": "noop_72"
+    },
+    "s73": {
+      "$step": "noop_73"
+    },
+    "s74": {
+      "$step": "noop_74"
+    },
+    "s75": {
+      "$step": "noop_75"
+    },
+    "s76": {
+      "$step": "noop_76"
+    },
+    "s77": {
+      "$step": "noop_77"
+    },
+    "s78": {
+      "$step": "noop_78"
+    },
+    "s79": {
+      "$step": "noop_79"
+    },
+    "s80": {
+      "$step": "noop_80"
+    },
+    "s81": {
+      "$step": "noop_81"
+    },
+    "s82": {
+      "$step": "noop_82"
+    },
+    "s83": {
+      "$step": "noop_83"
+    },
+    "s84": {
+      "$step": "noop_84"
+    },
+    "s85": {
+      "$step": "noop_85"
+    },
+    "s86": {
+      "$step": "noop_86"
+    },
+    "s87": {
+      "$step": "noop_87"
+    },
+    "s88": {
+      "$step": "noop_88"
+    },
+    "s89": {
+      "$step": "noop_89"
+    },
+    "s90": {
+      "$step": "noop_90"
+    },
+    "s91": {
+      "$step": "noop_91"
+    },
+    "s92": {
+      "$step": "noop_92"
+    },
+    "s93": {
+      "$step": "noop_93"
+    },
+    "s94": {
+      "$step": "noop_94"
+    },
+    "s95": {
+      "$step": "noop_95"
+    },
+    "s96": {
+      "$step": "noop_96"
+    },
+    "s97": {
+      "$step": "noop_97"
+    },
+    "s98": {
+      "$step": "noop_98"
+    },
+    "s99": {
+      "$step": "noop_99"
+    },
+    "s100": {
+      "$step": "noop_100"
+    }
+  }
+}

--- a/load-tests/workflows/bench-noop-parallel.json
+++ b/load-tests/workflows/bench-noop-parallel.json
@@ -1,0 +1,28 @@
+{
+  "name": "Benchmark - Noop x10",
+  "description": "10 independent /noop steps with no dependencies. Measures concurrent step scheduling within a single run.",
+  "steps": [
+    { "id": "noop_1", "component": "/noop", "input": { "step": 1 } },
+    { "id": "noop_2", "component": "/noop", "input": { "step": 2 } },
+    { "id": "noop_3", "component": "/noop", "input": { "step": 3 } },
+    { "id": "noop_4", "component": "/noop", "input": { "step": 4 } },
+    { "id": "noop_5", "component": "/noop", "input": { "step": 5 } },
+    { "id": "noop_6", "component": "/noop", "input": { "step": 6 } },
+    { "id": "noop_7", "component": "/noop", "input": { "step": 7 } },
+    { "id": "noop_8", "component": "/noop", "input": { "step": 8 } },
+    { "id": "noop_9", "component": "/noop", "input": { "step": 9 } },
+    { "id": "noop_10", "component": "/noop", "input": { "step": 10 } }
+  ],
+  "output": {
+    "s1": { "$step": "noop_1" },
+    "s2": { "$step": "noop_2" },
+    "s3": { "$step": "noop_3" },
+    "s4": { "$step": "noop_4" },
+    "s5": { "$step": "noop_5" },
+    "s6": { "$step": "noop_6" },
+    "s7": { "$step": "noop_7" },
+    "s8": { "$step": "noop_8" },
+    "s9": { "$step": "noop_9" },
+    "s10": { "$step": "noop_10" }
+  }
+}

--- a/load-tests/workflows/bench-python-echo.json
+++ b/load-tests/workflows/bench-python-echo.json
@@ -1,0 +1,12 @@
+{
+  "name": "Benchmark - Python Echo",
+  "description": "Single step calling a minimal Python echo component. Measures Python worker roundtrip overhead.",
+  "steps": [
+    {
+      "id": "echo",
+      "component": "/python/echo",
+      "input": { "$input": "" }
+    }
+  ],
+  "output": { "$step": "echo" }
+}

--- a/load-tests/workflows/bench-routed-noop.json
+++ b/load-tests/workflows/bench-routed-noop.json
@@ -1,0 +1,12 @@
+{
+  "name": "Benchmark - Routed Noop",
+  "description": "Single step routed to /bench/noop queue. Measures full gRPC dispatch path through PullTasks/CompleteTask (requires bench worker).",
+  "steps": [
+    {
+      "id": "noop",
+      "component": "/bench/noop",
+      "input": { "$input": "" }
+    }
+  ],
+  "output": { "$step": "noop" }
+}

--- a/load-tests/workflows/bench-rust-echo.json
+++ b/load-tests/workflows/bench-rust-echo.json
@@ -1,0 +1,12 @@
+{
+  "name": "Benchmark - Rust Echo",
+  "description": "Single step calling a Rust echo component via gRPC worker. Measures Rust worker roundtrip overhead.",
+  "steps": [
+    {
+      "id": "echo",
+      "component": "/rust/echo",
+      "input": { "$input": "" }
+    }
+  ],
+  "output": { "$step": "echo" }
+}

--- a/load-tests/workflows/bench-sleep-100ms.json
+++ b/load-tests/workflows/bench-sleep-100ms.json
@@ -1,0 +1,15 @@
+{
+  "name": "Benchmark - Sleep 100ms",
+  "description": "Single /sleep step with 100ms delay. Simulates typical worker latency for concurrent flow capacity testing.",
+  "steps": [
+    {
+      "id": "sleep",
+      "component": "/sleep",
+      "input": {
+        "duration_ms": 100,
+        "passthrough": { "$input": "data" }
+      }
+    }
+  ],
+  "output": { "$step": "sleep" }
+}

--- a/load-tests/workflows/bench-sleep-10ms.json
+++ b/load-tests/workflows/bench-sleep-10ms.json
@@ -1,0 +1,15 @@
+{
+  "name": "Benchmark - Sleep 10ms",
+  "description": "Single /sleep step with 10ms delay. Simulates fast worker latency for concurrent flow capacity testing.",
+  "steps": [
+    {
+      "id": "sleep",
+      "component": "/sleep",
+      "input": {
+        "duration_ms": 10,
+        "passthrough": { "$input": "data" }
+      }
+    }
+  ],
+  "output": { "$step": "sleep" }
+}

--- a/sdks/python/stepflow-py/src/stepflow_py/worker/main.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/main.py
@@ -22,6 +22,12 @@ from stepflow_py.worker.server import StepflowServer
 server = StepflowServer()
 
 
+@server.component(name="echo")
+def echo(input: dict) -> dict:
+    """Return input unchanged. Used for benchmarking worker overhead."""
+    return input
+
+
 def main():
     # Initialize observability before anything else
     # Configuration via environment variables:

--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -1278,6 +1278,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stepflow-bench-worker"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "futures",
+ "serde_json",
+ "stepflow-proto",
+ "stepflow-worker",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "stepflow-client"
 version = "0.1.0"
 dependencies = [

--- a/sdks/rust/crates/stepflow-bench-worker/Cargo.toml
+++ b/sdks/rust/crates/stepflow-bench-worker/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "stepflow-bench-worker"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Benchmark worker that instantly completes tasks for orchestrator throughput testing"
+
+[[bin]]
+name = "stepflow-bench-worker"
+path = "src/main.rs"
+
+[dependencies]
+stepflow-worker = { path = "../stepflow-worker" }
+stepflow-proto = { path = "../../../../stepflow-rs/crates/stepflow-proto" }
+tokio = { version = "1", features = ["full", "signal"] }
+tonic = { version = "0.14", features = ["transport"] }
+serde_json = "1"
+clap = { version = "4.5", features = ["derive", "env"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+uuid = { version = "1", features = ["v4"] }
+futures = "0.3"

--- a/sdks/rust/crates/stepflow-bench-worker/src/echo.rs
+++ b/sdks/rust/crates/stepflow-bench-worker/src/echo.rs
@@ -1,0 +1,65 @@
+// Copyright 2025 DataStax Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Real worker mode with an `/echo` component via the Rust SDK.
+
+use clap::Args;
+use stepflow_worker::{ComponentRegistry, Worker, WorkerConfig};
+use tracing::info;
+
+#[derive(Args, Debug)]
+pub struct EchoArgs {
+    /// URL of the Stepflow tasks gRPC service.
+    #[arg(
+        long,
+        env = "STEPFLOW_TASKS_URL",
+        default_value = "http://127.0.0.1:7840"
+    )]
+    tasks_url: String,
+
+    /// Queue name to pull tasks from.
+    #[arg(long, env = "STEPFLOW_QUEUE_NAME", default_value = "rust")]
+    queue_name: String,
+
+    /// Max concurrent task executions.
+    #[arg(long, env = "STEPFLOW_MAX_CONCURRENT", default_value = "10")]
+    max_concurrent: usize,
+}
+
+pub async fn run(args: EchoArgs) -> Result<(), Box<dyn std::error::Error>> {
+    info!(
+        tasks_url = %args.tasks_url,
+        queue_name = %args.queue_name,
+        max_concurrent = args.max_concurrent,
+        "Starting echo worker (Rust SDK)"
+    );
+
+    let mut registry = ComponentRegistry::new();
+
+    registry.register_fn("/echo", |input: serde_json::Value, _ctx| async move {
+        Ok(input)
+    });
+
+    let config = WorkerConfig {
+        tasks_url: args.tasks_url.clone(),
+        queue_name: args.queue_name,
+        max_concurrent: args.max_concurrent,
+        // Set orchestrator_url to match tasks_url so the SDK reuses the
+        // same gRPC channel for callbacks, avoiding ephemeral port exhaustion.
+        orchestrator_url: Some(args.tasks_url),
+        ..WorkerConfig::default()
+    };
+
+    Worker::new(registry, config).run().await?;
+
+    Ok(())
+}

--- a/sdks/rust/crates/stepflow-bench-worker/src/instant.rs
+++ b/sdks/rust/crates/stepflow-bench-worker/src/instant.rs
@@ -1,0 +1,293 @@
+// Copyright 2025 DataStax Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Instant-completion mode: pulls tasks via raw gRPC and completes them
+//! immediately, bypassing the worker SDK.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use clap::Args;
+use futures::StreamExt as _;
+use tracing::{error, info, warn};
+
+use stepflow_proto::{
+    CompleteTaskRequest, ComponentExecuteResponse, ComponentInfo as ProtoComponentInfo,
+    ListComponentsResult, TaskAssignment, TaskHeartbeatRequest, TaskStatus,
+    complete_task_request::Result as TaskResult,
+    orchestrator_service_client::OrchestratorServiceClient, task_assignment::Task,
+};
+use stepflow_worker::open_task_stream;
+
+#[derive(Args, Debug)]
+pub struct InstantArgs {
+    /// URL of the Stepflow tasks gRPC service.
+    #[arg(
+        long,
+        env = "STEPFLOW_TASKS_URL",
+        default_value = "http://127.0.0.1:7840"
+    )]
+    tasks_url: String,
+
+    /// Queue name to pull tasks from.
+    #[arg(long, env = "STEPFLOW_QUEUE_NAME", default_value = "bench")]
+    queue_name: String,
+
+    /// Optional delay (ms) before completing each task. Simulates work.
+    #[arg(long, default_value = "0")]
+    delay_ms: u64,
+
+    /// Number of concurrent pull streams (simulates multiple workers).
+    #[arg(long, default_value = "1")]
+    workers: usize,
+}
+
+pub async fn run(args: InstantArgs) -> Result<(), Box<dyn std::error::Error>> {
+    info!(
+        tasks_url = %args.tasks_url,
+        queue_name = %args.queue_name,
+        delay_ms = args.delay_ms,
+        workers = args.workers,
+        "Starting instant-completion worker"
+    );
+
+    let completed = Arc::new(AtomicU64::new(0));
+    let errors = Arc::new(AtomicU64::new(0));
+
+    // Spawn stats reporter
+    let stats_completed = completed.clone();
+    let stats_errors = errors.clone();
+    let stats_handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(5));
+        let mut last_count = 0u64;
+        loop {
+            interval.tick().await;
+            let current = stats_completed.load(Ordering::Relaxed);
+            let err_count = stats_errors.load(Ordering::Relaxed);
+            let delta = current - last_count;
+            let rps = delta as f64 / 5.0;
+            info!(
+                completed = current,
+                errors = err_count,
+                "tasks/sec (5s avg)" = format!("{rps:.1}"),
+                "Stats"
+            );
+            last_count = current;
+        }
+    });
+
+    // Spawn worker tasks
+    let mut handles = Vec::with_capacity(args.workers);
+    for i in 0..args.workers {
+        let tasks_url = args.tasks_url.clone();
+        let queue_name = args.queue_name.clone();
+        let delay_ms = args.delay_ms;
+        let completed = completed.clone();
+        let errors = errors.clone();
+
+        handles.push(tokio::spawn(async move {
+            let worker_id = uuid::Uuid::new_v4().to_string();
+            info!(worker = i, worker_id = %worker_id, "Connecting to task stream");
+
+            loop {
+                match open_task_stream(&tasks_url, &queue_name, &worker_id).await {
+                    Ok((channel, mut stream)) => {
+                        info!(worker = i, "Connected, pulling tasks");
+
+                        while let Some(result) = stream.next().await {
+                            match result {
+                                Ok(assignment) => {
+                                    handle_assignment(
+                                        assignment,
+                                        &worker_id,
+                                        channel.clone(),
+                                        &tasks_url,
+                                        delay_ms,
+                                        &completed,
+                                        &errors,
+                                    )
+                                    .await;
+                                }
+                                Err(e) => {
+                                    warn!(worker = i, "Stream error: {e}");
+                                    break;
+                                }
+                            }
+                        }
+
+                        warn!(worker = i, "Stream ended, reconnecting in 1s");
+                    }
+                    Err(e) => {
+                        error!(worker = i, "Failed to connect: {e}");
+                    }
+                }
+
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }));
+    }
+
+    // Wait for Ctrl+C
+    tokio::signal::ctrl_c().await?;
+    info!("Shutting down...");
+
+    let total = completed.load(Ordering::Relaxed);
+    let total_errors = errors.load(Ordering::Relaxed);
+    info!(
+        total_completed = total,
+        total_errors = total_errors,
+        "Final stats"
+    );
+
+    stats_handle.abort();
+    for h in handles {
+        h.abort();
+    }
+
+    Ok(())
+}
+
+async fn handle_assignment(
+    assignment: TaskAssignment,
+    worker_id: &str,
+    default_channel: tonic::transport::Channel,
+    tasks_url: &str,
+    delay_ms: u64,
+    completed: &AtomicU64,
+    errors: &AtomicU64,
+) {
+    let task_id = assignment.task_id.clone();
+    let task_context = assignment.context.clone().unwrap_or_default();
+
+    // Resolve orchestrator channel — reuse default_channel when possible
+    // to avoid ephemeral port exhaustion under high throughput.
+    let orch_channel = if task_context.orchestrator_service_url.is_empty() {
+        default_channel
+    } else {
+        let url = &task_context.orchestrator_service_url;
+        let normalised = if url.starts_with("http://") || url.starts_with("https://") {
+            url.to_string()
+        } else {
+            format!("http://{url}")
+        };
+        // Reuse default channel if the URL matches the tasks URL
+        if normalised == tasks_url {
+            default_channel
+        } else {
+            match tonic::transport::Channel::from_shared(normalised) {
+                Ok(endpoint) => endpoint.connect_lazy(),
+                Err(e) => {
+                    warn!(task_id, "Invalid orchestrator URL: {e}");
+                    errors.fetch_add(1, Ordering::Relaxed);
+                    return;
+                }
+            }
+        }
+    };
+
+    let mut orch_client = OrchestratorServiceClient::new(orch_channel.clone());
+
+    // Claim the task via initial heartbeat
+    let claim_result = orch_client
+        .task_heartbeat(TaskHeartbeatRequest {
+            task_id: task_id.clone(),
+            worker_id: worker_id.to_string(),
+            progress: None,
+            status_message: None,
+            run_id: None,
+        })
+        .await;
+
+    match claim_result {
+        Ok(resp) => {
+            if resp.into_inner().status == TaskStatus::AlreadyClaimed as i32 {
+                return;
+            }
+        }
+        Err(e) => {
+            warn!(task_id, "Failed to claim task: {e}");
+            errors.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+    }
+
+    // Optional delay (with heartbeat if delay is long)
+    if delay_ms > 0 {
+        let heartbeat_interval = assignment.heartbeat_interval_secs;
+        if delay_ms > (heartbeat_interval as u64 * 1000) && heartbeat_interval > 0 {
+            // Need heartbeat loop for long delays
+            let hb_task_id = task_id.clone();
+            let hb_worker_id = worker_id.to_string();
+            let hb_channel = orch_channel.clone();
+            let hb_handle = tokio::spawn(async move {
+                let mut client = OrchestratorServiceClient::new(hb_channel);
+                let interval = Duration::from_secs(heartbeat_interval.max(1) as u64);
+                loop {
+                    tokio::time::sleep(interval).await;
+                    let _ = client
+                        .task_heartbeat(TaskHeartbeatRequest {
+                            task_id: hb_task_id.clone(),
+                            worker_id: hb_worker_id.clone(),
+                            progress: None,
+                            status_message: None,
+                            run_id: None,
+                        })
+                        .await;
+                }
+            });
+
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            hb_handle.abort();
+        } else {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        }
+    }
+
+    // Build result based on task type
+    let complete_result = match assignment.task {
+        Some(Task::Execute(req)) => {
+            // Echo input back as output
+            TaskResult::Response(ComponentExecuteResponse { output: req.input })
+        }
+        Some(Task::ListComponents(_)) => TaskResult::ListComponents(ListComponentsResult {
+            components: vec![ProtoComponentInfo {
+                component_id: "noop".to_string(),
+                path: "/noop".to_string(),
+                description: Some("Benchmark noop component".to_string()),
+                input_schema: None,
+                output_schema: None,
+            }],
+        }),
+        None => {
+            warn!(task_id, "Empty task payload");
+            errors.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+    };
+
+    // Complete the task
+    if let Err(e) = OrchestratorServiceClient::new(orch_channel)
+        .complete_task(CompleteTaskRequest {
+            task_id: task_id.clone(),
+            result: Some(complete_result),
+            run_id: None,
+        })
+        .await
+    {
+        warn!(task_id, "Failed to complete task: {e}");
+        errors.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+
+    completed.fetch_add(1, Ordering::Relaxed);
+}

--- a/sdks/rust/crates/stepflow-bench-worker/src/main.rs
+++ b/sdks/rust/crates/stepflow-bench-worker/src/main.rs
@@ -1,0 +1,71 @@
+// Copyright 2025 DataStax Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! Benchmark worker for Stepflow throughput testing.
+//!
+//! Two modes:
+//!
+//! **`instant`** — Pulls tasks via raw gRPC and completes them immediately,
+//! bypassing the worker SDK. Measures orchestrator dispatch ceiling.
+//!
+//! **`echo`** — Runs a real worker (via the Rust SDK) with an `/echo` component
+//! that returns input unchanged. Measures Rust worker overhead.
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Instant completion (orchestrator ceiling)
+//! stepflow-bench-worker instant --queue-name bench --workers 10
+//!
+//! # Real Rust worker with echo component
+//! stepflow-bench-worker echo --queue-name rust
+//! ```
+
+use clap::{Parser, Subcommand};
+
+mod echo;
+mod instant;
+
+#[derive(Parser, Debug)]
+#[command(name = "stepflow-bench-worker")]
+#[command(about = "Benchmark worker for Stepflow throughput testing")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Pull tasks and complete them instantly (bypass worker SDK).
+    /// Measures orchestrator dispatch ceiling.
+    Instant(instant::InstantArgs),
+
+    /// Run a real worker with an /echo component (via Rust SDK).
+    /// Measures Rust worker overhead.
+    Echo(echo::EchoArgs),
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::Instant(args) => instant::run(args).await,
+        Command::Echo(args) => echo::run(args).await,
+    }
+}

--- a/stepflow-rs/crates/stepflow-builtins/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/lib.rs
@@ -27,9 +27,11 @@ mod map;
 mod messages;
 #[cfg(test)]
 mod mock_context;
+mod noop;
 mod openai;
 mod plugin;
 mod registry;
+mod sleep;
 
 use error::Result;
 pub use plugin::{BuiltinPluginConfig, Builtins};

--- a/stepflow-rs/crates/stepflow-builtins/src/noop.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/noop.rs
@@ -1,0 +1,81 @@
+// Copyright 2025 DataStax Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+use std::sync::Arc;
+use stepflow_core::FlowResult;
+use stepflow_core::workflow::Component;
+use stepflow_core::workflow::StepId;
+use stepflow_core::{component::ComponentInfo, workflow::ValueRef};
+use stepflow_plugin::RunContext;
+
+use crate::{BuiltinComponent, Result};
+
+/// A no-op component that accepts any JSON input and returns it unchanged.
+///
+/// Useful for benchmarking orchestrator overhead without any real work.
+pub struct NoopComponent;
+
+impl BuiltinComponent for NoopComponent {
+    fn component_info(&self) -> Result<ComponentInfo> {
+        Ok(ComponentInfo {
+            component: Component::from_string("/noop"),
+            path: "/noop".to_string(),
+            input_schema: None,
+            output_schema: None,
+            description: Some(
+                "No-op component that returns its input unchanged. Used for benchmarking."
+                    .to_string(),
+            ),
+        })
+    }
+
+    async fn execute(
+        &self,
+        _run_context: &Arc<RunContext>,
+        _step: Option<&StepId>,
+        input: ValueRef,
+    ) -> Result<FlowResult> {
+        Ok(input.as_ref().clone().into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock_context::MockContext;
+
+    #[tokio::test]
+    async fn test_noop_passes_through_input() {
+        let component = NoopComponent;
+        let input = serde_json::json!({"key": "value", "num": 42});
+        let mock = MockContext::new().await;
+        let output = component
+            .execute(&mock.run_context(), None, input.clone().into())
+            .await
+            .unwrap();
+        let result: serde_json::Value = output.success().unwrap().deserialize().unwrap();
+        assert_eq!(result, input);
+    }
+
+    #[tokio::test]
+    async fn test_noop_passes_through_null() {
+        let component = NoopComponent;
+        let input = serde_json::Value::Null;
+        let mock = MockContext::new().await;
+        let output = component
+            .execute(&mock.run_context(), None, input.clone().into())
+            .await
+            .unwrap();
+        let result: serde_json::Value = output.success().unwrap().deserialize().unwrap();
+        assert_eq!(result, input);
+    }
+}

--- a/stepflow-rs/crates/stepflow-builtins/src/registry.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/registry.rs
@@ -25,7 +25,9 @@ use crate::{
     load_file::LoadFileComponent,
     map::MapComponent,
     messages::CreateMessagesComponent,
+    noop::NoopComponent,
     openai::OpenAIComponent,
+    sleep::SleepComponent,
 };
 
 #[derive(Default)]
@@ -51,6 +53,8 @@ static REGISTRY: LazyLock<Registry> = LazyLock::new(|| {
     registry.register("/map", MapComponent::new());
     registry.register("/put_blob", PutBlobComponent::new());
     registry.register("/get_blob", GetBlobComponent::new());
+    registry.register("/noop", NoopComponent);
+    registry.register("/sleep", SleepComponent);
     registry
 });
 

--- a/stepflow-rs/crates/stepflow-builtins/src/sleep.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/sleep.rs
@@ -1,0 +1,150 @@
+// Copyright 2025 DataStax Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use error_stack::ResultExt as _;
+use serde::{Deserialize, Serialize};
+use stepflow_core::FlowResult;
+use stepflow_core::workflow::Component;
+use stepflow_core::workflow::StepId;
+use stepflow_core::{component::ComponentInfo, schema::SchemaRef, workflow::ValueRef};
+use stepflow_plugin::RunContext;
+
+use crate::{BuiltinComponent, Result, error::BuiltinError};
+
+/// A sleep component that waits for a specified duration before returning.
+///
+/// Uses `tokio::time::sleep` which is cooperative and lock-free, so thousands
+/// of concurrent sleep tasks will not exhaust threads. Useful for benchmarking
+/// orchestrator concurrent flow capacity with simulated worker latency.
+pub struct SleepComponent;
+
+#[derive(Serialize, Deserialize, schemars::JsonSchema, Default)]
+struct SleepInput {
+    /// Duration to sleep in milliseconds.
+    duration_ms: f64,
+
+    /// Optional data to pass through unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    passthrough: Option<serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize, schemars::JsonSchema, Default)]
+struct SleepOutput {
+    /// The duration that was slept, in milliseconds.
+    duration_ms: f64,
+
+    /// The passthrough data, if any was provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    passthrough: Option<serde_json::Value>,
+}
+
+impl BuiltinComponent for SleepComponent {
+    fn component_info(&self) -> Result<ComponentInfo> {
+        let input_schema = SchemaRef::for_type::<SleepInput>();
+        let output_schema = SchemaRef::for_type::<SleepOutput>();
+
+        Ok(ComponentInfo {
+            component: Component::from_string("/sleep"),
+            path: "/sleep".to_string(),
+            input_schema: Some(input_schema),
+            output_schema: Some(output_schema),
+            description: Some(
+                "Sleeps for a specified duration then returns. Used for benchmarking concurrent flow capacity."
+                    .to_string(),
+            ),
+        })
+    }
+
+    async fn execute(
+        &self,
+        _run_context: &Arc<RunContext>,
+        _step: Option<&StepId>,
+        input: ValueRef,
+    ) -> Result<FlowResult> {
+        let SleepInput {
+            duration_ms,
+            passthrough,
+        } = serde_json::from_value(input.as_ref().clone())
+            .change_context(BuiltinError::InvalidInput)?;
+
+        tokio::time::sleep(Duration::from_millis(duration_ms as u64)).await;
+
+        let result = SleepOutput {
+            duration_ms,
+            passthrough,
+        };
+        let output = serde_json::to_value(result).change_context(BuiltinError::Internal)?;
+        Ok(output.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock_context::MockContext;
+
+    #[tokio::test]
+    async fn test_sleep_returns_duration_and_passthrough() {
+        let component = SleepComponent;
+        let input = SleepInput {
+            duration_ms: 10.0,
+            passthrough: Some(serde_json::json!({"data": "hello"})),
+        };
+        let input = serde_json::to_value(input).unwrap();
+        let mock = MockContext::new().await;
+        let output = component
+            .execute(&mock.run_context(), None, input.into())
+            .await
+            .unwrap();
+        let result: SleepOutput = output.success().unwrap().deserialize().unwrap();
+        assert_eq!(result.duration_ms, 10.0);
+        assert_eq!(
+            result.passthrough,
+            Some(serde_json::json!({"data": "hello"}))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sleep_without_passthrough() {
+        let component = SleepComponent;
+        let input = serde_json::json!({"duration_ms": 1.0});
+        let mock = MockContext::new().await;
+        let output = component
+            .execute(&mock.run_context(), None, input.into())
+            .await
+            .unwrap();
+        let result: SleepOutput = output.success().unwrap().deserialize().unwrap();
+        assert_eq!(result.duration_ms, 1.0);
+        assert_eq!(result.passthrough, None);
+    }
+
+    #[tokio::test]
+    async fn test_sleep_actually_delays() {
+        let component = SleepComponent;
+        let input = serde_json::json!({"duration_ms": 50.0});
+        let mock = MockContext::new().await;
+        let start = std::time::Instant::now();
+        component
+            .execute(&mock.run_context(), None, input.into())
+            .await
+            .unwrap();
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(40),
+            "Expected at least 40ms delay, got {:?}",
+            elapsed
+        );
+    }
+}

--- a/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_custom_config.snap
+++ b/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_custom_config.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/stepflow-main/tests/commands/test_list_components.rs
+source: crates/stepflow-cli/tests/commands/test_list_components.rs
 info:
   program: stepflow
   args:
@@ -7,7 +7,15 @@ info:
     - "--omit-stack-trace"
     - "--log-level=error"
     - list-components
-    - "--config=/var/folders/c4/dcr0mh3d183d5kh9gf89wsc00000gn/T/.tmps4TvA1/custom-config.yml"
+    - "--config=/var/folders/zk/lxqpq1490bb5xkvpdg25058r0000gn/T/.tmp0QT2ZJ/custom-config.yml"
+  env:
+    STEPFLOW_LOG_DESTINATION: ""
+    STEPFLOW_LOG_FILE: ""
+    STEPFLOW_LOG_FORMAT: ""
+    STEPFLOW_LOG_LEVEL: ""
+    STEPFLOW_OTHER_LOG_LEVEL: ""
+    STEPFLOW_OTLP_ENDPOINT: ""
+    STEPFLOW_TRACE_ENABLED: ""
 ---
 success: true
 exit_code: 0
@@ -45,6 +53,11 @@ Component: /map (plugin: test-builtins)
   Available Routes:
     /test-builtins/map
 
+Component: /noop (plugin: test-builtins)
+  Description: No-op component that returns its input unchanged. Used for benchmarking.
+  Available Routes:
+    /test-builtins/noop
+
 Component: /openai (plugin: test-builtins)
   Description: Send messages to OpenAI's chat completion API and get a response
   Available Routes:
@@ -55,6 +68,11 @@ Component: /put_blob (plugin: test-builtins)
   Available Routes:
     /test-builtins/put_blob
 
-Total components: 8
+Component: /sleep (plugin: test-builtins)
+  Description: Sleeps for a specified duration then returns. Used for benchmarking concurrent flow capacity.
+  Available Routes:
+    /test-builtins/sleep
+
+Total components: 10
 
 ----- stderr -----

--- a/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_default.snap
+++ b/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_default.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/stepflow-main/tests/commands/test_list_components.rs
+source: crates/stepflow-cli/tests/commands/test_list_components.rs
 info:
   program: stepflow
   args:
@@ -8,6 +8,14 @@ info:
     - "--log-level=error"
     - list-components
     - "--config=tests/stepflow-config.yml"
+  env:
+    STEPFLOW_LOG_DESTINATION: ""
+    STEPFLOW_LOG_FILE: ""
+    STEPFLOW_LOG_FORMAT: ""
+    STEPFLOW_LOG_LEVEL: ""
+    STEPFLOW_OTHER_LOG_LEVEL: ""
+    STEPFLOW_OTLP_ENDPOINT: ""
+    STEPFLOW_TRACE_ENABLED: ""
 ---
 success: true
 exit_code: 0
@@ -45,6 +53,11 @@ Component: /map (plugin: builtin)
   Available Routes:
     /builtin/map
 
+Component: /noop (plugin: builtin)
+  Description: No-op component that returns its input unchanged. Used for benchmarking.
+  Available Routes:
+    /builtin/noop
+
 Component: /openai (plugin: builtin)
   Description: Send messages to OpenAI's chat completion API and get a response
   Available Routes:
@@ -55,6 +68,11 @@ Component: /put_blob (plugin: builtin)
   Available Routes:
     /builtin/put_blob
 
-Total components: 8
+Component: /sleep (plugin: builtin)
+  Description: Sleeps for a specified duration then returns. Used for benchmarking concurrent flow capacity.
+  Available Routes:
+    /builtin/sleep
+
+Total components: 10
 
 ----- stderr -----

--- a/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_json.snap
+++ b/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_json.snap
@@ -344,6 +344,15 @@ exit_code: 0
       ]
     },
     {
+      "component": "/noop",
+      "path": "/noop",
+      "description": "No-op component that returns its input unchanged. Used for benchmarking.",
+      "plugin": "builtin",
+      "routes": [
+        "/builtin/noop"
+      ]
+    },
+    {
       "component": "/openai",
       "path": "/openai",
       "description": "Send messages to OpenAI's chat completion API and get a response",
@@ -451,6 +460,51 @@ exit_code: 0
       "plugin": "builtin",
       "routes": [
         "/builtin/put_blob"
+      ]
+    },
+    {
+      "component": "/sleep",
+      "path": "/sleep",
+      "description": "Sleeps for a specified duration then returns. Used for benchmarking concurrent flow capacity.",
+      "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "SleepInput",
+        "type": "object",
+        "properties": {
+          "duration_ms": {
+            "description": "Duration to sleep in milliseconds.",
+            "type": "number",
+            "format": "double"
+          },
+          "passthrough": {
+            "description": "Optional data to pass through unchanged."
+          }
+        },
+        "required": [
+          "duration_ms"
+        ]
+      },
+      "output_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "SleepOutput",
+        "type": "object",
+        "properties": {
+          "duration_ms": {
+            "description": "The duration that was slept, in milliseconds.",
+            "type": "number",
+            "format": "double"
+          },
+          "passthrough": {
+            "description": "The passthrough data, if any was provided."
+          }
+        },
+        "required": [
+          "duration_ms"
+        ]
+      },
+      "plugin": "builtin",
+      "routes": [
+        "/builtin/sleep"
       ]
     }
   ]

--- a/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_yaml.snap
+++ b/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_yaml.snap
@@ -256,6 +256,12 @@ components:
   plugin: builtin
   routes:
   - /builtin/map
+- component: /noop
+  path: /noop
+  description: No-op component that returns its input unchanged. Used for benchmarking.
+  plugin: builtin
+  routes:
+  - /builtin/noop
 - component: /openai
   path: /openai
   description: Send messages to OpenAI's chat completion API and get a response
@@ -336,6 +342,38 @@ components:
   plugin: builtin
   routes:
   - /builtin/put_blob
+- component: /sleep
+  path: /sleep
+  description: Sleeps for a specified duration then returns. Used for benchmarking concurrent flow capacity.
+  input_schema:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    title: SleepInput
+    type: object
+    properties:
+      duration_ms:
+        description: Duration to sleep in milliseconds.
+        type: number
+        format: double
+      passthrough:
+        description: Optional data to pass through unchanged.
+    required:
+    - duration_ms
+  output_schema:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    title: SleepOutput
+    type: object
+    properties:
+      duration_ms:
+        description: The duration that was slept, in milliseconds.
+        type: number
+        format: double
+      passthrough:
+        description: The passthrough data, if any was provided.
+    required:
+    - duration_ms
+  plugin: builtin
+  routes:
+  - /builtin/sleep
 
 
 ----- stderr -----

--- a/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_hide_unreachable.snap
+++ b/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_hide_unreachable.snap
@@ -7,7 +7,7 @@ info:
     - "--omit-stack-trace"
     - "--log-level=error"
     - list-components
-    - "--config=/var/folders/zk/lxqpq1490bb5xkvpdg25058r0000gn/T/.tmp0tDVRc/filtered-config.yml"
+    - "--config=/var/folders/zk/lxqpq1490bb5xkvpdg25058r0000gn/T/.tmpi7RcjH/filtered-config.yml"
   env:
     STEPFLOW_LOG_DESTINATION: ""
     STEPFLOW_LOG_FILE: ""
@@ -53,6 +53,11 @@ Component: /map (plugin: test-builtins)
   Available Routes:
     /reachable/map
 
+Component: /noop (plugin: test-builtins)
+  Description: No-op component that returns its input unchanged. Used for benchmarking.
+  Available Routes:
+    /reachable/noop
+
 Component: /openai (plugin: test-builtins)
   Description: Send messages to OpenAI's chat completion API and get a response
   Available Routes:
@@ -63,6 +68,11 @@ Component: /put_blob (plugin: test-builtins)
   Available Routes:
     /reachable/put_blob
 
-Total components: 8
+Component: /sleep (plugin: test-builtins)
+  Description: Sleeps for a specified duration then returns. Used for benchmarking concurrent flow capacity.
+  Available Routes:
+    /reachable/sleep
+
+Total components: 10
 
 ----- stderr -----

--- a/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_json_no_schemas.snap
+++ b/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_json_no_schemas.snap
@@ -79,6 +79,15 @@ exit_code: 0
       ]
     },
     {
+      "component": "/noop",
+      "path": "/noop",
+      "description": "No-op component that returns its input unchanged. Used for benchmarking.",
+      "plugin": "builtin",
+      "routes": [
+        "/builtin/noop"
+      ]
+    },
+    {
       "component": "/openai",
       "path": "/openai",
       "description": "Send messages to OpenAI's chat completion API and get a response",
@@ -94,6 +103,15 @@ exit_code: 0
       "plugin": "builtin",
       "routes": [
         "/builtin/put_blob"
+      ]
+    },
+    {
+      "component": "/sleep",
+      "path": "/sleep",
+      "description": "Sleeps for a specified duration then returns. Used for benchmarking concurrent flow capacity.",
+      "plugin": "builtin",
+      "routes": [
+        "/builtin/sleep"
       ]
     }
   ]

--- a/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_show_unreachable.snap
+++ b/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_show_unreachable.snap
@@ -7,7 +7,7 @@ info:
     - "--omit-stack-trace"
     - "--log-level=error"
     - list-components
-    - "--config=/var/folders/zk/lxqpq1490bb5xkvpdg25058r0000gn/T/.tmprlzWDh/filtered-config.yml"
+    - "--config=/var/folders/zk/lxqpq1490bb5xkvpdg25058r0000gn/T/.tmp8slOF5/filtered-config.yml"
     - "--hide-unreachable=false"
   env:
     STEPFLOW_LOG_DESTINATION: ""
@@ -54,6 +54,11 @@ Component: /map (plugin: test-builtins)
   Available Routes:
     /reachable/map
 
+Component: /noop (plugin: test-builtins)
+  Description: No-op component that returns its input unchanged. Used for benchmarking.
+  Available Routes:
+    /reachable/noop
+
 Component: /openai (plugin: test-builtins)
   Description: Send messages to OpenAI's chat completion API and get a response
   Available Routes:
@@ -64,6 +69,11 @@ Component: /put_blob (plugin: test-builtins)
   Available Routes:
     /reachable/put_blob
 
-Total components: 8
+Component: /sleep (plugin: test-builtins)
+  Description: Sleeps for a specified duration then returns. Used for benchmarking concurrent flow capacity.
+  Available Routes:
+    /reachable/sleep
+
+Total components: 10
 
 ----- stderr -----

--- a/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_with_schemas.snap
+++ b/stepflow-rs/crates/stepflow-cli/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_with_schemas.snap
@@ -332,6 +332,11 @@ Component: /map (plugin: builtin)
       ]
     }
 
+Component: /noop (plugin: builtin)
+  Description: No-op component that returns its input unchanged. Used for benchmarking.
+  Available Routes:
+    /builtin/noop
+
 Component: /openai (plugin: builtin)
   Description: Send messages to OpenAI's chat completion API and get a response
   Available Routes:
@@ -438,6 +443,49 @@ Component: /put_blob (plugin: builtin)
       ]
     }
 
-Total components: 8
+Component: /sleep (plugin: builtin)
+  Description: Sleeps for a specified duration then returns. Used for benchmarking concurrent flow capacity.
+  Available Routes:
+    /builtin/sleep
+  Input Schema:
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "title": "SleepInput",
+      "type": "object",
+      "properties": {
+        "duration_ms": {
+          "description": "Duration to sleep in milliseconds.",
+          "type": "number",
+          "format": "double"
+        },
+        "passthrough": {
+          "description": "Optional data to pass through unchanged."
+        }
+      },
+      "required": [
+        "duration_ms"
+      ]
+    }
+  Output Schema:
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "title": "SleepOutput",
+      "type": "object",
+      "properties": {
+        "duration_ms": {
+          "description": "The duration that was slept, in milliseconds.",
+          "type": "number",
+          "format": "double"
+        },
+        "passthrough": {
+          "description": "The passthrough data, if any was provided."
+        }
+      },
+      "required": [
+        "duration_ms"
+      ]
+    }
+
+Total components: 10
 
 ----- stderr -----


### PR DESCRIPTION
## Summary

Adds a comprehensive benchmark suite for measuring orchestrator throughput, worker overhead, and concurrent flow capacity (#846, #847, #848).

- Add `/noop` and `/sleep` builtins for zero-cost orchestrator benchmarking
- Add k6 benchmark scripts with custom summary output and quick mode
- Add `stepflow-bench-worker` binary (instant-complete and Rust echo modes)
- Add `/echo` component to Python worker
- Add `bench.sh` as single entry point that builds, starts, runs, and reports
- Add `--concurrency N` flag to control worker concurrent task slots

## Example output

```
./bench.sh --quick --with-rust --with-python --concurrency 500
```

```
Summary (throughput across all benchmarks):

  Workflow                     Runs/sec        avg        med        p95     Errors
  --------                     --------        ---        ---        ---     ------
  bench-rust-echo               13,473       14ms        7ms       41ms       0.0%
  bench-python-echo                502      377ms       19ms      1.79s       0.0%
  bench-noop-1                  49,812        3ms        2ms       13ms       0.0%
  bench-noop-parallel (10)      23,994        8ms        3ms       29ms       0.0%
  bench-noop-100                 2,724       67ms       22ms      300ms       0.0%
  bench-sleep-10ms               8,475       22ms       13ms       60ms       0.0%
  bench-sleep-100ms              1,612      114ms      102ms      198ms       0.0%

Derived Metrics:

  Orchestrator ceiling (free components):
    Max steps/sec:       ~272,440
    Max flows/sec:       ~49,812  (single-step flows)

  Concurrent flow capacity:
    ~110 concurrent flows at 10ms task duration
    ~164 concurrent flows at 100ms task duration

  Worker overhead (per-task gRPC + execution cost):
    Backend                Overhead   Observed rps  Plumbing bottleneck if task <
    -------------------- ---------- -------------- ------------------------------
    Builtin                    2ms        49,812                         2ms
    Rust worker                7ms        13,473                         7ms
    Python worker             19ms           502                        19ms

  Projected throughput by component execution time:
    Compute time            Builtin      Rust worker    Python worker
    -------------- ---------------- ---------------- ----------------
    0ms                    49,812/s         13,473/s            502/s
    10ms                    8,302/s            588/s            138/s
    100ms                     977/s             93/s             34/s
    1000ms                     99/s             10/s              4/s
```

## Key findings

**Orchestrator capacity**: ~50K single-step flows/sec, ~272K steps/sec with parallel scheduling. Per-step overhead is ~0.21ms under load.

**Worker overhead comparison**: Builtin (~2ms) < Rust SDK worker (~7ms) < Python worker (~19ms). At 100ms+ component execution time, plumbing overhead becomes negligible and all backends converge.

**Worker concurrency is not the bottleneck**: Testing at 10, 100, and 500 `max_concurrent` slots showed negligible throughput change. A single Python worker process sustains ~500 tasks/sec regardless of concurrency settings — for async I/O-bound tasks (LLM calls at 500ms), that's ~250 concurrent in-flight tasks from one process.

**Concurrent flow capacity**: ~164 concurrent flows sustained on a single node (at 100ms task duration, 500 VUs).

## Issues discovered during benchmarking

- #865 — SDK ephemeral port exhaustion from URL mismatch in `resolve_orch_channel`
- #866 — Value resolution coerces JSON integers to floats
- #867 — Legacy `$from` value expression syntax not resolved in workflow output

## Test plan

- [x] `cargo test -p stepflow-builtins -- noop sleep` — unit tests pass
- [x] `cargo build -p stepflow-bench-worker --release` — binary builds
- [x] `./bench.sh --quick` — orchestrator benchmarks complete with 0% errors
- [x] `./bench.sh --quick --with-rust --with-python` — all benchmarks 0% errors
- [x] `./bench.sh --quick --with-rust --with-python --concurrency 500` — high concurrency 0% errors
- [x] Derived metrics (steps/sec, overhead, projections) compute correctly