### PR TITLE
fix: Handle empty path in gRPC worker component discovery

### DIFF
--- a/stepflow-rs/crates/stepflow-grpc/src/queue_plugin.rs
+++ b/stepflow-rs/crates/stepflow-grpc/src/queue_plugin.rs
@@ -337,7 +337,6 @@ fn parse_discovery_result(value: &ValueRef) -> Result<Vec<ComponentInfo>> {
     for c in components_json {
         let name = c
             .get("component_id")
-            .or_else(|| c.get("name"))
             .and_then(|v| v.as_str())
             .unwrap_or_default();
         let path = c

--- a/stepflow-rs/crates/stepflow-grpc/src/queue_plugin.rs
+++ b/stepflow-rs/crates/stepflow-grpc/src/queue_plugin.rs
@@ -337,11 +337,13 @@ fn parse_discovery_result(value: &ValueRef) -> Result<Vec<ComponentInfo>> {
     for c in components_json {
         let name = c
             .get("component_id")
+            .or_else(|| c.get("name"))
             .and_then(|v| v.as_str())
             .unwrap_or_default();
         let path = c
             .get("path")
             .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
             .unwrap_or(name)
             .to_string();
         let description = c


### PR DESCRIPTION
## Summary

When Python SDK workers report components via `ListComponentsResult`, the `component_id` field includes a leading slash (e.g., `"/udf"`) and the `path` field is an empty string. `parse_discovery_result` treated the empty path as a valid value, so the trie builder produced double-slash paths (`"//udf"`) that never match during routing.

- Filter empty `path` strings so they fall back to the `component_id` value