### PR TITLE
feat: Support datetime objects in Python SDK auto-conversion

### DIFF
--- a/sdks/python/stepflow-py/src/stepflow_py/worker/__init__.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/__init__.py
@@ -14,6 +14,7 @@
 
 from . import blob_ref, blob_store, execution_context
 from .context import StepflowContext
+from .encoding import default_enc_hook
 from .expressions import ValueExpr
 from .flow_builder import Component, FlowBuilder, StepHandle
 from .generated_flow import (
@@ -55,6 +56,8 @@ __all__ = [
     "OnErrorFail",
     "OnErrorDefault",
     "OnErrorRetry",
+    # Encoding hooks
+    "default_enc_hook",
 ]
 
 # Add LangChain exports if available

--- a/sdks/python/stepflow-py/src/stepflow_py/worker/encoding.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/encoding.py
@@ -1,0 +1,47 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""Default encoding hook for converting non-JSON types to JSON-compatible values.
+
+This module provides the default ``enc_hook`` used by :class:`FlowBuilder` to
+convert non-JSON-native types during ``_auto_convert_input``.  Users can supply
+their own hook to handle additional types; the convention (matching *msgspec*)
+is to raise :class:`TypeError` for unrecognised objects so callers can fall back.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+
+def default_enc_hook(obj: Any) -> Any:
+    """Convert non-JSON-native Python objects to JSON-compatible values.
+
+    Supported conversions:
+    - ``datetime.datetime`` → ISO 8601 string (via ``.isoformat()``)
+    - ``datetime.date`` → ISO 8601 string (via ``.isoformat()``)
+    - ``datetime.time`` → ISO 8601 string (via ``.isoformat()``)
+
+    Raises:
+        TypeError: For types that are not handled.
+    """
+    # Note: check datetime before date, since datetime is a subclass of date.
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    if isinstance(obj, datetime.date):
+        return obj.isoformat()
+    if isinstance(obj, datetime.time):
+        return obj.isoformat()
+    raise TypeError(f"Encoding objects of type {type(obj)} is not supported")

--- a/sdks/python/stepflow-py/src/stepflow_py/worker/flow_builder.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/flow_builder.py
@@ -21,12 +21,14 @@ for JSON/YAML or the ``store_flow`` API.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, is_dataclass
-from typing import Any
+from typing import Any, cast
 
 import msgspec
 from typing_extensions import assert_never
 
+from .encoding import default_enc_hook
 from .generated_flow import (
     ErrorAction,
     Flow,
@@ -119,6 +121,7 @@ class FlowBuilder:
         description: str | None = None,
         version: str | None = None,
         metadata: dict[str, Any] | None = None,
+        enc_hook: Callable[[Any], Any] | None = None,
     ):
         self.name = name
         self.description = description
@@ -131,6 +134,7 @@ class FlowBuilder:
         self._step_handles: dict[str, StepHandle] = {}
         self._output: Any | None = None
         self._output_fields: dict[str, Valuable] = {}  # For incremental output building
+        self._enc_hook = enc_hook or default_enc_hook
 
     @classmethod
     def load(cls, flow: Flow | dict[str, Any]) -> FlowBuilder:
@@ -364,6 +368,12 @@ class FlowBuilder:
 
         if isinstance(input_data, list):
             return [self._auto_convert_input(item) for item in input_data]
+
+        # Try the enc_hook for non-JSON-native types (e.g. datetime)
+        try:
+            return cast("Valuable", self._enc_hook(input_data))
+        except TypeError:
+            pass
 
         assert_never(input_data)
 

--- a/sdks/python/stepflow-py/src/stepflow_py/worker/flow_builder.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/flow_builder.py
@@ -26,7 +26,6 @@ from dataclasses import dataclass, is_dataclass
 from typing import Any, cast
 
 import msgspec
-from typing_extensions import assert_never
 
 from .encoding import default_enc_hook
 from .generated_flow import (
@@ -372,10 +371,11 @@ class FlowBuilder:
         # Try the enc_hook for non-JSON-native types (e.g. datetime)
         try:
             return cast("Valuable", self._enc_hook(input_data))
-        except TypeError:
-            pass
-
-        assert_never(input_data)
+        except TypeError as exc:
+            raise TypeError(
+                f"Unsupported input type for auto conversion: "
+                f"{type(input_data).__name__}"
+            ) from exc
 
     def build(self) -> Flow:
         """Build the Flow as a msgspec Struct.

--- a/sdks/python/stepflow-py/src/stepflow_py/worker/task_handler.py
+++ b/sdks/python/stepflow-py/src/stepflow_py/worker/task_handler.py
@@ -30,6 +30,7 @@ report completion via gRPC ``OrchestratorService`` using the
 from __future__ import annotations
 
 import asyncio
+import datetime
 import inspect
 import logging
 import math
@@ -827,6 +828,8 @@ def python_to_proto_value(obj: Any) -> struct_pb2.Value:
         for item in obj:
             list_value.values.append(python_to_proto_value(item))
         value.list_value.CopyFrom(list_value)
+    elif isinstance(obj, datetime.datetime | datetime.date | datetime.time):
+        value.string_value = obj.isoformat()
     else:
         # Fallback: try to convert to dict
         import json

--- a/sdks/python/stepflow-py/tests/test_encoding.py
+++ b/sdks/python/stepflow-py/tests/test_encoding.py
@@ -1,0 +1,49 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import datetime
+
+import pytest
+
+from stepflow_py.worker.encoding import default_enc_hook
+
+
+def test_enc_hook_datetime():
+    dt = datetime.datetime(2025, 6, 15, 10, 30, 0, tzinfo=datetime.timezone.utc)
+    assert default_enc_hook(dt) == "2025-06-15T10:30:00+00:00"
+
+
+def test_enc_hook_datetime_naive():
+    dt = datetime.datetime(2025, 6, 15, 10, 30, 0)
+    assert default_enc_hook(dt) == "2025-06-15T10:30:00"
+
+
+def test_enc_hook_date():
+    d = datetime.date(2025, 6, 15)
+    assert default_enc_hook(d) == "2025-06-15"
+
+
+def test_enc_hook_time():
+    t = datetime.time(10, 30, 0)
+    assert default_enc_hook(t) == "10:30:00"
+
+
+def test_enc_hook_time_with_tz():
+    t = datetime.time(10, 30, 0, tzinfo=datetime.timezone.utc)
+    assert default_enc_hook(t) == "10:30:00+00:00"
+
+
+def test_enc_hook_unknown_type_raises():
+    with pytest.raises(TypeError, match="not supported"):
+        default_enc_hook(object())

--- a/sdks/python/stepflow-py/tests/test_flow_builder.py
+++ b/sdks/python/stepflow-py/tests/test_flow_builder.py
@@ -12,6 +12,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+import datetime
+
 import msgspec
 import pytest
 
@@ -694,3 +696,69 @@ def test_new_object_oriented_api():
 
     assert len(input_refs) == 1  # input().data_source
     assert len(step_refs) == 2  # Two step references in step2 input and flow output
+
+
+def test_auto_convert_datetime_input():
+    """datetime objects in step input are converted to ISO 8601 strings."""
+    builder = FlowBuilder(name="datetime_flow")
+
+    dt = datetime.datetime(2025, 6, 15, 10, 30, 0, tzinfo=datetime.timezone.utc)
+    d = datetime.date(2025, 6, 15)
+    t = datetime.time(10, 30, 0)
+
+    step = builder.add_step(
+        id="step1",
+        component="test",
+        input_data={
+            "timestamp": dt,
+            "date": d,
+            "time": t,
+            "nested": {"created_at": dt},
+            "list_of_dates": [d, d],
+        },
+    )
+    builder.set_output(Value.step(step.id))
+
+    flow = builder.build()
+    data = msgspec.to_builtins(flow)
+    step_input = data["steps"][0]["input"]
+
+    assert step_input["timestamp"] == "2025-06-15T10:30:00+00:00"
+    assert step_input["date"] == "2025-06-15"
+    assert step_input["time"] == "10:30:00"
+    assert step_input["nested"]["created_at"] == "2025-06-15T10:30:00+00:00"
+    assert step_input["list_of_dates"] == ["2025-06-15", "2025-06-15"]
+
+
+def test_custom_enc_hook():
+    """Users can provide a custom enc_hook to handle additional types."""
+    from stepflow_py.worker.encoding import default_enc_hook
+
+    class MyCustomType:
+        def __init__(self, value: str):
+            self.value = value
+
+    def my_hook(obj):
+        if isinstance(obj, MyCustomType):
+            return f"custom:{obj.value}"
+        return default_enc_hook(obj)
+
+    builder = FlowBuilder(name="custom_hook_flow", enc_hook=my_hook)
+
+    dt = datetime.datetime(2025, 6, 15, 10, 30, 0, tzinfo=datetime.timezone.utc)
+    step = builder.add_step(
+        id="step1",
+        component="test",
+        input_data={
+            "custom": MyCustomType("hello"),
+            "timestamp": dt,
+        },
+    )
+    builder.set_output(Value.step(step.id))
+
+    flow = builder.build()
+    data = msgspec.to_builtins(flow)
+    step_input = data["steps"][0]["input"]
+
+    assert step_input["custom"] == "custom:hello"
+    assert step_input["timestamp"] == "2025-06-15T10:30:00+00:00"

--- a/sdks/python/stepflow-py/tests/test_proto_value.py
+++ b/sdks/python/stepflow-py/tests/test_proto_value.py
@@ -1,0 +1,50 @@
+# Copyright 2025 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import datetime
+
+from stepflow_py.worker.task_handler import (
+    proto_value_to_python,
+    python_to_proto_value,
+)
+
+
+def test_python_to_proto_value_datetime():
+    dt = datetime.datetime(2025, 6, 15, 10, 30, 0, tzinfo=datetime.timezone.utc)
+    value = python_to_proto_value(dt)
+    assert value.string_value == "2025-06-15T10:30:00+00:00"
+
+
+def test_python_to_proto_value_date():
+    d = datetime.date(2025, 6, 15)
+    value = python_to_proto_value(d)
+    assert value.string_value == "2025-06-15"
+
+
+def test_python_to_proto_value_time():
+    t = datetime.time(10, 30, 0)
+    value = python_to_proto_value(t)
+    assert value.string_value == "10:30:00"
+
+
+def test_python_to_proto_value_datetime_nested():
+    """Datetime values nested in dicts and lists are converted."""
+    dt = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+    obj = {"created": dt, "tags": [dt]}
+    value = python_to_proto_value(obj)
+    result = proto_value_to_python(value)
+    assert result == {
+        "created": "2025-01-01T00:00:00+00:00",
+        "tags": ["2025-01-01T00:00:00+00:00"],
+    }


### PR DESCRIPTION
## Summary

- Add `datetime.datetime`, `datetime.date`, and `datetime.time` support to the Python SDK's type conversion paths, serializing as ISO 8601 strings
- Introduce an extensible `enc_hook` pattern on `FlowBuilder` so users can register their own type conversions
- Handle datetime explicitly in `python_to_proto_value` instead of falling through to the lossy `json.dumps(default=str)` fallback

No orchestrator or Rust SDK changes needed — datetimes are ISO 8601 strings on the wire, which the orchestrator passes through opaquely.

## Test plan

- [x] New `test_encoding.py` — unit tests for `default_enc_hook` (datetime, date, time, unknown type)
- [x] New `test_proto_value.py` — proto value round-trip tests for datetime types
- [x] New tests in `test_flow_builder.py` — datetime input conversion + custom `enc_hook` composability
- [x] All 144 tests pass (`uv run poe test`)
- [x] Type checker clean (`uv run poe typecheck`, only pre-existing nats stub errors)

Closes #903